### PR TITLE
Adding `icon_url` to OAuth2 connection types

### DIFF
--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -427,6 +427,7 @@ func TestAccConnectionOAuth2(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr("auth0_connection.oauth2", "options.0.scopes.*", "email"),
 					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.scripts.fetchUserProfile", "function( { return callback(null) }"),
 					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.set_user_root_attributes", "on_each_login"),
+					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.icon_url", ""),
 				),
 			},
 			{
@@ -441,6 +442,7 @@ func TestAccConnectionOAuth2(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr("auth0_connection.oauth2", "options.0.scopes.*", "email"),
 					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.scripts.fetchUserProfile", "function( { return callback(null) }"),
 					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.set_user_root_attributes", "on_first_login"),
+					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.icon_url", "https://cdn.paypal.com/assets/logo.png"),
 				),
 			},
 		},
@@ -478,6 +480,7 @@ resource "auth0_connection" "oauth2" {
 		authorization_endpoint = "https://www.paypal.com/signin/authorize"
 		scopes = [ "openid", "email" ]
 		set_user_root_attributes = "on_first_login"
+		icon_url = "https://cdn.paypal.com/assets/logo.png"
 		scripts = {
 			fetchUserProfile= "function( { return callback(null) }"
 		}

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -152,6 +152,7 @@ func flattenConnectionOptionsOAuth2(options *management.ConnectionOptionsOAuth2)
 		"scripts":                  options.Scripts,
 		"set_user_root_attributes": options.GetSetUserAttributes(),
 		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
+		"icon_url":                 options.GetLogoURL(),
 	}
 }
 
@@ -554,6 +555,7 @@ func expandConnectionOptionsOAuth2(d ResourceData) *management.ConnectionOptions
 		TokenURL:           String(d, "token_endpoint"),
 		SetUserAttributes:  String(d, "set_user_root_attributes"),
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
+		LogoURL:            String(d, "icon_url"),
 	}
 	options.Scripts = Map(d, "scripts")
 

--- a/auth0/testdata/recordings/TestAccConnectionOAuth2.yaml
+++ b/auth0/testdata/recordings/TestAccConnectionOAuth2.yaml
@@ -84,7 +84,7 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"is_domain_connection":false,"options":{"client_id":"1234567","client_secret":"1234567","authorizationURL":"https://www.paypal.com/signin/authorize","tokenURL":"https://api.paypal.com/v1/oauth2/token","scope":"email openid","set_user_root_attributes":"on_first_login","non_persistent_attrs":null,"scripts":{"fetchUserProfile":"function( { return callback(null) }"}}}
+      {"is_domain_connection":false,"options":{"client_id":"1234567","icon_url":"https://cdn.paypal.com/assets/logo.png","client_secret":"1234567","authorizationURL":"https://www.paypal.com/signin/authorize","tokenURL":"https://api.paypal.com/v1/oauth2/token","scope":"email openid","set_user_root_attributes":"on_first_login","non_persistent_attrs":null,"scripts":{"fetchUserProfile":"function( { return callback(null) }"}}}
     form: {}
     headers:
       Content-Type:
@@ -94,7 +94,7 @@ interactions:
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EFFoG0suO6epOXKQ
     method: PATCH
   response:
-    body: '{"id":"con_EFFoG0suO6epOXKQ","options":{"scope":"email openid","scripts":{"fetchUserProfile":"function(
+    body: '{"id":"con_EFFoG0suO6epOXKQ","options":{"icon_url":"https://cdn.paypal.com/assets/logo.png","scope":"email openid","scripts":{"fetchUserProfile":"function(
       { return callback(null) }"},"tokenURL":"https://api.paypal.com/v1/oauth2/token","client_id":"1234567","client_secret":"1234567","authorizationURL":"https://www.paypal.com/signin/authorize","non_persistent_attrs":null,"set_user_root_attributes":"on_first_login"},"strategy":"oauth2","name":"Acceptance-Test-OAuth2-TestAccConnectionOAuth2","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-OAuth2-TestAccConnectionOAuth2"]}'
     headers:
       Content-Type:
@@ -114,7 +114,7 @@ interactions:
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EFFoG0suO6epOXKQ
     method: GET
   response:
-    body: '{"id":"con_EFFoG0suO6epOXKQ","options":{"scope":"email openid","scripts":{"fetchUserProfile":"function(
+    body: '{"id":"con_EFFoG0suO6epOXKQ","options":{"scope":"email openid","icon_url":"https://cdn.paypal.com/assets/logo.png","scripts":{"fetchUserProfile":"function(
       { return callback(null) }"},"tokenURL":"https://api.paypal.com/v1/oauth2/token","client_id":"1234567","client_secret":"1234567","authorizationURL":"https://www.paypal.com/signin/authorize","non_persistent_attrs":null,"set_user_root_attributes":"on_first_login"},"strategy":"oauth2","name":"Acceptance-Test-OAuth2-TestAccConnectionOAuth2","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-OAuth2-TestAccConnectionOAuth2"]}'
     headers:
       Content-Type:
