### PR TITLE
[DXCDT-157] Add datadog_region validation

### DIFF
--- a/auth0/resource_auth0_log_stream.go
+++ b/auth0/resource_auth0_log_stream.go
@@ -153,9 +153,12 @@ func newLogStream() *schema.Resource {
 
 						"datadog_region": {
 							Type:         schema.TypeString,
-							Sensitive:    true,
 							Optional:     true,
 							RequiredWith: []string{"sink.0.datadog_api_key"},
+							ValidateFunc: validation.StringInSlice(
+								[]string{"us", "eu", "us3", "us5"},
+								false,
+							),
 						},
 						"datadog_api_key": {
 							Type:         schema.TypeString,

--- a/auth0/resource_auth0_log_stream_test.go
+++ b/auth0/resource_auth0_log_stream_test.go
@@ -3,6 +3,7 @@ package auth0
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -314,6 +315,33 @@ resource "auth0_log_stream" "my_log_stream" {
   	  azure_subscription_id = "b69a6835-57c7-4d53-b0d5-1c6ae580b6d5"
 	  azure_region = "westeurope"
 	  azure_resource_group = "azure-logs-rg"
+	}
+}
+`
+
+func TestAccLogStreamDataDogRegionValidation(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testProviders(nil),
+		Steps: []resource.TestStep{
+			{
+				Config:      fmt.Sprintf(logStreamDatadogInvalidConfig, "uS"),
+				ExpectError: regexp.MustCompile(`expected sink.0.datadog_region to be one of \[us eu us3 us5\], got uS`),
+			},
+			{
+				Config:      fmt.Sprintf(logStreamDatadogInvalidConfig, "us9"),
+				ExpectError: regexp.MustCompile(`expected sink.0.datadog_region to be one of \[us eu us3 us5\], got us9`),
+			},
+		},
+	})
+}
+
+const logStreamDatadogInvalidConfig = `
+resource "auth0_log_stream" "my_log_stream" {
+	name = "Acceptance-Test-LogStream-datadog-{{.testName}}"
+	type = "datadog"
+	sink {
+	  datadog_region = "%s"
+	  datadog_api_key = "121233123455"
 	}
 }
 `

--- a/docs/resources/log_stream.md
+++ b/docs/resources/log_stream.md
@@ -66,7 +66,7 @@ For "http" the following arguments are supported:
 - `http_custom_headers` - (Optional) Additional HTTP headers to be included as part of the HTTP request
 
 For "datadog" the following arguments are supported:
-- `datadog_region` - (Required) The Datadog region
+- `datadog_region` - (Required) The Datadog region. Options are ["us", "eu", "us3", "us5"]
 - `datadog_api_key` - (Required) The Datadog API key
 
 For "splunk" the following arguments are supported:


### PR DESCRIPTION
## Description

Fixes: https://github.com/auth0/terraform-provider-auth0/issues/145.

We are adding datadog_region validation in this one to help with understanding the cryptic error message we get when the region is wrong. Within our API we only accept the following case sensitive options:

```
      datadogRegion: {
        type: 'string',
        description: 'Datadog region',
        enum: ['us', 'eu', 'us3', 'us5'],
      },
```

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [ ] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [ ] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Does the description provide the correct amount of context?
- [ ] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [ ] Yes, all code changes are intentional and no debugging calls are left over