### PR TITLE
Add auth0_tenant data source

### DIFF
--- a/auth0/data_source_auth0_tenant.go
+++ b/auth0/data_source_auth0_tenant.go
@@ -1,0 +1,44 @@
+package auth0
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func newDataTenant() *schema.Resource {
+	return &schema.Resource{
+		Read: readDataTenant,
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"management_api_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func readDataTenant(d *schema.ResourceData, m interface{}) error {
+	api := m.(*management.Management)
+
+	u, err := url.Parse(api.URI())
+	if err != nil {
+		return fmt.Errorf("unable to determine management API URL: %w", err)
+	}
+
+	d.SetId(resource.UniqueId())
+
+	var result *multierror.Error
+	result = multierror.Append(result, d.Set("domain", u.Hostname()))
+	result = multierror.Append(result, d.Set("management_api_identifier", u.String()))
+
+	return result.ErrorOrNil()
+}

--- a/auth0/data_source_auth0_tenant_test.go
+++ b/auth0/data_source_auth0_tenant_test.go
@@ -1,0 +1,46 @@
+package auth0
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/auth0/terraform-provider-auth0/auth0/internal/random"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+const testAccDataTenantConfig = `
+data auth0_tenant current {
+}
+
+resource auth0_client my_client {
+	name = "Acceptance Test - Tenant Data Source - {{.random}}"
+	app_type = "non_interactive"
+}
+
+resource auth0_client_grant management_api {
+	client_id = auth0_client.my_client.id
+	audience = data.auth0_tenant.current.management_api_identifier
+	scope = [ "read:insights" ]
+}
+`
+
+func TestAccDataTenant(t *testing.T) {
+	rand := random.String(6)
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: random.Template(testAccDataTenantConfig, rand),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.auth0_tenant.current", "domain", os.Getenv("AUTH0_DOMAIN")),
+					resource.TestCheckResourceAttr("data.auth0_tenant.current", "management_api_identifier", fmt.Sprintf("https://%s/api/v2/", os.Getenv("AUTH0_DOMAIN"))),
+				),
+			},
+		},
+	})
+}

--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -82,6 +82,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"auth0_client":        newDataClient(),
 			"auth0_global_client": newDataGlobalClient(),
+			"auth0_tenant":        newDataTenant(),
 		},
 	}
 

--- a/docs/data-sources/tenant.md
+++ b/docs/data-sources/tenant.md
@@ -1,0 +1,25 @@
+---
+layout: "auth0"
+page_title: "Data Source: auth0_tenant"
+description: |-
+Use this data source to access information about the tenant this provider is configured to access.
+---
+
+# Data Source: auth0_tenant
+
+Use this data source to access information about the tenant this provider is configured to access.
+
+## Example Usage
+
+```hcl
+data "auth0_tenant" "current" {}
+```
+
+## Argument Reference
+
+No arguments accepted.
+
+## Attribute Reference
+
+* `domain` - String. Your Auth0 domain name.
+* `management_api_identifier` - String. The identifier value of the built-in Management API resource server, which can be used as an audience when configuring client grants.

--- a/example/multiple_environments/README.md
+++ b/example/multiple_environments/README.md
@@ -1,0 +1,5 @@
+# Multiple Environments
+
+This example demonstrates how you can share tenant configurations between different environments by leveraging Terraform modules.
+
+It has configurations for three tenants: [prod](prod), [stage](stage), and a [custom](custom) tenant where the Auth0 domain is set by a Terraform variable or environment variable. Each of these tenants is set up identically with the included [admin_console](modules/admin_console) module.

--- a/example/multiple_environments/custom/main.tf
+++ b/example/multiple_environments/custom/main.tf
@@ -1,0 +1,12 @@
+variable "auth0_domain" {
+  type    = string
+  default = null # Leave empty to use AUTH0_DOMAIN from the environment
+}
+
+provider "auth0" {
+  domain = var.auth0_domain
+}
+
+module "admin_console" {
+  source = "../modules/admin_console"
+}

--- a/example/multiple_environments/custom/versions.tf
+++ b/example/multiple_environments/custom/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    auth0 = {
+      source = "auth0/auth0"
+    }
+  }
+}

--- a/example/multiple_environments/modules/admin_console/main.tf
+++ b/example/multiple_environments/modules/admin_console/main.tf
@@ -1,0 +1,12 @@
+resource "auth0_client" "admin" {
+  name     = "Admin Console"
+  app_type = "non_interactive"
+}
+
+data "auth0_tenant" "current" {}
+
+resource "auth0_client_grant" "admin_management_api" {
+  client_id = auth0_client.admin.client_id
+  audience  = data.auth0_tenant.current.management_api_identifier
+  scope     = ["read:users", "create:users", "update:users", "delete:users"]
+}

--- a/example/multiple_environments/modules/admin_console/versions.tf
+++ b/example/multiple_environments/modules/admin_console/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    auth0 = {
+      source = "auth0/auth0"
+    }
+  }
+}

--- a/example/multiple_environments/prod/main.tf
+++ b/example/multiple_environments/prod/main.tf
@@ -1,0 +1,7 @@
+provider "auth0" {
+  domain = "example-prod.us.auth0.com"
+}
+
+module "admin_console" {
+  source = "../modules/admin_console"
+}

--- a/example/multiple_environments/prod/versions.tf
+++ b/example/multiple_environments/prod/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    auth0 = {
+      source = "auth0/auth0"
+    }
+  }
+}

--- a/example/multiple_environments/stage/main.tf
+++ b/example/multiple_environments/stage/main.tf
@@ -1,0 +1,7 @@
+provider "auth0" {
+  domain = "example-stage.us.auth0.com"
+}
+
+module "admin_console" {
+  source = "../modules/admin_console"
+}

--- a/example/multiple_environments/stage/versions.tf
+++ b/example/multiple_environments/stage/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    auth0 = {
+      source = "auth0/auth0"
+    }
+  }
+}


### PR DESCRIPTION
## Description

This is a replacement for #84, because I didn't realize changing the branch name would close that PR. :disappointed: 

It addresses the feedback in https://github.com/auth0/terraform-provider-auth0/pull/84#pullrequestreview-916011642, including an added example. The original description is below for posterity:

This change adds a new data source, `auth0_tenant`, which simply returns some helpful information about the current provider configuration. It is particularly helpful when developing a reusable module that expects this provider as an input, because the module may need to know the domain for downstream configuration (e.g. of frontend applications for redirects) or to set up client grants against the management API.

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over