### PR TITLE
Correct docs example typo binding_method to protocol_binding

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -474,7 +474,7 @@ resource "auth0_connection" "samlp" {
     sign_out_endpoint   = "https://saml.provider/sign_out"
     tenant_domain       = "example.com"
     domain_aliases      = ["example.com", "alias.example.com"]
-    binding_method      = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+    protocol_binding    = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
     request_template    = "<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\"\n@@AssertServiceURLAndDestination@@\n    ID=\"@@ID@@\"\n    IssueInstant=\"@@IssueInstant@@\"\n    ProtocolBinding=\"@@ProtocolBinding@@\" Version=\"2.0\">\n    <saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">@@Issuer@@</saml:Issuer>\n</samlp:AuthnRequest>"
     user_id_attribute   = "https://saml.provider/imi/ns/identity-200810"
     signature_algorithm = "rsa-sha256"


### PR DESCRIPTION
## Description

The parameter `binding_method` is referenced in the SAML example, it doesn't seem as though `binding_method` is a valid option. Based on the value of this parameter it looks like it should be `protocol_binding`.

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over