@@ -134,7 +134,7 @@ interactions:
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EFFoG0suO6epOXKQ
     method: GET
   response:
-    body: '{"id":"con_EFFoG0suO6epOXKQ","options":{"scope":"email openid","scripts":{"fetchUserProfile":"function(
+    body: '{"id":"con_EFFoG0suO6epOXKQ","options":{"scope":"email openid","icon_url":"https://cdn.paypal.com/assets/logo.png","scripts":{"fetchUserProfile":"function(
       { return callback(null) }"},"tokenURL":"https://api.paypal.com/v1/oauth2/token","client_id":"1234567","client_secret":"1234567","authorizationURL":"https://www.paypal.com/signin/authorize","non_persistent_attrs":null,"set_user_root_attributes":"on_first_login"},"strategy":"oauth2","name":"Acceptance-Test-OAuth2-TestAccConnectionOAuth2","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-OAuth2-TestAccConnectionOAuth2"]}'
     headers:
       Content-Type:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/auth0/terraform-provider-auth0
 go 1.18
 
 require (
-	github.com/auth0/go-auth0 v0.0.0-20220621140101-1d904472f214
+	github.com/auth0/go-auth0 v0.6.4
 	github.com/dnaeon/go-vcr/v2 v2.0.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/auth0/terraform-provider-auth0
 go 1.18
 
 require (
-	github.com/auth0/go-auth0 v0.6.4
+	github.com/auth0/go-auth0 v0.0.0-20220621140101-1d904472f214
 	github.com/dnaeon/go-vcr/v2 v2.0.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/auth0/terraform-provider-auth0
 go 1.18
 
 require (
-	github.com/auth0/go-auth0 v0.0.0-20220621140101-1d904472f214
+	github.com/auth0/go-auth0 v0.7.0
 	github.com/dnaeon/go-vcr/v2 v2.0.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -54,10 +54,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/auth0/go-auth0 v0.0.0-20220621140101-1d904472f214 h1:GekFnAlW3yN0+DL3yRB/2lUWMXXxNm29VwibqHldaRc=
-github.com/auth0/go-auth0 v0.0.0-20220621140101-1d904472f214/go.mod h1:05vJEvCIFVXOwkB2qHmYSAJAPKOq2oI1mqsHdfuwCoE=
-github.com/auth0/go-auth0 v0.6.4 h1:CEazCLJOWmScA/sWJJD3ZFqBUBSmsft/HNoOm95rvg4=
-github.com/auth0/go-auth0 v0.6.4/go.mod h1:zuk36Mb4HsIKOFhvaAwh2Wa7Z/ZaXZizMTSA1mnGPBU=
+github.com/auth0/go-auth0 v0.7.0 h1:mw7KbtVfAdVhJqinPeCNQQRuP4kv7eXe2GujaULgPWs=
+github.com/auth0/go-auth0 v0.7.0/go.mod h1:05vJEvCIFVXOwkB2qHmYSAJAPKOq2oI1mqsHdfuwCoE=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/auth0/go-auth0 v0.0.0-20220621140101-1d904472f214 h1:GekFnAlW3yN0+DL3yRB/2lUWMXXxNm29VwibqHldaRc=
+github.com/auth0/go-auth0 v0.0.0-20220621140101-1d904472f214/go.mod h1:05vJEvCIFVXOwkB2qHmYSAJAPKOq2oI1mqsHdfuwCoE=
 github.com/auth0/go-auth0 v0.6.4 h1:CEazCLJOWmScA/sWJJD3ZFqBUBSmsft/HNoOm95rvg4=
 github.com/auth0/go-auth0 v0.6.4/go.mod h1:zuk36Mb4HsIKOFhvaAwh2Wa7Z/ZaXZizMTSA1mnGPBU=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/auth0/go-auth0 v0.0.0-20220621140101-1d904472f214 h1:GekFnAlW3yN0+DL3yRB/2lUWMXXxNm29VwibqHldaRc=
-github.com/auth0/go-auth0 v0.0.0-20220621140101-1d904472f214/go.mod h1:05vJEvCIFVXOwkB2qHmYSAJAPKOq2oI1mqsHdfuwCoE=
 github.com/auth0/go-auth0 v0.6.4 h1:CEazCLJOWmScA/sWJJD3ZFqBUBSmsft/HNoOm95rvg4=
 github.com/auth0/go-auth0 v0.6.4/go.mod h1:zuk36Mb4HsIKOFhvaAwh2Wa7Z/ZaXZizMTSA1mnGPBU=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=


### PR DESCRIPTION
## Description

As noted in #186 , the `icon_url` property on the `options` object isn't supported in Terraform and gets cleared out every time the configuration applies. 

This PR relies on [this PR](https://github.com/auth0/go-auth0/pull/74) in the Go SDK as a dependency before this can get deployed.

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over