### PR TITLE
Preserve user ID casing in state

### DIFF
--- a/auth0/resource_auth0_user.go
+++ b/auth0/resource_auth0_user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
@@ -34,9 +33,6 @@ func newUser() *schema.Resource {
 				Computed: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return old == "auth0|"+new
-				},
-				StateFunc: func(s interface{}) string {
-					return strings.ToLower(s.(string))
 				},
 			},
 			"connection_name": {


### PR DESCRIPTION
## Description

As noted in #41 , the Terraform inexplicably converts all user IDs to lower case when writing to state. The specific block of code in question is:

```go
StateFunc: func(s interface{}) string {
   return strings.ToLower(s.(string))
},
```

This was added in [this commit](https://github.com/auth0/terraform-provider-auth0/commit/fb0b56b08b81cebc1a6daad541c817ea62e5789e) that was pushed directly to master. It doesn't appear that this code serves any functional purpose and I suspect that it was added in error. Additionally, this line is taken from one of the [Terraform SDK examples](https://www.terraform.io/plugin/sdkv2/schemas/schema-behaviors#statefunc), which further suggests that it doesn't serve a functional purpose to Auth0.

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over