### PR TITLE
Fix conversion issue flattenAddons func in client resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.30.1
+
+BUG FIXES:
+
+- `resource/auth0_client`: Fix conversion issue flattenAddons func in client resource ([#140](https://github.com/auth0/terraform-provider-auth0/pull/140))
+
+
 ## 0.30.0
 
 FEATURES:

--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -995,7 +995,10 @@ func flattenClientAddons(addons map[string]interface{}) []interface{} {
 			"include_attribute_name_format":      samlp["includeAttributeNameFormat"],
 			"binding":                            samlp["binding"],
 			"signing_cert":                       samlp["signingCert"],
-			"logout":                             mapToState(samlp["logout"].(map[string]interface{})),
+		}
+
+		if logout, ok := samlp["logout"].(map[string]interface{}); ok {
+			samlpMap["logout"] = mapToState(logout)
 		}
 
 		m["samlp"] = []interface{}{samlpMap}
@@ -1009,8 +1012,9 @@ func flattenClientAddons(addons map[string]interface{}) []interface{} {
 		"springcm", "wams", "wsfed", "zendesk", "zoom",
 	} {
 		if value, ok := addons[name]; ok {
-			addonType := value.(map[string]interface{})
-			m[name] = mapToState(addonType)
+			if addonType, ok := value.(map[string]interface{}); ok {
+				m[name] = mapToState(addonType)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Fixes #139 

Fixes issue with the logout property on flattenAddons where we're trying to typecast it always to a map[string]interface{} without checking if it was actually present in the payload.

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over