### PR TITLE
Fix serialization of log streams with http sink custom headers

### DIFF
--- a/auth0/resource_auth0_log_stream.go
+++ b/auth0/resource_auth0_log_stream.go
@@ -127,8 +127,11 @@ func newLogStream() *schema.Resource {
 							RequiredWith: []string{"sink.0.http_content_format", "sink.0.http_endpoint", "sink.0.http_content_type"},
 						},
 						"http_custom_headers": {
-							Type:        schema.TypeSet,
-							Elem:        &schema.Schema{Type: schema.TypeString},
+							Type: schema.TypeList,
+							Elem: &schema.Schema{
+								Type: schema.TypeMap,
+								Elem: &schema.Schema{Type: schema.TypeString},
+							},
 							Optional:    true,
 							Default:     nil,
 							Description: "Custom HTTP headers",
@@ -381,7 +384,7 @@ func expandLogStreamSinkHTTP(d ResourceData) *management.LogStreamSinkHTTP {
 		ContentType:   String(d, "http_content_type"),
 		Endpoint:      String(d, "http_endpoint"),
 		Authorization: String(d, "http_authorization"),
-		CustomHeaders: Set(d, "http_custom_headers").List(),
+		CustomHeaders: List(d, "http_custom_headers").List(),
 	}
 }
 func expandLogStreamSinkDatadog(d ResourceData) *management.LogStreamSinkDatadog {

--- a/auth0/resource_auth0_log_stream_test.go
+++ b/auth0/resource_auth0_log_stream_test.go
@@ -94,6 +94,22 @@ func TestAccLogStreamHTTP(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_authorization", "AKIAXXXXXXXXXXXXXXXX"),
 				),
 			},
+			{
+				Config: random.Template(testAccLogStreamHTTPConfigUpdateCustomHTTPHeaders, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-http-new-{{.random}}", rand),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "http"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_endpoint", "https://example.com/logs"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_content_type", "application/json"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_content_format", "JSONLINES"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_authorization", "AKIAXXXXXXXXXXXXXXXX"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_custom_headers.#", "2"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_custom_headers.0.header", "foo"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_custom_headers.0.value", "bar"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_custom_headers.1.header", "bar"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_custom_headers.1.value", "foo"),
+				),
+			},
 		},
 	})
 }
@@ -147,6 +163,29 @@ resource "auth0_log_stream" "my_log_stream" {
 	  http_content_type = "application/json"
 	  http_content_format = "JSONLINES"
 	  http_authorization = "AKIAXXXXXXXXXXXXXXXX"
+	}
+}
+`
+
+const testAccLogStreamHTTPConfigUpdateCustomHTTPHeaders = `
+resource "auth0_log_stream" "my_log_stream" {
+	name = "Acceptance-Test-LogStream-http-new-{{.random}}"
+	type = "http"
+	sink {
+	  http_endpoint = "https://example.com/logs"
+	  http_content_type = "application/json"
+	  http_content_format = "JSONLINES"
+	  http_authorization = "AKIAXXXXXXXXXXXXXXXX"
+	  http_custom_headers = [
+        {
+          header = "foo"
+          value  = "bar"
+        },
+		{
+          header = "bar"
+          value  = "foo"
+        }
+      ]
 	}
 }
 `

--- a/example/log_stream/main.tf
+++ b/example/log_stream/main.tf
@@ -8,6 +8,12 @@ resource "auth0_log_stream" "example_http" {
     http_content_type   = "application/json"
     http_content_format = "JSONOBJECT"
     http_authorization  = "AKIAXXXXXXXXXXXXXXXX"
+    http_custom_headers = [
+      {
+          header = "foo"
+          value  = "bar"
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
## Description
This introduces a different schema for the http sink custom headers attribute and fixes its serialization. 

Fixes #119.

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over