### PR TITLE
Add `ShowAsButton` option

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -665,6 +665,11 @@ var connectionSchema = map[string]*schema.Schema{
 		Computed:    true,
 		Description: "Defines the realms for which the connection will be used (i.e., email domains). If not specified, the connection name is added as the realm",
 	},
+	"show_as_button": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Display connection as a button",
+	},
 }
 
 func connectionSchemaV0() *schema.Resource {
@@ -788,6 +793,7 @@ func readConnection(d *schema.ResourceData, m interface{}) error {
 	d.Set("options", flattenConnectionOptions(d, c.Options))
 	d.Set("enabled_clients", c.EnabledClients)
 	d.Set("realms", c.Realms)
+	d.Set("show_as_button", c.ShowAsButton)
 	return nil
 }
 

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -326,6 +326,7 @@ func expandConnection(d ResourceData) *management.Connection {
 		IsDomainConnection: Bool(d, "is_domain_connection"),
 		EnabledClients:     Set(d, "enabled_clients").List(),
 		Realms:             Slice(d, "realms", IsNewResource(), HasChange()),
+		ShowAsButton:       Bool(d, "show_as_button"),
 	}
 
 	s := d.Get("strategy").(string)

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -55,6 +55,7 @@ Arguments accepted by this resource include:
 * `options` - (Optional) Configuration settings for connection options. For details, see [Options](#options).
 * `enabled_clients` - (Optional) IDs of the clients for which the connection is enabled. If not specified, no clients are enabled.
 * `realms` - (Optional) Defines the realms for which the connection will be used (i.e., email domains). If not specified, the connection name is added as the realm.
+* `show_as_button` - (Optional) Display connection as a button.
 
 ### Options
 


### PR DESCRIPTION
## Description

Add a new `show_as_button` option to be able to show a connection as a button.

Depends on https://github.com/auth0/terraform-provider-auth0/pull/69.
Migrated from https://github.com/alexkappa/terraform-provider-auth0/pull/500.

<!-- Describe the purpose of this PR along with any background information and the impacts of the proposed change. 
For the benefit of the community, please do not assume prior context. -->

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over