### PR TITLE
Fix some of the linting issues

### DIFF
--- a/auth0/data_source_helpers.go
+++ b/auth0/data_source_helpers.go
@@ -7,9 +7,9 @@ import (
 // datasourceSchemaFromResourceSchema is a recursive func that
 // converts an existing Resource schema to a Datasource schema.
 // All schema elements are copied, but certain attributes are ignored or changed:
-// - all attributes have Computed = true
-// - all attributes have ForceNew, Required = false
-// - Validation funcs and attributes (e.g. MaxItems) are not copied
+// - all attributes have Computed = true.
+// - all attributes have ForceNew, Required = false.
+// - Validation funcs and attributes (e.g. MaxItems) are not copied.
 func datasourceSchemaFromResourceSchema(rs map[string]*schema.Schema) map[string]*schema.Schema {
 	ds := make(map[string]*schema.Schema, len(rs))
 	for k, v := range rs {
@@ -42,10 +42,8 @@ func datasourceSchemaFromResourceSchema(rs map[string]*schema.Schema) map[string
 		default:
 			// Elem of all other types are copied as-is
 			dv.Elem = v.Elem
-
 		}
 		ds[k] = dv
-
 	}
 	return ds
 }

--- a/auth0/internal/debug/debug.go
+++ b/auth0/internal/debug/debug.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
+// DumpAttr will print n's attributes.
 func DumpAttr(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/auth0/internal/hash/hash_test.go
+++ b/auth0/internal/hash/hash_test.go
@@ -3,7 +3,6 @@ package hash
 import "testing"
 
 func TestStringKey(t *testing.T) {
-
 	v := map[string]interface{}{
 		"Foo": "Foo",
 		"Bar": "Bar",

--- a/auth0/internal/validation/validation.go
+++ b/auth0/internal/validation/validation.go
@@ -8,7 +8,6 @@ import (
 // IsURLWithNoFragment is a SchemaValidateFunc which tests if the provided value
 // is of type string and a valid URL with no fragment.
 func IsURLWithNoFragment(i interface{}, k string) (warnings []string, errors []error) {
-
 	v, ok := i.(string)
 	if !ok {
 		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))

--- a/auth0/resource_auth0_action.go
+++ b/auth0/resource_auth0_action.go
@@ -190,13 +190,10 @@ func updateAction(d *schema.ResourceData, m interface{}) error {
 }
 
 func deployAction(d *schema.ResourceData, m interface{}) error {
-
 	if d.Get("deploy").(bool) == true {
-
 		api := m.(*management.Management)
 
 		err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-
 			a, err := api.Action.Read(d.Id())
 			if err != nil {
 				return resource.NonRetryableError(err)
@@ -239,7 +236,6 @@ func deleteAction(d *schema.ResourceData, m interface{}) error {
 }
 
 func expandAction(d *schema.ResourceData) *management.Action {
-
 	a := &management.Action{
 		Name:    String(d, "name"),
 		Code:    String(d, "code"),

--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -911,16 +911,16 @@ func flattenClientJwtConfiguration(jwt *management.ClientJWTConfiguration) []int
 	return []interface{}{m}
 }
 
-func flattenClientRefreshTokenConfiguration(refresh_token *management.ClientRefreshToken) []interface{} {
+func flattenClientRefreshTokenConfiguration(refreshToken *management.ClientRefreshToken) []interface{} {
 	m := make(map[string]interface{})
-	if refresh_token != nil {
-		m["rotation_type"] = refresh_token.RotationType
-		m["expiration_type"] = refresh_token.ExpirationType
-		m["leeway"] = refresh_token.Leeway
-		m["token_lifetime"] = refresh_token.TokenLifetime
-		m["infinite_token_lifetime"] = refresh_token.InfiniteTokenLifetime
-		m["infinite_idle_token_lifetime"] = refresh_token.InfiniteIdleTokenLifetime
-		m["idle_token_lifetime"] = refresh_token.IdleTokenLifetime
+	if refreshToken != nil {
+		m["rotation_type"] = refreshToken.RotationType
+		m["expiration_type"] = refreshToken.ExpirationType
+		m["leeway"] = refreshToken.Leeway
+		m["token_lifetime"] = refreshToken.TokenLifetime
+		m["infinite_token_lifetime"] = refreshToken.InfiniteTokenLifetime
+		m["infinite_idle_token_lifetime"] = refreshToken.InfiniteIdleTokenLifetime
+		m["idle_token_lifetime"] = refreshToken.IdleTokenLifetime
 	}
 	return []interface{}{m}
 }

--- a/auth0/resource_auth0_client_test.go
+++ b/auth0/resource_auth0_client_test.go
@@ -267,25 +267,25 @@ func TestAccClientInitiateLoginUri(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config:      random.Template(testAccClientConfigInitiateLoginUriHttp, rand),
+				Config:      random.Template(testAccClientConfigInitiateLoginURIHTTP, rand),
 				ExpectError: regexp.MustCompile("to have a url with schema"),
 			},
 			{
-				Config:      random.Template(testAccClientConfigInitiateLoginUriFragment, rand),
+				Config:      random.Template(testAccClientConfigInitiateLoginURIFragment, rand),
 				ExpectError: regexp.MustCompile("to have a url with an empty fragment"),
 			},
 		},
 	})
 }
 
-const testAccClientConfigInitiateLoginUriHttp = `
+const testAccClientConfigInitiateLoginURIHTTP = `
 resource "auth0_client" "my_client" {
   name = "Acceptance Test - Initiate Login URI - {{.random}}"
   initiate_login_uri = "http://example.com/login"
 }
 `
 
-const testAccClientConfigInitiateLoginUriFragment = `
+const testAccClientConfigInitiateLoginURIFragment = `
 resource "auth0_client" "my_client" {
   name = "Acceptance Test - Initiate Login URI - {{.random}}"
   initiate_login_uri = "https://example.com/login#fragment"

--- a/auth0/resource_auth0_global_client.go
+++ b/auth0/resource_auth0_global_client.go
@@ -41,13 +41,13 @@ func in(needle string, haystack []string) bool {
 }
 
 func createGlobalClient(d *schema.ResourceData, m interface{}) error {
-	if err := readGlobalClientId(d, m); err != nil {
+	if err := readGlobalClientID(d, m); err != nil {
 		return err
 	}
 	return updateClient(d, m)
 }
 
-func readGlobalClientId(d *schema.ResourceData, m interface{}) error {
+func readGlobalClientID(d *schema.ResourceData, m interface{}) error {
 	api := m.(*management.Management)
 	clients, err := api.Client.List(management.Parameter("is_global", "true"), management.IncludeFields("client_id"))
 	if err != nil {

--- a/auth0/resource_auth0_log_stream_test.go
+++ b/auth0/resource_auth0_log_stream_test.go
@@ -221,11 +221,12 @@ resource "auth0_log_stream" "my_log_stream" {
 }
 `
 
-// This test fails it subscription key is not valid, or Eventgrid Resource Provider is not registered in the subscription
+// This test fails it subscription key is not valid, or EventGrid
+// Resource Provider is not registered in the subscription.
 func TestAccLogStreamEventGrid(t *testing.T) {
-	rand := random.String(6)
-
 	t.Skip("this test requires an active subscription")
+
+	rand := random.String(6)
 
 	resource.Test(t, resource.TestCase{
 		Providers: map[string]terraform.ResourceProvider{

--- a/auth0/resource_auth0_user.go
+++ b/auth0/resource_auth0_user.go
@@ -89,13 +89,13 @@ func newUser() *schema.Resource {
 			"user_metadata": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ValidateFunc:     validation.ValidateJsonString,
+				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},
 			"app_metadata": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ValidateFunc:     validation.ValidateJsonString,
+				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},
 			"blocked": {

--- a/auth0/resource_data.go
+++ b/auth0/resource_data.go
@@ -12,7 +12,6 @@ import (
 // ResourceData generalises schema.ResourceData so that we can reuse the
 // accessor methods defined below.
 type ResourceData interface {
-
 	// IsNewResource reports whether or not the resource is seen for the first
 	// time. If so, checks for change won't be carried out.
 	IsNewResource() bool
@@ -61,30 +60,40 @@ func newResourceDataAtIndex(i int, d ResourceData) ResourceData {
 	return &resourceData{d, strconv.Itoa(i)}
 }
 
+// IsNewResource reports whether the resource is seen for the first time.
 func (d *resourceData) IsNewResource() bool {
 	return d.ResourceData.IsNewResource()
 }
 
+// HasChange reports whether the given key has been changed.
 func (d *resourceData) HasChange(key string) bool {
 	return d.ResourceData.HasChange(d.prefix + "." + key)
 }
 
+// GetChange returns the old and new value for a given key.
 func (d *resourceData) GetChange(key string) (interface{}, interface{}) {
 	return d.ResourceData.GetChange(d.prefix + "." + key)
 }
 
+// Get returns the data for the given key, or nil
+// if the key doesn't exist in the schema.
 func (d *resourceData) Get(key string) interface{} {
 	return d.ResourceData.Get(d.prefix + "." + key)
 }
 
+// GetOk returns the data for the given key and whether the
+// key has been set to a non-zero value at some point.
 func (d *resourceData) GetOk(key string) (interface{}, bool) {
 	return d.ResourceData.GetOk(d.prefix + "." + key)
 }
 
+// GetOkExists can check if TypeBool attributes that are
+// Optional with no Default value have been set.
 func (d *resourceData) GetOkExists(key string) (interface{}, bool) {
 	return d.ResourceData.GetOkExists(d.prefix + "." + key)
 }
 
+// Set sets the value for the given key.
 func (d *resourceData) Set(key string, value interface{}) error {
 	return d.ResourceData.Set(d.prefix+"."+key, value)
 }
@@ -93,33 +102,43 @@ func (d *resourceData) Set(key string, value interface{}) error {
 // accessor methods defined below.
 type MapData map[string]interface{}
 
+// IsNewResource reports whether the resource is seen for the first time.
 func (md MapData) IsNewResource() bool {
 	return false
 }
 
+// HasChange reports whether the given key has been changed.
 func (md MapData) HasChange(key string) bool {
 	_, ok := md[key]
 	return ok
 }
 
+// GetChange returns the old and new value for a given key.
 func (md MapData) GetChange(key string) (interface{}, interface{}) {
 	return md[key], md[key]
 }
 
+// Get returns the data for the given key, or nil
+// if the key doesn't exist in the schema.
 func (md MapData) Get(key string) interface{} {
 	return md[key]
 }
 
+// GetOk returns the data for the given key and whether the
+// key has been set to a non-zero value at some point.
 func (md MapData) GetOk(key string) (interface{}, bool) {
 	v, ok := md[key]
 	return v, ok && !isNil(v) && !isZero(v)
 }
 
+// GetOkExists can check if TypeBool attributes that are
+// Optional with no Default value have been set.
 func (md MapData) GetOkExists(key string) (interface{}, bool) {
 	v, ok := md[key]
 	return v, ok && !isNil(v)
 }
 
+// Set sets the value for the given key.
 func (md MapData) Set(key string, value interface{}) error {
 	if !isNil(value) {
 		md[key] = value
@@ -305,16 +324,19 @@ type list struct {
 	v []interface{}
 }
 
+// Elem will loop through each element of the list and apply fn().
 func (l *list) Elem(fn func(ResourceData)) {
 	for idx := range l.v {
 		fn(newResourceDataAtIndex(idx, l.d))
 	}
 }
 
+// List will return the values as list.
 func (l *list) List() []interface{} {
 	return l.v
 }
 
+// Len returns the length of the list values.
 func (l *list) Len() int {
 	return len(l.v)
 }
@@ -332,22 +354,25 @@ func (s *set) hash(item interface{}) string {
 	return strconv.Itoa(code)
 }
 
+// Elem will loop through each element of the set and apply fn().
 func (s *set) Elem(fn func(ResourceData)) {
 	for _, v := range s.s.List() {
 		fn(newResourceDataAtKey(s.hash(v), s.d))
 	}
 }
 
+// List will return the values of the set as a list.
 func (s *set) List() []interface{} {
 	return s.s.List()
 }
 
+// Len returns the length of the set values.
 func (s *set) Len() int {
 	return s.s.Len()
 }
 
 // Diff accesses the value held by key and type asserts it to a set. It then
-// compares it's changes if any and returns what needs to be added and what
+// compares its changes if any and returns what needs to be added and what
 // needs to be removed.
 func Diff(d ResourceData, key string) (add Iterator, rm Iterator) {
 	// Zero the add and rm sets. These may be modified if the diff observed any

--- a/auth0/resource_data_test.go
+++ b/auth0/resource_data_test.go
@@ -36,7 +36,6 @@ func TestMapData(t *testing.T) {
 			}
 		}
 	})
-
 }
 
 func TestJSON(t *testing.T) {
@@ -52,7 +51,6 @@ func TestJSON(t *testing.T) {
 }
 
 func TestIsNil(t *testing.T) {
-
 	for _, v := range []interface{}{
 		nil,
 		(*bool)(nil),


### PR DESCRIPTION
## Description

<!--- 
Describe the purpose of this PR along with any background information and the impacts of the proposed change. 
For the benefit of the community, please do not assume prior context.

Provide details that support your chosen implementation, including: 
- breaking changes
- alternatives considered
- changes to the API
- demos (screenshots, videos) if you find that useful
- etc.
-->

In this PR we fix some of the linting issues found inside the project after running:

```sh
docker run --rm -v `pwd`:/terraform-provider-auth0 -w /terraform-provider-auth0 golangci/golangci-lint:v1.44.0 golangci-lint run ./...
```


## References

<!--- 
Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow post
- Support forum thread
- Related pull requests/issues from other repos

If there are no references, simply delete this section.
-->


## Testing

<!--- 
Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. 
If this library has unit and/or integration testing, tests should be added for new functionality and 
existing tests should complete without errors.
-->

- [ ] This change adds test coverage for new/changed/fixed functionality


## Checklist

<!---
Tick with "x" the boxes that apply. You can also fill these out after creating the PR.
-->

- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md).
- [x] I have reviewed my own code beforehand.
- [x] I have added documentation for new/changed functionality in this PR.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used, if not `main`.
