### PR TITLE
Add auth0_config data source

### DIFF
--- a/auth0/data_source_auth0_config.go
+++ b/auth0/data_source_auth0_config.go
@@ -1,0 +1,40 @@
+package auth0
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func newDataConfig() *schema.Resource {
+	return &schema.Resource{
+		Read: readDataConfig,
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"management_api_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func readDataConfig(d *schema.ResourceData, m interface{}) error {
+	api := m.(*management.Management)
+
+	u, err := url.Parse(api.URI())
+	if err != nil {
+		return fmt.Errorf("unable to read management API URL from client: %w", err)
+	}
+
+	d.SetId(resource.UniqueId())
+	d.Set("domain", u.Hostname())
+	d.Set("management_api_identifier", u.String())
+	return nil
+}

--- a/auth0/data_source_auth0_config_test.go
+++ b/auth0/data_source_auth0_config_test.go
@@ -1,0 +1,47 @@
+package auth0
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/auth0/terraform-provider-auth0/auth0/internal/random"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+const testAccDataConfigConfig = `
+
+data auth0_config current {
+}
+
+resource auth0_client my_client {
+	name = "Acceptance Test - Config Data Source - {{.random}}"
+	app_type = "non_interactive"
+}
+
+resource auth0_client_grant management_api {
+	client_id = auth0_client.my_client.id
+	audience = data.auth0_config.current.management_api_identifier
+	scope = [ "read:insights" ]
+}
+`
+
+func TestAccDataConfig(t *testing.T) {
+	rand := random.String(6)
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: random.Template(testAccDataConfigConfig, rand),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.auth0_config.current", "domain", os.Getenv("AUTH0_DOMAIN")),
+					resource.TestCheckResourceAttr("data.auth0_config.current", "management_api_identifier", fmt.Sprintf("https://%s/api/v2/", os.Getenv("AUTH0_DOMAIN"))),
+				),
+			},
+		},
+	})
+}

--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -81,6 +81,7 @@ func Provider() *schema.Provider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"auth0_client":        newDataClient(),
+			"auth0_config":        newDataConfig(),
 			"auth0_global_client": newDataGlobalClient(),
 		},
 	}

--- a/docs/data-sources/config.md
+++ b/docs/data-sources/config.md
@@ -1,0 +1,25 @@
+---
+layout: "auth0"
+page_title: "Data Source: auth0_config"
+description: |-
+Use this data source to access the configuration of the Auth0 provider.
+---
+
+# Data Source: auth0_config
+
+Use this data source to access the configuration of the Auth0 provider.
+
+## Example Usage
+
+```hcl
+data "auth0_config" "current" {}
+```
+
+## Argument Reference
+
+No arguments accepted.
+
+## Attribute Reference
+
+* `domain` - String. Your Auth0 domain name.
+* `management_api_identifier` - String. The identifier value of the built-in Management API resource server, which can be used as an audience when configuring client grants.


### PR DESCRIPTION
## Description

This change adds a new data source, `auth0_config`, which simply returns some helpful information about the current provider configuration. It is particularly helpful when developing a reusable module that expects this provider as an input, because the module may need to know the domain for downstream configuration (e.g. of frontend applications for redirects) or to set up client grants against the management API.

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over