### PR TITLE
Fix crash with domain_aliases for ADFS

### DIFF
--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -793,7 +793,7 @@ func expandConnectionOptionsSAML(d ResourceData) *management.ConnectionOptionsSA
 func expandConnectionOptionsADFS(d ResourceData) *management.ConnectionOptionsADFS {
 	return &management.ConnectionOptionsADFS{
 		TenantDomain:       String(d, "tenant_domain"),
-		DomainAliases:      Slice(d, "domain_aliases"),
+		DomainAliases:      Set(d, "domain_aliases").List(),
 		LogoURL:            String(d, "icon_url"),
 		ADFSServer:         String(d, "adfs_server"),
 		EnableUsersAPI:     Bool(d, "api_enable_users"),


### PR DESCRIPTION
## Description

When setting domain_aliases on an ADFS connection the following crash occurs:

> Stack trace from the terraform-provider-auth0_v0.30.3.exe plugin:
> 
> panic: interface conversion: interface {} is *schema.Set, not []interface {}
> 
> goroutine 16 [running]:
> github.com/auth0/terraform-provider-auth0/auth0.Slice({0xcb4b10, 0xc000582560}, {0xb89507, 0xe}, {0x0, 0x0, 0x0})
>         github.com/auth0/terraform-provider-auth0/auth0/resource_data.go:286 +0xe5
> github.com/auth0/terraform-provider-auth0/auth0.expandConnectionOptionsADFS({0xcb4b10, 0xc000582560})
>         github.com/auth0/terraform-provider-auth0/auth0/structure_auth0_connection.go:796 +0x85
> github.com/auth0/terraform-provider-auth0/auth0.expandConnection.func1({0xcb4b10, 0xc000582560})
>         github.com/auth0/terraform-provider-auth0/auth0/structure_auth0_connection.go:435 +0x19f
> github.com/auth0/terraform-provider-auth0/auth0.(*list).Elem(0xc00058b530, 0xc000582540)
>         github.com/auth0/terraform-provider-auth0/auth0/resource_data.go:345 +0x43
> github.com/auth0/terraform-provider-auth0/auth0.expandConnection({0xcb4bb0, 0xc0002bb480})
>         github.com/auth0/terraform-provider-auth0/auth0/structure_auth0_connection.go:398 +0x53b
> github.com/auth0/terraform-provider-auth0/auth0.updateConnection({0xcb2ab8, 0xc00007eae0}, 0xc0002bb480, {0xac8fc0?, 0xc00057a640?})
>         github.com/auth0/terraform-provider-auth0/auth0/resource_auth0_connection.go:825 +0x50
> github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).update(0xc0004b08c0, {0xcb2af0, 0xc000298840}, 0xd?, {0xac8fc0, 0xc00057a640})
>         github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/resource.go:741 +0x12e
> github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0004b08c0, {0xcb2af0, 0xc000298840}, 0xc0000451e0, 0xc0002ba280, {0xac8fc0, 0xc00057a640})
>         github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/resource.go:847 +0x82c
> github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc0004865e8, {0xcb2a48?, 0xc00025f280?}, 0xc000324320)      
>         github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/grpc_provider.go:1021 +0xe3c
> github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc00045ab40, {0xcb2af0?, 0xc000298030?}, 0xc000106000)
>         github.com/hashicorp/terraform-plugin-go@v0.9.1/tfprotov5/tf5server/server.go:812 +0x515
> github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0xb50b00?, 0xc00045ab40}, {0xcb2af0, 0xc000298030}, 0xc00019aa20, 0x0)
>         github.com/hashicorp/terraform-plugin-go@v0.9.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
> google.golang.org/grpc.(*Server).processUnaryRPC(0xc0002b8a80, {0xcb5608, 0xc00051c1a0}, 0xc0000da480, 0xc0004e2ed0, 0x1191c60, 0x0)
>         google.golang.org/grpc@v1.46.2/server.go:1283 +0xcfd
> google.golang.org/grpc.(*Server).handleStream(0xc0002b8a80, {0xcb5608, 0xc00051c1a0}, 0xc0000da480, 0x0)
>         google.golang.org/grpc@v1.46.2/server.go:1620 +0xa1b
> google.golang.org/grpc.(*Server).serveStreams.func1.2()
>         google.golang.org/grpc@v1.46.2/server.go:922 +0x98
> created by google.golang.org/grpc.(*Server).serveStreams.func1
>         google.golang.org/grpc@v1.46.2/server.go:920 +0x28a
> 
> Error: The terraform-provider-auth0_v0.30.3.exe plugin crashed!

This change fixes the crash by updating expandConnectionOptionsADFS to behave consistently with the other connection strategies.

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [X] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [X] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [X] Not needed

#### Does the description provide the correct amount of context?
- [X] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [X] Not needed

#### Is this code ready for production?
- [X] Yes, all code changes are intentional and no debugging calls are left over