### PR TITLE
DXCDT-39: Add github actions workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: Main Workflow
+
+concurrency:
+  group: one-at-time
+  cancel-in-progress: false
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Check out the code
+        uses: actions/checkout@v2
+
+      - name: Install the provider
+        run: make build
+
+      - name: Start docker containers
+        run: docker-compose up -d --build
+
+      - name: Run tests
+        run: make testacc OPTS=-coverprofile=c.out
+        env:
+          AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
+
+      - name: Stop docker containers
+        if: always()
+        run: docker-compose down

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![GoDoc](https://pkg.go.dev/badge/github.com/auth0/terraform-provider-auth0.svg)](https://pkg.go.dev/github.com/auth0/terraform-provider-auth0)
 [![License](https://img.shields.io/github/license/auth0/terraform-provider-auth0.svg?style=flat-square)](https://github.com/auth0/terraform-provider-auth0/blob/main/LICENSE)
-[![Tests](https://github.com/auth0/terraform-provider-auth0/workflows/Build/badge.svg)](https://github.com/auth0/terraform-provider-auth0/actions?query=branch%3Amain)
 [![Release](https://img.shields.io/github/v/release/auth0/terraform-provider-auth0?include_prereleases&style=flat-square)](https://github.com/auth0/terraform-provider-auth0/releases)
+[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fauth0%2Fterraform-provider-auth0%2Fbadge%3Fref%3Dmain&style=flat-square)](https://github.com/auth0/terraform-provider-auth0/actions?query=branch%3Amain)
 
 ---
 


### PR DESCRIPTION
## Description

<!--- 
Describe the purpose of this PR along with any background information and the impacts of the proposed change. 
For the benefit of the community, please do not assume prior context.

Provide details that support your chosen implementation, including: 
- breaking changes
- alternatives considered
- changes to the API
- demos (screenshots, videos) if you find that useful
- etc.
-->

In this PR we are adding the first github actions workflow that is tasked to run automatically the tests on each merge to master and on opening PRs from collaborators. 

Acceptance tests are also set to run only one at a time to not interfere with the state of the Auth0 Tenant. 


## References

<!--- 
Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow post
- Support forum thread
- Related pull requests/issues from other repos

If there are no references, simply delete this section.
-->


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [ ] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [ ] I have reviewed my own code beforehand.
- [ ] I have added documentation for new/changed functionality in this PR.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [ ] The correct base branch is being used, if not `main`.
