### PR TITLE
DXCDT-80 Stop ignoring errors when setting resource data within prompt

### DIFF
--- a/auth0/resource_auth0_prompt.go
+++ b/auth0/resource_auth0_prompt.go
@@ -11,9 +11,7 @@ import (
 )
 
 func newPrompt() *schema.Resource {
-
 	return &schema.Resource{
-
 		Create: createPrompt,
 		Read:   readPrompt,
 		Update: updatePrompt,
@@ -21,7 +19,6 @@ func newPrompt() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-
 		Schema: map[string]*schema.Schema{
 			"universal_login_experience": {
 				Type:     schema.TypeString,
@@ -45,7 +42,7 @@ func createPrompt(d *schema.ResourceData, m interface{}) error {
 
 func readPrompt(d *schema.ResourceData, m interface{}) error {
 	api := m.(*management.Management)
-	p, err := api.Prompt.Read()
+	prompt, err := api.Prompt.Read()
 	if err != nil {
 		if mErr, ok := err.(management.Error); ok {
 			if mErr.Status() == http.StatusNotFound {
@@ -55,18 +52,20 @@ func readPrompt(d *schema.ResourceData, m interface{}) error {
 		}
 		return err
 	}
-	d.Set("universal_login_experience", p.UniversalLoginExperience)
-	d.Set("identifier_first", p.IdentifierFirst)
+
+	d.Set("universal_login_experience", prompt.UniversalLoginExperience)
+	d.Set("identifier_first", prompt.IdentifierFirst)
+
 	return nil
 }
 
 func updatePrompt(d *schema.ResourceData, m interface{}) error {
-	p := buildPrompt(d)
+	prompt := buildPrompt(d)
 	api := m.(*management.Management)
-	err := api.Prompt.Update(p)
-	if err != nil {
+	if err := api.Prompt.Update(prompt); err != nil {
 		return err
 	}
+
 	return readPrompt(d, m)
 }
 

--- a/auth0/resource_auth0_prompt.go
+++ b/auth0/resource_auth0_prompt.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -53,10 +54,12 @@ func readPrompt(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.Set("universal_login_experience", prompt.UniversalLoginExperience)
-	d.Set("identifier_first", prompt.IdentifierFirst)
+	result := multierror.Append(
+		d.Set("universal_login_experience", prompt.UniversalLoginExperience),
+		d.Set("identifier_first", prompt.IdentifierFirst),
+	)
 
-	return nil
+	return result.ErrorOrNil()
 }
 
 func updatePrompt(d *schema.ResourceData, m interface{}) error {

--- a/auth0/resource_auth0_prompt_custom_text.go
+++ b/auth0/resource_auth0_prompt_custom_text.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -67,10 +68,12 @@ func importPromptCustomText(d *schema.ResourceData, _ interface{}) ([]*schema.Re
 
 	d.SetId(d.Id())
 
-	d.Set("prompt", prompt)
-	d.Set("language", language)
+	result := multierror.Append(
+		d.Set("prompt", prompt),
+		d.Set("language", language),
+	)
 
-	return []*schema.ResourceData{d}, nil
+	return []*schema.ResourceData{d}, result.ErrorOrNil()
 }
 
 func createPromptCustomText(d *schema.ResourceData, m interface{}) error {
@@ -121,8 +124,9 @@ func updatePromptCustomText(d *schema.ResourceData, m interface{}) error {
 }
 
 func deletePromptCustomText(d *schema.ResourceData, m interface{}) error {
-	d.Set("body", "{}")
-
+	if err := d.Set("body", "{}"); err != nil {
+		return err
+	}
 	if err := updatePromptCustomText(d, m); err != nil {
 		return err
 	}

--- a/auth0/resource_auth0_prompt_custom_text.go
+++ b/auth0/resource_auth0_prompt_custom_text.go
@@ -66,6 +66,7 @@ func importPromptCustomText(d *schema.ResourceData, _ interface{}) ([]*schema.Re
 	}
 
 	d.SetId(d.Id())
+
 	d.Set("prompt", prompt)
 	d.Set("language", language)
 
@@ -95,8 +96,7 @@ func readPromptCustomText(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.Set("body", body)
-	return nil
+	return d.Set("body", body)
 }
 
 func updatePromptCustomText(d *schema.ResourceData, m interface{}) error {
@@ -112,8 +112,7 @@ func updatePromptCustomText(d *schema.ResourceData, m interface{}) error {
 			return err
 		}
 
-		err := api.Prompt.SetCustomText(prompt, language, body)
-		if err != nil {
+		if err := api.Prompt.SetCustomText(prompt, language, body); err != nil {
 			return err
 		}
 	}
@@ -129,6 +128,7 @@ func deletePromptCustomText(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.SetId("")
+
 	return nil
 }
 
@@ -153,13 +153,13 @@ func getPromptAndLanguage(d *schema.ResourceData) (string, string, error) {
 func marshalCustomTextBody(b map[string]interface{}) (string, error) {
 	bodyBytes, err := json.Marshal(b)
 	if err != nil {
-		return "", fmt.Errorf("Failed to serialize the custom texts to JSON: %w", err)
+		return "", fmt.Errorf("failed to serialize the custom texts to JSON: %w", err)
 	}
 
 	var buffer bytes.Buffer
 	const jsonIndentation = "    "
 	if err := json.Indent(&buffer, bodyBytes, "", jsonIndentation); err != nil {
-		return "", fmt.Errorf("Failed to format the custom texts JSON: %w", err)
+		return "", fmt.Errorf("failed to format the custom texts JSON: %w", err)
 	}
 
 	return buffer.String(), nil

--- a/auth0/resource_auth0_prompt_test.go
+++ b/auth0/resource_auth0_prompt_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestAccPrompt(t *testing.T) {
-
 	resource.Test(t, resource.TestCase{
 		Providers: map[string]terraform.ResourceProvider{
 			"auth0": Provider(),
@@ -33,7 +32,6 @@ func TestAccPrompt(t *testing.T) {
 }
 
 const testAccPromptCreate = `
-
 resource "auth0_prompt" "prompt" {
   universal_login_experience = "classic"
   identifier_first = false
@@ -41,7 +39,6 @@ resource "auth0_prompt" "prompt" {
 `
 
 const testAccPromptUpdate = `
-
 resource "auth0_prompt" "prompt" {
   universal_login_experience = "new"
   identifier_first = true


### PR DESCRIPTION
## Description

Stop ignoring errors when setting resource data within prompt.

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over