### PR TITLE
[3/3] DXCDT-103 Replace resource funcs to use context.Context and Diagnostics

### DIFF
--- a/auth0/data_source_auth0_client.go
+++ b/auth0/data_source_auth0_client.go
@@ -1,18 +1,18 @@
 package auth0
 
 import (
-	"errors"
-	"fmt"
+	"context"
 
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func newDataClient() *schema.Resource {
 	return &schema.Resource{
-		Read:   readDataClient,
-		Schema: newClientSchema(),
+		ReadContext: readDataClient,
+		Schema:      newClientSchema(),
 	}
 }
 
@@ -23,30 +23,30 @@ func newClientSchema() map[string]*schema.Schema {
 	return clientSchema
 }
 
-func readDataClient(d *schema.ResourceData, m interface{}) error {
+func readDataClient(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	clientId := auth0.StringValue(String(d, "client_id"))
 	if clientId != "" {
 		d.SetId(clientId)
-		return readClient(d, m)
+		return readClient(ctx, d, m)
 	}
 
 	// If not provided ID, perform looking of client by name
 	name := auth0.StringValue(String(d, "name"))
 	if name == "" {
-		return errors.New("no 'client_id' or 'name' was specified")
+		return diag.Errorf("no 'client_id' or 'name' was specified")
 	}
 
 	api := m.(*management.Management)
 	clients, err := api.Client.List(management.IncludeFields("client_id", "name"))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	for _, client := range clients.Clients {
 		if auth0.StringValue(client.Name) == name {
 			clientId = auth0.StringValue(client.ClientID)
 			d.SetId(clientId)
-			return readClient(d, m)
+			return readClient(ctx, d, m)
 		}
 	}
-	return fmt.Errorf("no client found with 'name' = '%s'", name)
+	return diag.Errorf("no client found with 'name' = '%s'", name)
 }

--- a/auth0/data_source_auth0_global_client.go
+++ b/auth0/data_source_auth0_global_client.go
@@ -1,19 +1,22 @@
 package auth0
 
 import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func newDataGlobalClient() *schema.Resource {
 	return &schema.Resource{
-		Read:   readDataGlobalClient,
-		Schema: newClientSchema(),
+		ReadContext: readDataGlobalClient,
+		Schema:      newClientSchema(),
 	}
 }
 
-func readDataGlobalClient(d *schema.ResourceData, m interface{}) error {
-	if err := readGlobalClientID(d, m); err != nil {
+func readDataGlobalClient(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if err := readGlobalClientID(ctx, d, m); err != nil {
 		return err
 	}
-	return readClient(d, m)
+	return readClient(ctx, d, m)
 }

--- a/auth0/data_source_auth0_tenant.go
+++ b/auth0/data_source_auth0_tenant.go
@@ -1,18 +1,20 @@
 package auth0
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func newDataTenant() *schema.Resource {
 	return &schema.Resource{
-		Read: readDataTenant,
+		ReadContext: readDataTenant,
 		Schema: map[string]*schema.Schema{
 			"domain": {
 				Type:     schema.TypeString,
@@ -26,12 +28,12 @@ func newDataTenant() *schema.Resource {
 	}
 }
 
-func readDataTenant(d *schema.ResourceData, m interface{}) error {
+func readDataTenant(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	api := m.(*management.Management)
 
 	u, err := url.Parse(api.URI())
 	if err != nil {
-		return fmt.Errorf("unable to determine management API URL: %w", err)
+		return diag.FromErr(fmt.Errorf("unable to determine management API URL: %w", err))
 	}
 
 	d.SetId(resource.UniqueId())
@@ -40,5 +42,5 @@ func readDataTenant(d *schema.ResourceData, m interface{}) error {
 	result = multierror.Append(result, d.Set("domain", u.Hostname()))
 	result = multierror.Append(result, d.Set("management_api_identifier", u.String()))
 
-	return result.ErrorOrNil()
+	return diag.FromErr(result.ErrorOrNil())
 }

--- a/auth0/provider_test.go
+++ b/auth0/provider_test.go
@@ -19,12 +19,16 @@ const wiremockHost = "localhost:8080"
 
 func providerWithTestingConfiguration() *schema.Provider {
 	provider := Provider()
-	provider.ConfigureFunc = func(data *schema.ResourceData) (interface{}, error) {
-		return management.New(
+	provider.ConfigureContextFunc = func(_ context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
+		apiClient, err := management.New(
 			wiremockHost,
 			management.WithInsecure(),
 			management.WithDebug(true),
 		)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+		return apiClient, nil
 	}
 	return provider
 }

--- a/auth0/resource_auth0_global_client.go
+++ b/auth0/resource_auth0_global_client.go
@@ -1,16 +1,17 @@
 package auth0
 
 import (
-	"errors"
+	"context"
 
 	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func newGlobalClient() *schema.Resource {
 	client := newClient()
-	client.Create = createGlobalClient
-	client.Delete = deleteGlobalClient
+	client.CreateContext = createGlobalClient
+	client.DeleteContext = deleteGlobalClient
 
 	exclude := []string{"client_secret_rotation_trigger"}
 
@@ -40,26 +41,26 @@ func in(needle string, haystack []string) bool {
 	return false
 }
 
-func createGlobalClient(d *schema.ResourceData, m interface{}) error {
-	if err := readGlobalClientID(d, m); err != nil {
+func createGlobalClient(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if err := readGlobalClientID(ctx, d, m); err != nil {
 		return err
 	}
-	return updateClient(d, m)
+	return updateClient(ctx, d, m)
 }
 
-func readGlobalClientID(d *schema.ResourceData, m interface{}) error {
+func readGlobalClientID(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	api := m.(*management.Management)
 	clients, err := api.Client.List(management.Parameter("is_global", "true"), management.IncludeFields("client_id"))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if len(clients.Clients) == 0 {
-		return errors.New("no auth0 global client found")
+		return diag.Errorf("no auth0 global client found")
 	}
 	d.SetId(clients.Clients[0].GetClientID())
 	return nil
 }
 
-func deleteGlobalClient(d *schema.ResourceData, m interface{}) error {
+func deleteGlobalClient(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	return nil
 }

--- a/auth0/resource_auth0_rule_config.go
+++ b/auth0/resource_auth0_rule_config.go
@@ -1,21 +1,23 @@
 package auth0
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func newRuleConfig() *schema.Resource {
 	return &schema.Resource{
-		Create: createRuleConfig,
-		Read:   readRuleConfig,
-		Update: updateRuleConfig,
-		Delete: deleteRuleConfig,
+		CreateContext: createRuleConfig,
+		ReadContext:   readRuleConfig,
+		UpdateContext: updateRuleConfig,
+		DeleteContext: deleteRuleConfig,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
 			"key": {
@@ -32,21 +34,21 @@ func newRuleConfig() *schema.Resource {
 	}
 }
 
-func createRuleConfig(d *schema.ResourceData, m interface{}) error {
+func createRuleConfig(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	ruleConfig := buildRuleConfig(d)
 	key := auth0.StringValue(ruleConfig.Key)
 	ruleConfig.Key = nil
 	api := m.(*management.Management)
 	if err := api.RuleConfig.Upsert(key, ruleConfig); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(auth0.StringValue(ruleConfig.Key))
 
-	return readRuleConfig(d, m)
+	return readRuleConfig(ctx, d, m)
 }
 
-func readRuleConfig(d *schema.ResourceData, m interface{}) error {
+func readRuleConfig(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	api := m.(*management.Management)
 	ruleConfig, err := api.RuleConfig.Read(d.Id())
 	if err != nil {
@@ -56,24 +58,24 @@ func readRuleConfig(d *schema.ResourceData, m interface{}) error {
 				return nil
 			}
 		}
-		return err
+		return diag.FromErr(err)
 	}
 
-	return d.Set("key", ruleConfig.Key)
+	return diag.FromErr(d.Set("key", ruleConfig.Key))
 }
 
-func updateRuleConfig(d *schema.ResourceData, m interface{}) error {
+func updateRuleConfig(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	ruleConfig := buildRuleConfig(d)
 	ruleConfig.Key = nil
 	api := m.(*management.Management)
 	if err := api.RuleConfig.Upsert(d.Id(), ruleConfig); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
-	return readRuleConfig(d, m)
+	return readRuleConfig(ctx, d, m)
 }
 
-func deleteRuleConfig(d *schema.ResourceData, m interface{}) error {
+func deleteRuleConfig(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	api := m.(*management.Management)
 	if err := api.RuleConfig.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok {


### PR DESCRIPTION
## Description

With terraform-plugin-sdk@v2 we now have more support for context.Context and Diagnostics. 

- https://www.terraform.io/plugin/sdkv2/guides/v2-upgrade-guide#more-support-for-context-context
- https://www.terraform.io/plugin/sdkv2/guides/v2-upgrade-guide#support-for-diagnostics

So in this PR we're going ahead and make use of those and remove the deprecated CRUD funcs without the context param in favour of the ones with Context.

No other changes were bundled in this PR. 

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over