### PR TITLE
DXCDT-95 Stop ignoring errors when setting resource data within the connection

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -218,6 +218,7 @@ var connectionSchema = map[string]*schema.Schema{
 				},
 				"allowed_audiences": {
 					Type:        schema.TypeSet,
+					Computed:    true,
 					Elem:        &schema.Schema{Type: schema.TypeString},
 					Optional:    true,
 					Description: "",
@@ -244,6 +245,7 @@ var connectionSchema = map[string]*schema.Schema{
 				},
 				"domain_aliases": {
 					Type:        schema.TypeSet,
+					Computed:    true,
 					Elem:        &schema.Schema{Type: schema.TypeString},
 					Optional:    true,
 					Description: "",
@@ -287,6 +289,7 @@ var connectionSchema = map[string]*schema.Schema{
 					Type:        schema.TypeSet,
 					Elem:        &schema.Schema{Type: schema.TypeString},
 					Optional:    true,
+					Computed:    true,
 					Description: "",
 				},
 				"use_cert_auth": {
@@ -366,6 +369,7 @@ var connectionSchema = map[string]*schema.Schema{
 				"mfa": {
 					Type:     schema.TypeList,
 					MaxItems: 1,
+					Computed: true,
 					Optional: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
@@ -380,7 +384,6 @@ var connectionSchema = map[string]*schema.Schema{
 						},
 					},
 				},
-
 				// custom sms gateway options
 				"provider": {
 					Type:        schema.TypeString,
@@ -420,6 +423,7 @@ var connectionSchema = map[string]*schema.Schema{
 							"secret": {
 								Type:        schema.TypeString,
 								Optional:    true,
+								Sensitive:   true,
 								Description: "Secret used to sign the HS256 token sent to gateway_url",
 							},
 							"secret_base64_encoded": {
@@ -460,7 +464,6 @@ var connectionSchema = map[string]*schema.Schema{
 					}, false),
 					Description: "Choose how Auth0 sets the email_verified field in the user profile.",
 				},
-
 				// apple options
 				"team_id": {
 					Type:        schema.TypeString,
@@ -472,31 +475,27 @@ var connectionSchema = map[string]*schema.Schema{
 					Optional:    true,
 					Description: "Apple Key ID",
 				},
-
 				// adfs options
 				"adfs_server": {
 					Type:     schema.TypeString,
 					Optional: true,
 				},
-
 				// salesforce options
 				"community_base_url": {
 					Type:     schema.TypeString,
 					Optional: true,
 				},
-
 				"strategy_version": {
 					Type:     schema.TypeInt,
 					Optional: true,
 					Computed: true,
 				},
-
 				"scopes": {
 					Type:     schema.TypeSet,
+					Computed: true,
 					Optional: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
-
 				// OIDC options
 				"type": {
 					Type:        schema.TypeString,
@@ -566,7 +565,6 @@ var connectionSchema = map[string]*schema.Schema{
 				"idp_initiated": {
 					Type:     schema.TypeList,
 					MaxItems: 1,
-					Required: false,
 					Optional: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -77,7 +77,6 @@ func TestAccConnection(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.import_mode", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.disable_signup", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.requires_username", "true"),
-					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.set_user_root_attributes", "on_each_login"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.0.username.0.min", "10"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.0.username.0.max", "40"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.custom_scripts.get_user", "myFunction"),
@@ -91,7 +90,6 @@ func TestAccConnection(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.brute_force_protection", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.mfa.0.return_enroll_settings", "false"),
-					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.set_user_root_attributes", "on_first_login"),
 				),
 			},
 		},
@@ -140,7 +138,6 @@ resource "auth0_connection" "my_connection" {
 			active                 = true
 			return_enroll_settings = true
 		}
-		set_user_root_attributes = "on_each_login"
 	}
 }
 `
@@ -174,7 +171,6 @@ resource "auth0_connection" "my_connection" {
 			active                 = true
 			return_enroll_settings = false
 		}
-		set_user_root_attributes = "on_first_login"
 	}
 }
 `
@@ -216,6 +212,7 @@ resource "auth0_connection" "ad" {
 	strategy = "ad"
 	show_as_button = true
 	options {
+		brute_force_protection = true
 		tenant_domain = "example.com"
 		domain_aliases = [
 			"example.com",
@@ -1199,6 +1196,7 @@ resource "auth0_connection" "my_connection" {
 	is_domain_connection = true
 	strategy = "auth0"
 	options {
+		brute_force_protection = true
 		configuration = {
 			foo = "xxx"
 			bar = "zzz"
@@ -1213,6 +1211,7 @@ resource "auth0_connection" "my_connection" {
 	is_domain_connection = true
 	strategy = "auth0"
 	options {
+		brute_force_protection = true
 		configuration = {
 			foo = "xxx"
 			bar = "yyy"

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -8,311 +8,368 @@ import (
 )
 
 func flattenConnectionOptions(d ResourceData, options interface{}) []interface{} {
+	if options == nil || optionsBlockIsNotDefined(d) {
+		return nil
+	}
+
 	var m interface{}
 
-	switch o := options.(type) {
+	switch connectionOptions := options.(type) {
 	case *management.ConnectionOptions:
-		m = flattenConnectionOptionsAuth0(d, o)
+		m = flattenConnectionOptionsAuth0(d, connectionOptions)
 	case *management.ConnectionOptionsGoogleOAuth2:
-		m = flattenConnectionOptionsGoogleOAuth2(o)
+		m = flattenConnectionOptionsGoogleOAuth2(connectionOptions)
 	case *management.ConnectionOptionsGoogleApps:
-		m = flattenConnectionOptionsGoogleApps(o)
+		m = flattenConnectionOptionsGoogleApps(connectionOptions)
 	case *management.ConnectionOptionsOAuth2:
-		m = flattenConnectionOptionsOAuth2(o)
+		m = flattenConnectionOptionsOAuth2(connectionOptions)
 	case *management.ConnectionOptionsFacebook:
-		m = flattenConnectionOptionsFacebook(o)
+		m = flattenConnectionOptionsFacebook(connectionOptions)
 	case *management.ConnectionOptionsApple:
-		m = flattenConnectionOptionsApple(o)
+		m = flattenConnectionOptionsApple(connectionOptions)
 	case *management.ConnectionOptionsLinkedin:
-		m = flattenConnectionOptionsLinkedin(o)
+		m = flattenConnectionOptionsLinkedin(connectionOptions)
 	case *management.ConnectionOptionsGitHub:
-		m = flattenConnectionOptionsGitHub(o)
+		m = flattenConnectionOptionsGitHub(connectionOptions)
 	case *management.ConnectionOptionsWindowsLive:
-		m = flattenConnectionOptionsWindowsLive(o)
+		m = flattenConnectionOptionsWindowsLive(connectionOptions)
 	case *management.ConnectionOptionsSalesforce:
-		m = flattenConnectionOptionsSalesforce(o)
+		m = flattenConnectionOptionsSalesforce(connectionOptions)
 	case *management.ConnectionOptionsEmail:
-		m = flattenConnectionOptionsEmail(o)
+		m = flattenConnectionOptionsEmail(connectionOptions)
 	case *management.ConnectionOptionsSMS:
-		m = flattenConnectionOptionsSMS(o)
+		m = flattenConnectionOptionsSMS(connectionOptions)
 	case *management.ConnectionOptionsOIDC:
-		m = flattenConnectionOptionsOIDC(o)
+		m = flattenConnectionOptionsOIDC(connectionOptions)
 	case *management.ConnectionOptionsAD:
-		m = flattenConnectionOptionsAD(o)
+		m = flattenConnectionOptionsAD(connectionOptions)
 	case *management.ConnectionOptionsAzureAD:
-		m = flattenConnectionOptionsAzureAD(o)
+		m = flattenConnectionOptionsAzureAD(connectionOptions)
 	case *management.ConnectionOptionsADFS:
-		m = flattenConnectionOptionsADFS(o)
+		m = flattenConnectionOptionsADFS(connectionOptions)
 	case *management.ConnectionOptionsSAML:
-		m = flattenConnectionOptionsSAML(o)
+		m = flattenConnectionOptionsSAML(connectionOptions)
 	}
 
 	return []interface{}{m}
 }
 
-func flattenConnectionOptionsGitHub(o *management.ConnectionOptionsGitHub) interface{} {
+func optionsBlockIsNotDefined(d ResourceData) bool {
+	_, ok := d.GetOk("options")
+	return !ok
+}
+
+func flattenConnectionOptionsGitHub(options *management.ConnectionOptionsGitHub) interface{} {
 	return map[string]interface{}{
-		"client_id":                o.GetClientID(),
-		"client_secret":            o.GetClientSecret(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
-		"scopes":                   o.Scopes(),
+		"client_id":                options.GetClientID(),
+		"client_secret":            options.GetClientSecret(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
+		"scopes":                   options.Scopes(),
 	}
 }
 
-func flattenConnectionOptionsWindowsLive(o *management.ConnectionOptionsWindowsLive) interface{} {
+func flattenConnectionOptionsWindowsLive(options *management.ConnectionOptionsWindowsLive) interface{} {
 	return map[string]interface{}{
-		"client_id":                o.GetClientID(),
-		"client_secret":            o.GetClientSecret(),
-		"scopes":                   o.Scopes(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
-		"strategy_version":         o.GetStrategyVersion(),
+		"client_id":                options.GetClientID(),
+		"client_secret":            options.GetClientSecret(),
+		"scopes":                   options.Scopes(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
+		"strategy_version":         options.GetStrategyVersion(),
 	}
 }
 
-func flattenConnectionOptionsAuth0(d ResourceData, o *management.ConnectionOptions) interface{} {
+func flattenConnectionOptionsAuth0(d ResourceData, options *management.ConnectionOptions) interface{} {
+	m := map[string]interface{}{
+		"password_policy":                options.GetPasswordPolicy(),
+		"enabled_database_customization": options.GetEnabledDatabaseCustomization(),
+		"brute_force_protection":         options.GetBruteForceProtection(),
+		"import_mode":                    options.GetImportMode(),
+		"disable_signup":                 options.GetDisableSignup(),
+		"requires_username":              options.GetRequiresUsername(),
+		"custom_scripts":                 options.CustomScripts,
+		"configuration":                  Map(d, "options.0.configuration"), // does not get read back
+		"non_persistent_attrs":           options.GetNonPersistentAttrs(),
+	}
+
+	if options.PasswordComplexityOptions != nil {
+		m["password_complexity_options"] = []interface{}{options.PasswordComplexityOptions}
+	}
+	if options.PasswordDictionary != nil {
+		m["password_dictionary"] = []interface{}{options.PasswordDictionary}
+	}
+	if options.PasswordNoPersonalInfo != nil {
+		m["password_no_personal_info"] = []interface{}{options.PasswordNoPersonalInfo}
+	}
+	if options.PasswordHistory != nil {
+		m["password_history"] = []interface{}{options.PasswordHistory}
+	}
+	if options.MFA != nil {
+		m["mfa"] = []interface{}{options.MFA}
+	}
+	if options.Validation != nil {
+		m["validation"] = []interface{}{
+			map[string]interface{}{
+				"username": []interface{}{
+					options.Validation["username"],
+				},
+			},
+		}
+	}
+
+	return m
+}
+
+func flattenConnectionOptionsGoogleOAuth2(options *management.ConnectionOptionsGoogleOAuth2) interface{} {
 	return map[string]interface{}{
-		"validation":                     o.Validation,
-		"password_policy":                o.GetPasswordPolicy(),
-		"password_history":               o.PasswordHistory,
-		"password_no_personal_info":      o.PasswordNoPersonalInfo,
-		"password_dictionary":            o.PasswordDictionary,
-		"password_complexity_options":    o.PasswordComplexityOptions,
-		"enabled_database_customization": o.GetEnabledDatabaseCustomization(),
-		"brute_force_protection":         o.GetBruteForceProtection(),
-		"import_mode":                    o.GetImportMode(),
-		"disable_signup":                 o.GetDisableSignup(),
-		"requires_username":              o.GetRequiresUsername(),
-		"custom_scripts":                 o.CustomScripts,
-		"mfa":                            o.MFA,
-		"configuration":                  Map(d, "configuration"), // does not get read back
-		"non_persistent_attrs":           o.GetNonPersistentAttrs(),
+		"client_id":                options.GetClientID(),
+		"client_secret":            options.GetClientSecret(),
+		"allowed_audiences":        options.AllowedAudiences,
+		"scopes":                   options.Scopes(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
 	}
 }
 
-func flattenConnectionOptionsGoogleOAuth2(o *management.ConnectionOptionsGoogleOAuth2) interface{} {
+func flattenConnectionOptionsGoogleApps(options *management.ConnectionOptionsGoogleApps) interface{} {
 	return map[string]interface{}{
-		"client_id":                o.GetClientID(),
-		"client_secret":            o.GetClientSecret(),
-		"allowed_audiences":        o.AllowedAudiences,
-		"scopes":                   o.Scopes(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+		"client_id":                options.GetClientID(),
+		"client_secret":            options.GetClientSecret(),
+		"domain":                   options.GetDomain(),
+		"tenant_domain":            options.GetTenantDomain(),
+		"api_enable_users":         options.GetEnableUsersAPI(),
+		"scopes":                   options.Scopes(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
+		"domain_aliases":           options.DomainAliases,
+		"icon_url":                 options.GetLogoURL(),
 	}
 }
 
-func flattenConnectionOptionsGoogleApps(o *management.ConnectionOptionsGoogleApps) interface{} {
+func flattenConnectionOptionsOAuth2(options *management.ConnectionOptionsOAuth2) interface{} {
 	return map[string]interface{}{
-		"client_id":                o.GetClientID(),
-		"client_secret":            o.GetClientSecret(),
-		"domain":                   o.GetDomain(),
-		"tenant_domain":            o.GetTenantDomain(),
-		"api_enable_users":         o.GetEnableUsersAPI(),
-		"scopes":                   o.Scopes(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
-		"domain_aliases":           o.DomainAliases,
-		"icon_url":                 o.GetLogoURL(),
+		"client_id":                options.GetClientID(),
+		"client_secret":            options.GetClientSecret(),
+		"scopes":                   options.Scopes(),
+		"token_endpoint":           options.GetTokenURL(),
+		"authorization_endpoint":   options.GetAuthorizationURL(),
+		"scripts":                  options.Scripts,
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
 	}
 }
 
-func flattenConnectionOptionsOAuth2(o *management.ConnectionOptionsOAuth2) interface{} {
+func flattenConnectionOptionsFacebook(options *management.ConnectionOptionsFacebook) interface{} {
 	return map[string]interface{}{
-		"client_id":                o.GetClientID(),
-		"client_secret":            o.GetClientSecret(),
-		"scopes":                   o.Scopes(),
-		"token_endpoint":           o.GetTokenURL(),
-		"authorization_endpoint":   o.GetAuthorizationURL(),
-		"scripts":                  o.Scripts,
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+		"client_id":                options.GetClientID(),
+		"client_secret":            options.GetClientSecret(),
+		"scopes":                   options.Scopes(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
 	}
 }
 
-func flattenConnectionOptionsFacebook(o *management.ConnectionOptionsFacebook) interface{} {
+func flattenConnectionOptionsApple(options *management.ConnectionOptionsApple) interface{} {
 	return map[string]interface{}{
-		"client_id":                o.GetClientID(),
-		"client_secret":            o.GetClientSecret(),
-		"scopes":                   o.Scopes(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+		"client_id":                options.GetClientID(),
+		"client_secret":            options.GetClientSecret(),
+		"team_id":                  options.GetTeamID(),
+		"key_id":                   options.GetKeyID(),
+		"scopes":                   options.Scopes(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
 	}
 }
 
-func flattenConnectionOptionsApple(o *management.ConnectionOptionsApple) interface{} {
+func flattenConnectionOptionsLinkedin(options *management.ConnectionOptionsLinkedin) interface{} {
 	return map[string]interface{}{
-		"client_id":                o.GetClientID(),
-		"client_secret":            o.GetClientSecret(),
-		"team_id":                  o.GetTeamID(),
-		"key_id":                   o.GetKeyID(),
-		"scopes":                   o.Scopes(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+		"client_id":                options.GetClientID(),
+		"client_secret":            options.GetClientSecret(),
+		"strategy_version":         options.GetStrategyVersion(),
+		"scopes":                   options.Scopes(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
 	}
 }
 
-func flattenConnectionOptionsLinkedin(o *management.ConnectionOptionsLinkedin) interface{} {
+func flattenConnectionOptionsSalesforce(options *management.ConnectionOptionsSalesforce) interface{} {
 	return map[string]interface{}{
-		"client_id":                o.GetClientID(),
-		"client_secret":            o.GetClientSecret(),
-		"strategy_version":         o.GetStrategyVersion(),
-		"scopes":                   o.Scopes(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+		"client_id":                options.GetClientID(),
+		"client_secret":            options.GetClientSecret(),
+		"community_base_url":       options.GetCommunityBaseURL(),
+		"scopes":                   options.Scopes(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
 	}
 }
 
-func flattenConnectionOptionsSalesforce(o *management.ConnectionOptionsSalesforce) interface{} {
+func flattenConnectionOptionsSMS(options *management.ConnectionOptionsSMS) interface{} {
+	m := map[string]interface{}{
+		"name":                   options.GetName(),
+		"from":                   options.GetFrom(),
+		"syntax":                 options.GetSyntax(),
+		"template":               options.GetTemplate(),
+		"twilio_sid":             options.GetTwilioSID(),
+		"twilio_token":           options.GetTwilioToken(),
+		"messaging_service_sid":  options.GetMessagingServiceSID(),
+		"disable_signup":         options.GetDisableSignup(),
+		"brute_force_protection": options.GetBruteForceProtection(),
+		"provider":               options.GetProvider(),
+		"gateway_url":            options.GetGatewayURL(),
+		"forward_request_info":   options.GetForwardRequestInfo(),
+	}
+
+	if options.OTP != nil {
+		m["totp"] = []interface{}{
+			map[string]interface{}{
+				"time_step": options.OTP.GetTimeStep(),
+				"length":    options.OTP.GetLength(),
+			},
+		}
+	}
+
+	if options.GatewayAuthentication != nil {
+		m["gateway_authentication"] = []interface{}{
+			map[string]interface{}{
+				"method":                options.GatewayAuthentication.GetMethod(),
+				"subject":               options.GatewayAuthentication.GetSubject(),
+				"audience":              options.GatewayAuthentication.GetAudience(),
+				"secret":                options.GatewayAuthentication.GetSecret(),
+				"secret_base64_encoded": options.GatewayAuthentication.GetSecretBase64Encoded(),
+			},
+		}
+	}
+
+	return m
+}
+
+func flattenConnectionOptionsOIDC(options *management.ConnectionOptionsOIDC) interface{} {
 	return map[string]interface{}{
-		"client_id":                o.GetClientID(),
-		"client_secret":            o.GetClientSecret(),
-		"community_base_url":       o.GetCommunityBaseURL(),
-		"scopes":                   o.Scopes(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+		"client_id":                options.GetClientID(),
+		"client_secret":            options.GetClientSecret(),
+		"icon_url":                 options.GetLogoURL(),
+		"tenant_domain":            options.GetTenantDomain(),
+		"domain_aliases":           options.DomainAliases,
+		"type":                     options.GetType(),
+		"scopes":                   options.Scopes(),
+		"issuer":                   options.GetIssuer(),
+		"jwks_uri":                 options.GetJWKSURI(),
+		"discovery_url":            options.GetDiscoveryURL(),
+		"token_endpoint":           options.GetTokenEndpoint(),
+		"userinfo_endpoint":        options.GetUserInfoEndpoint(),
+		"authorization_endpoint":   options.GetAuthorizationEndpoint(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
 	}
 }
 
-func flattenConnectionOptionsSMS(o *management.ConnectionOptionsSMS) interface{} {
+func flattenConnectionOptionsEmail(options *management.ConnectionOptionsEmail) interface{} {
+	m := map[string]interface{}{
+		"name":                     options.GetName(),
+		"from":                     options.GetEmail().GetFrom(),
+		"syntax":                   options.GetEmail().GetSyntax(),
+		"subject":                  options.GetEmail().GetSubject(),
+		"template":                 options.GetEmail().GetBody(),
+		"disable_signup":           options.GetDisableSignup(),
+		"brute_force_protection":   options.GetBruteForceProtection(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
+	}
+
+	if options.OTP != nil {
+		m["totp"] = []interface{}{
+			map[string]interface{}{
+				"time_step": options.OTP.GetTimeStep(),
+				"length":    options.OTP.GetLength(),
+			},
+		}
+	}
+
+	return m
+}
+
+func flattenConnectionOptionsAD(options *management.ConnectionOptionsAD) interface{} {
 	return map[string]interface{}{
-		"name":                   o.GetName(),
-		"from":                   o.GetFrom(),
-		"syntax":                 o.GetSyntax(),
-		"template":               o.GetTemplate(),
-		"twilio_sid":             o.GetTwilioSID(),
-		"twilio_token":           o.GetTwilioToken(),
-		"messaging_service_sid":  o.GetMessagingServiceSID(),
-		"disable_signup":         o.GetDisableSignup(),
-		"brute_force_protection": o.GetBruteForceProtection(),
-		"totp": map[string]interface{}{
-			"time_step": o.OTP.GetTimeStep(),
-			"length":    o.OTP.GetLength(),
-		},
-		"provider":    o.GetProvider(),
-		"gateway_url": o.GetGatewayURL(),
-		"gateway_authentication": map[string]interface{}{
-			"method":                o.GatewayAuthentication.GetMethod(),
-			"subject":               o.GatewayAuthentication.GetSubject(),
-			"audience":              o.GatewayAuthentication.GetAudience(),
-			"secret_base64_encoded": o.GatewayAuthentication.GetSecretBase64Encoded(),
-		},
-		"forward_request_info": o.GetForwardRequestInfo(),
+		"tenant_domain":            options.GetTenantDomain(),
+		"domain_aliases":           options.DomainAliases,
+		"icon_url":                 options.GetLogoURL(),
+		"ips":                      options.IPs,
+		"use_cert_auth":            options.GetCertAuth(),
+		"use_kerberos":             options.GetKerberos(),
+		"disable_cache":            options.GetDisableCache(),
+		"brute_force_protection":   options.GetBruteForceProtection(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
 	}
 }
 
-func flattenConnectionOptionsOIDC(o *management.ConnectionOptionsOIDC) interface{} {
+func flattenConnectionOptionsAzureAD(options *management.ConnectionOptionsAzureAD) interface{} {
 	return map[string]interface{}{
-		"client_id":                o.GetClientID(),
-		"client_secret":            o.GetClientSecret(),
-		"icon_url":                 o.GetLogoURL(),
-		"tenant_domain":            o.GetTenantDomain(),
-		"domain_aliases":           o.DomainAliases,
-		"type":                     o.GetType(),
-		"scopes":                   o.Scopes(),
-		"issuer":                   o.GetIssuer(),
-		"jwks_uri":                 o.GetJWKSURI(),
-		"discovery_url":            o.GetDiscoveryURL(),
-		"token_endpoint":           o.GetTokenEndpoint(),
-		"userinfo_endpoint":        o.GetUserInfoEndpoint(),
-		"authorization_endpoint":   o.GetAuthorizationEndpoint(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+		"client_id":                              options.GetClientID(),
+		"client_secret":                          options.GetClientSecret(),
+		"app_id":                                 options.GetAppID(),
+		"tenant_domain":                          options.GetTenantDomain(),
+		"domain":                                 options.GetDomain(),
+		"domain_aliases":                         options.DomainAliases,
+		"icon_url":                               options.GetLogoURL(),
+		"identity_api":                           options.GetIdentityAPI(),
+		"waad_protocol":                          options.GetWAADProtocol(),
+		"waad_common_endpoint":                   options.GetUseCommonEndpoint(),
+		"use_wsfed":                              options.GetUseWSFederation(),
+		"api_enable_users":                       options.GetEnableUsersAPI(),
+		"max_groups_to_retrieve":                 options.GetMaxGroupsToRetrieve(),
+		"scopes":                                 options.Scopes(),
+		"set_user_root_attributes":               options.GetSetUserAttributes(),
+		"non_persistent_attrs":                   options.GetNonPersistentAttrs(),
+		"should_trust_email_verified_connection": options.GetTrustEmailVerified(),
 	}
 }
 
-func flattenConnectionOptionsEmail(o *management.ConnectionOptionsEmail) interface{} {
+func flattenConnectionOptionsADFS(options *management.ConnectionOptionsADFS) interface{} {
 	return map[string]interface{}{
-		"name":                   o.GetName(),
-		"from":                   o.GetEmail().GetFrom(),
-		"syntax":                 o.GetEmail().GetSyntax(),
-		"subject":                o.GetEmail().GetSubject(),
-		"template":               o.GetEmail().GetBody(),
-		"disable_signup":         o.GetDisableSignup(),
-		"brute_force_protection": o.GetBruteForceProtection(),
-		"totp": map[string]interface{}{
-			"time_step": o.OTP.GetTimeStep(),
-			"length":    o.OTP.GetLength(),
-		},
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+		"tenant_domain":            options.GetTenantDomain(),
+		"domain_aliases":           options.DomainAliases,
+		"icon_url":                 options.GetLogoURL(),
+		"adfs_server":              options.GetADFSServer(),
+		"api_enable_users":         options.GetEnableUsersAPI(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
 	}
 }
 
-func flattenConnectionOptionsAD(o *management.ConnectionOptionsAD) interface{} {
-	return map[string]interface{}{
-		"tenant_domain":            o.GetTenantDomain(),
-		"domain_aliases":           o.DomainAliases,
-		"icon_url":                 o.GetLogoURL(),
-		"ips":                      o.IPs,
-		"use_cert_auth":            o.GetCertAuth(),
-		"use_kerberos":             o.GetKerberos(),
-		"disable_cache":            o.GetDisableCache(),
-		"brute_force_protection":   o.GetBruteForceProtection(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+func flattenConnectionOptionsSAML(options *management.ConnectionOptionsSAML) interface{} {
+	m := map[string]interface{}{
+		"signing_cert":             options.GetSigningCert(),
+		"protocol_binding":         options.GetProtocolBinding(),
+		"debug":                    options.GetDebug(),
+		"tenant_domain":            options.GetTenantDomain(),
+		"domain_aliases":           options.DomainAliases,
+		"sign_in_endpoint":         options.GetSignInEndpoint(),
+		"sign_out_endpoint":        options.GetSignOutEndpoint(),
+		"signature_algorithm":      options.GetSignatureAlgorithm(),
+		"digest_algorithm":         options.GetDigestAglorithm(),
+		"fields_map":               options.FieldsMap,
+		"sign_saml_request":        options.GetSignSAMLRequest(),
+		"icon_url":                 options.GetLogoURL(),
+		"request_template":         options.GetRequestTemplate(),
+		"user_id_attribute":        options.GetUserIDAttribute(),
+		"set_user_root_attributes": options.GetSetUserAttributes(),
+		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
+		"entity_id":                options.GetEntityID(),
 	}
-}
 
-func flattenConnectionOptionsAzureAD(o *management.ConnectionOptionsAzureAD) interface{} {
-	return map[string]interface{}{
-		"client_id":                              o.GetClientID(),
-		"client_secret":                          o.GetClientSecret(),
-		"app_id":                                 o.GetAppID(),
-		"tenant_domain":                          o.GetTenantDomain(),
-		"domain":                                 o.GetDomain(),
-		"domain_aliases":                         o.DomainAliases,
-		"icon_url":                               o.GetLogoURL(),
-		"identity_api":                           o.GetIdentityAPI(),
-		"waad_protocol":                          o.GetWAADProtocol(),
-		"waad_common_endpoint":                   o.GetUseCommonEndpoint(),
-		"use_wsfed":                              o.GetUseWSFederation(),
-		"api_enable_users":                       o.GetEnableUsersAPI(),
-		"max_groups_to_retrieve":                 o.GetMaxGroupsToRetrieve(),
-		"scopes":                                 o.Scopes(),
-		"set_user_root_attributes":               o.GetSetUserAttributes(),
-		"non_persistent_attrs":                   o.GetNonPersistentAttrs(),
-		"should_trust_email_verified_connection": o.GetTrustEmailVerified(),
+	if options.IdpInitiated != nil {
+		m["idp_initiated"] = []interface{}{
+			map[string]interface{}{
+				"client_id":              options.IdpInitiated.GetClientID(),
+				"client_protocol":        options.IdpInitiated.GetClientProtocol(),
+				"client_authorize_query": options.IdpInitiated.GetClientAuthorizeQuery(),
+			},
+		}
 	}
-}
 
-func flattenConnectionOptionsADFS(o *management.ConnectionOptionsADFS) interface{} {
-	return map[string]interface{}{
-		"tenant_domain":            o.GetTenantDomain(),
-		"domain_aliases":           o.DomainAliases,
-		"icon_url":                 o.GetLogoURL(),
-		"adfs_server":              o.GetADFSServer(),
-		"api_enable_users":         o.GetEnableUsersAPI(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
-	}
-}
-
-func flattenConnectionOptionsSAML(o *management.ConnectionOptionsSAML) interface{} {
-	return map[string]interface{}{
-		"signing_cert":     o.GetSigningCert(),
-		"protocol_binding": o.GetProtocolBinding(),
-		"debug":            o.GetDebug(),
-		"idp_initiated": map[string]interface{}{
-			"client_id":              o.IdpInitiated.GetClientID(),
-			"client_protocol":        o.IdpInitiated.GetClientProtocol(),
-			"client_authorize_query": o.IdpInitiated.GetClientAuthorizeQuery(),
-		},
-		"tenant_domain":            o.GetTenantDomain(),
-		"domain_aliases":           o.DomainAliases,
-		"sign_in_endpoint":         o.GetSignInEndpoint(),
-		"sign_out_endpoint":        o.GetSignOutEndpoint(),
-		"signature_algorithm":      o.GetSignatureAlgorithm(),
-		"digest_algorithm":         o.GetDigestAglorithm(),
-		"fields_map":               o.FieldsMap,
-		"sign_saml_request":        o.GetSignSAMLRequest(),
-		"icon_url":                 o.GetLogoURL(),
-		"request_template":         o.GetRequestTemplate(),
-		"user_id_attribute":        o.GetUserIDAttribute(),
-		"set_user_root_attributes": o.GetSetUserAttributes(),
-		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
-		"entity_id":                o.GetEntityID(),
-	}
+	return m
 }
 
 func expandConnection(d ResourceData) *management.Connection {
@@ -416,7 +473,10 @@ func expandConnectionOptionsAuth0(d ResourceData) *management.ConnectionOptions 
 	List(d, "password_history").Elem(func(d ResourceData) {
 		options.PasswordHistory = make(map[string]interface{})
 		options.PasswordHistory["enable"] = Bool(d, "enable")
-		options.PasswordHistory["size"] = Int(d, "size")
+
+		if size, ok := d.GetOk("size"); ok {
+			options.PasswordHistory["size"] = auth0.Int(size.(int))
+		}
 	})
 
 	List(d, "password_no_personal_info").Elem(func(d ResourceData) {
@@ -633,25 +693,17 @@ func expandConnectionOptionsEmail(d ResourceData) *management.ConnectionOptionsE
 
 func expandConnectionOptionsAD(d ResourceData) *management.ConnectionOptionsAD {
 	options := &management.ConnectionOptionsAD{
-		DomainAliases:      Set(d, "domain_aliases").List(),
-		TenantDomain:       String(d, "tenant_domain"),
-		LogoURL:            String(d, "icon_url"),
-		IPs:                Set(d, "ips").List(),
-		CertAuth:           Bool(d, "use_cert_auth"),
-		Kerberos:           Bool(d, "use_kerberos"),
-		DisableCache:       Bool(d, "disable_cache"),
-		SetUserAttributes:  String(d, "set_user_root_attributes"),
-		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
+		DomainAliases:        Set(d, "domain_aliases").List(),
+		TenantDomain:         String(d, "tenant_domain"),
+		LogoURL:              String(d, "icon_url"),
+		IPs:                  Set(d, "ips").List(),
+		CertAuth:             Bool(d, "use_cert_auth"),
+		Kerberos:             Bool(d, "use_kerberos"),
+		DisableCache:         Bool(d, "disable_cache"),
+		SetUserAttributes:    String(d, "set_user_root_attributes"),
+		NonPersistentAttrs:   castToListOfStrings(Set(d, "non_persistent_attrs").List()),
+		BruteForceProtection: Bool(d, "brute_force_protection"),
 	}
-
-	// `brute_force_protection` will default to true by the API if we don't
-	// specify it. Therefore if it's not specified we'll set it to false
-	// ourselves.
-	v, ok := d.GetOk("brute_force_protection")
-	if !ok {
-		v = false
-	}
-	options.BruteForceProtection = auth0.Bool(v.(bool))
 
 	return options
 }

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -8,7 +8,6 @@ import (
 )
 
 func flattenConnectionOptions(d ResourceData, options interface{}) []interface{} {
-
 	var m interface{}
 
 	switch o := options.(type) {
@@ -204,12 +203,11 @@ func flattenConnectionOptionsSMS(o *management.ConnectionOptionsSMS) interface{}
 
 func flattenConnectionOptionsOIDC(o *management.ConnectionOptionsOIDC) interface{} {
 	return map[string]interface{}{
-		"client_id":      o.GetClientID(),
-		"client_secret":  o.GetClientSecret(),
-		"icon_url":       o.GetLogoURL(),
-		"tenant_domain":  o.GetTenantDomain(),
-		"domain_aliases": o.DomainAliases,
-
+		"client_id":                o.GetClientID(),
+		"client_secret":            o.GetClientSecret(),
+		"icon_url":                 o.GetLogoURL(),
+		"tenant_domain":            o.GetTenantDomain(),
+		"domain_aliases":           o.DomainAliases,
 		"type":                     o.GetType(),
 		"scopes":                   o.Scopes(),
 		"issuer":                   o.GetIssuer(),
@@ -318,7 +316,7 @@ func flattenConnectionOptionsSAML(o *management.ConnectionOptionsSAML) interface
 }
 
 func expandConnection(d ResourceData) *management.Connection {
-	c := &management.Connection{
+	connection := &management.Connection{
 		Name:               String(d, "name", IsNewResource()),
 		DisplayName:        String(d, "display_name"),
 		Strategy:           String(d, "strategy", IsNewResource()),
@@ -335,47 +333,47 @@ func expandConnection(d ResourceData) *management.Connection {
 		management.ConnectionStrategyAzureAD,
 		management.ConnectionStrategySAML,
 		management.ConnectionStrategyADFS:
-		c.ShowAsButton = Bool(d, "show_as_button")
+		connection.ShowAsButton = Bool(d, "show_as_button")
 	}
 
 	List(d, "options").Elem(func(d ResourceData) {
 		switch strategy {
 		case management.ConnectionStrategyAuth0:
-			c.Options = expandConnectionOptionsAuth0(d)
+			connection.Options = expandConnectionOptionsAuth0(d)
 		case management.ConnectionStrategyGoogleOAuth2:
-			c.Options = expandConnectionOptionsGoogleOAuth2(d)
+			connection.Options = expandConnectionOptionsGoogleOAuth2(d)
 		case management.ConnectionStrategyGoogleApps:
-			c.Options = expandConnectionOptionsGoogleApps(d)
+			connection.Options = expandConnectionOptionsGoogleApps(d)
 		case management.ConnectionStrategyOAuth2:
-			c.Options = expandConnectionOptionsOAuth2(d)
+			connection.Options = expandConnectionOptionsOAuth2(d)
 		case management.ConnectionStrategyFacebook:
-			c.Options = expandConnectionOptionsFacebook(d)
+			connection.Options = expandConnectionOptionsFacebook(d)
 		case management.ConnectionStrategyApple:
-			c.Options = expandConnectionOptionsApple(d)
+			connection.Options = expandConnectionOptionsApple(d)
 		case management.ConnectionStrategyLinkedin:
-			c.Options = expandConnectionOptionsLinkedin(d)
+			connection.Options = expandConnectionOptionsLinkedin(d)
 		case management.ConnectionStrategyGitHub:
-			c.Options = expandConnectionOptionsGitHub(d)
+			connection.Options = expandConnectionOptionsGitHub(d)
 		case management.ConnectionStrategyWindowsLive:
-			c.Options = expandConnectionOptionsWindowsLive(d)
+			connection.Options = expandConnectionOptionsWindowsLive(d)
 		case management.ConnectionStrategySalesforce,
 			management.ConnectionStrategySalesforceCommunity,
 			management.ConnectionStrategySalesforceSandbox:
-			c.Options = expandConnectionOptionsSalesforce(d)
+			connection.Options = expandConnectionOptionsSalesforce(d)
 		case management.ConnectionStrategySMS:
-			c.Options = expandConnectionOptionsSMS(d)
+			connection.Options = expandConnectionOptionsSMS(d)
 		case management.ConnectionStrategyOIDC:
-			c.Options = expandConnectionOptionsOIDC(d)
+			connection.Options = expandConnectionOptionsOIDC(d)
 		case management.ConnectionStrategyAD:
-			c.Options = expandConnectionOptionsAD(d)
+			connection.Options = expandConnectionOptionsAD(d)
 		case management.ConnectionStrategyAzureAD:
-			c.Options = expandConnectionOptionsAzureAD(d)
+			connection.Options = expandConnectionOptionsAzureAD(d)
 		case management.ConnectionStrategyEmail:
-			c.Options = expandConnectionOptionsEmail(d)
+			connection.Options = expandConnectionOptionsEmail(d)
 		case management.ConnectionStrategySAML:
-			c.Options = expandConnectionOptionsSAML(d)
+			connection.Options = expandConnectionOptionsSAML(d)
 		case management.ConnectionStrategyADFS:
-			c.Options = expandConnectionOptionsADFS(d)
+			connection.Options = expandConnectionOptionsADFS(d)
 		default:
 			log.Printf("[WARN]: Unsupported connection strategy %s", strategy)
 			log.Printf("[WARN]: Raise an issue with the auth0 provider in order to support it:")
@@ -383,82 +381,79 @@ func expandConnection(d ResourceData) *management.Connection {
 		}
 	})
 
-	return c
+	return connection
 }
 
 func expandConnectionOptionsGitHub(d ResourceData) *management.ConnectionOptionsGitHub {
-
-	o := &management.ConnectionOptionsGitHub{
+	options := &management.ConnectionOptionsGitHub{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
 		SetUserAttributes:  String(d, "set_user_root_attributes"),
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
-	expandConnectionOptionsScopes(d, o)
+	expandConnectionOptionsScopes(d, options)
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsAuth0(d ResourceData) *management.ConnectionOptions {
-
-	o := &management.ConnectionOptions{
+	options := &management.ConnectionOptions{
 		PasswordPolicy:     String(d, "password_policy"),
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	List(d, "validation").Elem(func(d ResourceData) {
-		o.Validation = make(map[string]interface{})
+		options.Validation = make(map[string]interface{})
 		List(d, "username").Elem(func(d ResourceData) {
 			usernameValidation := make(map[string]*int)
 			usernameValidation["min"] = Int(d, "min")
 			usernameValidation["max"] = Int(d, "max")
-			o.Validation["username"] = usernameValidation
+			options.Validation["username"] = usernameValidation
 		})
 	})
 
 	List(d, "password_history").Elem(func(d ResourceData) {
-		o.PasswordHistory = make(map[string]interface{})
-		o.PasswordHistory["enable"] = Bool(d, "enable")
-		o.PasswordHistory["size"] = Int(d, "size")
+		options.PasswordHistory = make(map[string]interface{})
+		options.PasswordHistory["enable"] = Bool(d, "enable")
+		options.PasswordHistory["size"] = Int(d, "size")
 	})
 
 	List(d, "password_no_personal_info").Elem(func(d ResourceData) {
-		o.PasswordNoPersonalInfo = make(map[string]interface{})
-		o.PasswordNoPersonalInfo["enable"] = Bool(d, "enable")
+		options.PasswordNoPersonalInfo = make(map[string]interface{})
+		options.PasswordNoPersonalInfo["enable"] = Bool(d, "enable")
 	})
 
 	List(d, "password_dictionary").Elem(func(d ResourceData) {
-		o.PasswordDictionary = make(map[string]interface{})
-		o.PasswordDictionary["enable"] = Bool(d, "enable")
-		o.PasswordDictionary["dictionary"] = Set(d, "dictionary").List()
+		options.PasswordDictionary = make(map[string]interface{})
+		options.PasswordDictionary["enable"] = Bool(d, "enable")
+		options.PasswordDictionary["dictionary"] = Set(d, "dictionary").List()
 	})
 
 	List(d, "password_complexity_options").Elem(func(d ResourceData) {
-		o.PasswordComplexityOptions = make(map[string]interface{})
-		o.PasswordComplexityOptions["min_length"] = Int(d, "min_length")
+		options.PasswordComplexityOptions = make(map[string]interface{})
+		options.PasswordComplexityOptions["min_length"] = Int(d, "min_length")
 	})
 
 	List(d, "mfa").Elem(func(d ResourceData) {
-		o.MFA = make(map[string]interface{})
-		o.MFA["active"] = Bool(d, "active")
-		o.MFA["return_enroll_settings"] = Bool(d, "return_enroll_settings")
+		options.MFA = make(map[string]interface{})
+		options.MFA["active"] = Bool(d, "active")
+		options.MFA["return_enroll_settings"] = Bool(d, "return_enroll_settings")
 	})
 
-	o.EnabledDatabaseCustomization = Bool(d, "enabled_database_customization")
-	o.BruteForceProtection = Bool(d, "brute_force_protection")
-	o.ImportMode = Bool(d, "import_mode")
-	o.DisableSignup = Bool(d, "disable_signup")
-	o.RequiresUsername = Bool(d, "requires_username")
-	o.CustomScripts = Map(d, "custom_scripts")
-	o.Configuration = Map(d, "configuration")
+	options.EnabledDatabaseCustomization = Bool(d, "enabled_database_customization")
+	options.BruteForceProtection = Bool(d, "brute_force_protection")
+	options.ImportMode = Bool(d, "import_mode")
+	options.DisableSignup = Bool(d, "disable_signup")
+	options.RequiresUsername = Bool(d, "requires_username")
+	options.CustomScripts = Map(d, "custom_scripts")
+	options.Configuration = Map(d, "configuration")
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsGoogleOAuth2(d ResourceData) *management.ConnectionOptionsGoogleOAuth2 {
-
-	o := &management.ConnectionOptionsGoogleOAuth2{
+	options := &management.ConnectionOptionsGoogleOAuth2{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
 		AllowedAudiences:   Set(d, "allowed_audiences").List(),
@@ -466,14 +461,13 @@ func expandConnectionOptionsGoogleOAuth2(d ResourceData) *management.ConnectionO
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
-	expandConnectionOptionsScopes(d, o)
+	expandConnectionOptionsScopes(d, options)
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsGoogleApps(d ResourceData) *management.ConnectionOptionsGoogleApps {
-
-	o := &management.ConnectionOptionsGoogleApps{
+	options := &management.ConnectionOptionsGoogleApps{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
 		Domain:             String(d, "domain"),
@@ -485,14 +479,13 @@ func expandConnectionOptionsGoogleApps(d ResourceData) *management.ConnectionOpt
 		LogoURL:            String(d, "icon_url"),
 	}
 
-	expandConnectionOptionsScopes(d, o)
+	expandConnectionOptionsScopes(d, options)
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsOAuth2(d ResourceData) *management.ConnectionOptionsOAuth2 {
-
-	o := &management.ConnectionOptionsOAuth2{
+	options := &management.ConnectionOptionsOAuth2{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
 		AuthorizationURL:   String(d, "authorization_endpoint"),
@@ -500,30 +493,28 @@ func expandConnectionOptionsOAuth2(d ResourceData) *management.ConnectionOptions
 		SetUserAttributes:  String(d, "set_user_root_attributes"),
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
-	o.Scripts = Map(d, "scripts")
+	options.Scripts = Map(d, "scripts")
 
-	expandConnectionOptionsScopes(d, o)
+	expandConnectionOptionsScopes(d, options)
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsFacebook(d ResourceData) *management.ConnectionOptionsFacebook {
-
-	o := &management.ConnectionOptionsFacebook{
+	options := &management.ConnectionOptionsFacebook{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
 		SetUserAttributes:  String(d, "set_user_root_attributes"),
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
-	expandConnectionOptionsScopes(d, o)
+	expandConnectionOptionsScopes(d, options)
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsApple(d ResourceData) *management.ConnectionOptionsApple {
-
-	o := &management.ConnectionOptionsApple{
+	options := &management.ConnectionOptionsApple{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
 		TeamID:             String(d, "team_id"),
@@ -532,14 +523,13 @@ func expandConnectionOptionsApple(d ResourceData) *management.ConnectionOptionsA
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
-	expandConnectionOptionsScopes(d, o)
+	expandConnectionOptionsScopes(d, options)
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsLinkedin(d ResourceData) *management.ConnectionOptionsLinkedin {
-
-	o := &management.ConnectionOptionsLinkedin{
+	options := &management.ConnectionOptionsLinkedin{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
 		StrategyVersion:    Int(d, "strategy_version"),
@@ -547,14 +537,13 @@ func expandConnectionOptionsLinkedin(d ResourceData) *management.ConnectionOptio
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
-	expandConnectionOptionsScopes(d, o)
+	expandConnectionOptionsScopes(d, options)
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsSalesforce(d ResourceData) *management.ConnectionOptionsSalesforce {
-
-	o := &management.ConnectionOptionsSalesforce{
+	options := &management.ConnectionOptionsSalesforce{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
 		CommunityBaseURL:   String(d, "community_base_url"),
@@ -562,14 +551,13 @@ func expandConnectionOptionsSalesforce(d ResourceData) *management.ConnectionOpt
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
-	expandConnectionOptionsScopes(d, o)
+	expandConnectionOptionsScopes(d, options)
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsWindowsLive(d ResourceData) *management.ConnectionOptionsWindowsLive {
-
-	o := &management.ConnectionOptionsWindowsLive{
+	options := &management.ConnectionOptionsWindowsLive{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
 		StrategyVersion:    Int(d, "strategy_version"),
@@ -577,14 +565,13 @@ func expandConnectionOptionsWindowsLive(d ResourceData) *management.ConnectionOp
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
-	expandConnectionOptionsScopes(d, o)
+	expandConnectionOptionsScopes(d, options)
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsSMS(d ResourceData) *management.ConnectionOptionsSMS {
-
-	o := &management.ConnectionOptionsSMS{
+	options := &management.ConnectionOptionsSMS{
 		Name:                 String(d, "name"),
 		From:                 String(d, "from"),
 		Syntax:               String(d, "syntax"),
@@ -600,14 +587,14 @@ func expandConnectionOptionsSMS(d ResourceData) *management.ConnectionOptionsSMS
 	}
 
 	List(d, "totp").Elem(func(d ResourceData) {
-		o.OTP = &management.ConnectionOptionsOTP{
+		options.OTP = &management.ConnectionOptionsOTP{
 			TimeStep: Int(d, "time_step"),
 			Length:   Int(d, "length"),
 		}
 	})
 
 	List(d, "gateway_authentication").Elem(func(d ResourceData) {
-		o.GatewayAuthentication = &management.ConnectionGatewayAuthentication{
+		options.GatewayAuthentication = &management.ConnectionGatewayAuthentication{
 			Method:              String(d, "method"),
 			Subject:             String(d, "subject"),
 			Audience:            String(d, "audience"),
@@ -616,12 +603,11 @@ func expandConnectionOptionsSMS(d ResourceData) *management.ConnectionOptionsSMS
 		}
 	})
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsEmail(d ResourceData) *management.ConnectionOptionsEmail {
-
-	o := &management.ConnectionOptionsEmail{
+	options := &management.ConnectionOptionsEmail{
 		Name:          String(d, "name"),
 		DisableSignup: Bool(d, "disable_signup"),
 		Email: &management.ConnectionOptionsEmailSettings{
@@ -636,18 +622,17 @@ func expandConnectionOptionsEmail(d ResourceData) *management.ConnectionOptionsE
 	}
 
 	List(d, "totp").Elem(func(d ResourceData) {
-		o.OTP = &management.ConnectionOptionsOTP{
+		options.OTP = &management.ConnectionOptionsOTP{
 			TimeStep: Int(d, "time_step"),
 			Length:   Int(d, "length"),
 		}
 	})
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsAD(d ResourceData) *management.ConnectionOptionsAD {
-
-	o := &management.ConnectionOptionsAD{
+	options := &management.ConnectionOptionsAD{
 		DomainAliases:      Set(d, "domain_aliases").List(),
 		TenantDomain:       String(d, "tenant_domain"),
 		LogoURL:            String(d, "icon_url"),
@@ -666,14 +651,13 @@ func expandConnectionOptionsAD(d ResourceData) *management.ConnectionOptionsAD {
 	if !ok {
 		v = false
 	}
-	o.BruteForceProtection = auth0.Bool(v.(bool))
+	options.BruteForceProtection = auth0.Bool(v.(bool))
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsAzureAD(d ResourceData) *management.ConnectionOptionsAzureAD {
-
-	o := &management.ConnectionOptionsAzureAD{
+	options := &management.ConnectionOptionsAzureAD{
 		ClientID:            String(d, "client_id"),
 		ClientSecret:        String(d, "client_secret"),
 		AppID:               String(d, "app_id"),
@@ -692,14 +676,13 @@ func expandConnectionOptionsAzureAD(d ResourceData) *management.ConnectionOption
 		TrustEmailVerified:  String(d, "should_trust_email_verified_connection"),
 	}
 
-	expandConnectionOptionsScopes(d, o)
+	expandConnectionOptionsScopes(d, options)
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsOIDC(d ResourceData) *management.ConnectionOptionsOIDC {
-
-	o := &management.ConnectionOptionsOIDC{
+	options := &management.ConnectionOptionsOIDC{
 		ClientID:              String(d, "client_id"),
 		ClientSecret:          String(d, "client_secret"),
 		TenantDomain:          String(d, "tenant_domain"),
@@ -716,13 +699,13 @@ func expandConnectionOptionsOIDC(d ResourceData) *management.ConnectionOptionsOI
 		NonPersistentAttrs:    castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
-	expandConnectionOptionsScopes(d, o)
+	expandConnectionOptionsScopes(d, options)
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsSAML(d ResourceData) *management.ConnectionOptionsSAML {
-	o := &management.ConnectionOptionsSAML{
+	options := &management.ConnectionOptionsSAML{
 		Debug:              Bool(d, "debug"),
 		SigningCert:        String(d, "signing_cert"),
 		ProtocolBinding:    String(d, "protocol_binding"),
@@ -743,14 +726,14 @@ func expandConnectionOptionsSAML(d ResourceData) *management.ConnectionOptionsSA
 	}
 
 	List(d, "idp_initiated").Elem(func(d ResourceData) {
-		o.IdpInitiated = &management.ConnectionOptionsSAMLIdpInitiated{
+		options.IdpInitiated = &management.ConnectionOptionsSAMLIdpInitiated{
 			ClientID:             String(d, "client_id"),
 			ClientProtocol:       String(d, "client_protocol"),
 			ClientAuthorizeQuery: String(d, "client_authorize_query"),
 		}
 	})
 
-	return o
+	return options
 }
 
 func expandConnectionOptionsADFS(d ResourceData) *management.ConnectionOptionsADFS {
@@ -771,12 +754,12 @@ type scoper interface {
 }
 
 func expandConnectionOptionsScopes(d ResourceData, s scoper) {
-	add := Set(d, "scopes").List()
-	_, rm := Diff(d, "scopes")
-	for _, scope := range add {
+	scopesList := Set(d, "scopes").List()
+	_, scopesDiff := Diff(d, "scopes")
+	for _, scope := range scopesList {
 		s.SetScopes(true, scope.(string))
 	}
-	for _, scope := range rm.List() {
+	for _, scope := range scopesDiff.List() {
 		s.SetScopes(false, scope.(string))
 	}
 }


### PR DESCRIPTION
## Description

This PR stops ignoring errors when setting resource data within the connection.

```
            * options.0.password_dictionary: '': source data must be an array or slice, got map
            * options.0.password_history: '': source data must be an array or slice, got map
            * options.0.totp: '': source data must be an array or slice, got map
            * options.0.gateway_authentication: '': source data must be an array or slice, got map
            * options.0.idp_initiated: '': source data must be an array or slice, got map
            * options.0.validation: '': source data must be an array or slice, got map
            * options.0.mfa: '': source data must be an array or slice, got map
            * options.0.password_no_personal_info: '': source data must be an array or slice, got map
            * options.0.password_complexity_options: '': source data must be an array or slice, got map
        Error: 400 Bad Request: options.set_user_root_attributes can be set only for enterprise connections, social connections or custom database connections (using external users store)
```

Ultimately fixing these fixes several issues we have on github:

- https://github.com/auth0/terraform-provider-auth0/issues/33
- https://github.com/auth0/terraform-provider-auth0/issues/30
- https://github.com/auth0/terraform-provider-auth0/issues/26
- https://github.com/auth0/terraform-provider-auth0/issues/23
- https://github.com/auth0/terraform-provider-auth0/issues/21
- https://github.com/auth0/terraform-provider-auth0/issues/19
- https://github.com/auth0/terraform-provider-auth0/issues/82

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over