### PR TITLE
Remove deprecated verification_method from custom domain resource

### DIFF
--- a/auth0/resource_auth0_custom_domain.go
+++ b/auth0/resource_auth0_custom_domain.go
@@ -47,13 +47,6 @@ func newCustomDomain() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"verification_method": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Deprecated:   "The method is chosen according to the type of the custom domain. CNAME for auth0_managed_certs, TXT for self_managed_certs",
-				ValidateFunc: validation.StringInSlice([]string{"txt"}, true),
-			},
 			"verification": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -72,7 +65,7 @@ func newCustomDomain() *schema.Resource {
 }
 
 func createCustomDomain(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	customDomain := buildCustomDomain(d)
+	customDomain := expandCustomDomain(d)
 	api := m.(*management.Management)
 	if err := api.CustomDomain.Create(customDomain); err != nil {
 		return diag.FromErr(err)
@@ -127,10 +120,9 @@ func deleteCustomDomain(ctx context.Context, d *schema.ResourceData, m interface
 	return nil
 }
 
-func buildCustomDomain(d *schema.ResourceData) *management.CustomDomain {
+func expandCustomDomain(d *schema.ResourceData) *management.CustomDomain {
 	return &management.CustomDomain{
-		Domain:             String(d, "domain"),
-		Type:               String(d, "type"),
-		VerificationMethod: String(d, "verification_method"),
+		Domain: String(d, "domain"),
+		Type:   String(d, "type"),
 	}
 }

--- a/docs/resources/custom_domain.md
+++ b/docs/resources/custom_domain.md
@@ -26,8 +26,7 @@ Arguments accepted by this resource include:
 
 * `domain` - (Required) String. Name of the custom domain. 
 * `type` - (Required) String. Provisioning type for the custom domain. Options include `auth0_managed_certs` and `self_managed_certs`.
-* `verification_method` - (Deprecated) String. Domain verification method. The method is chosen according to the type of
-the custom domain. `CNAME` for `auth0_managed_certs`, `TXT` for `self_managed_certs`.
+
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/auth0/terraform-provider-auth0/issues/45. 

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over