### PR TITLE
GitHub connection scopes documentation

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -508,9 +508,6 @@ var connectionSchema = map[string]*schema.Schema{
 					Computed: true,
 					Optional: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
-					ValidateFunc: validation.StringInSlice([]string{
-						"admin_org", "admin_public_key", "admin_repo_hook", "delete_repo", "email", "follow", "gist", "notifications", "profile", "public_repo", "read_org", "read_public_key", "read_repo_hook", "read_user", "repo", "repo_deployment", "repo_status", "write_org", "write_public_key", "write_repo_hook",
-					}, true),
 				},
 				// OIDC options
 				"type": {

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -508,6 +508,9 @@ var connectionSchema = map[string]*schema.Schema{
 					Computed: true,
 					Optional: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
+					ValidateFunc: validation.StringInSlice([]string{
+						"admin_org", "admin_public_key", "admin_repo_hook", "delete_repo", "email", "follow", "gist", "notifications", "profile", "public_repo", "read_org", "read_public_key", "read_repo_hook", "read_user", "repo", "repo_deployment", "repo_status", "write_org", "write_public_key", "write_repo_hook",
+					}, true),
 				},
 				// OIDC options
 				"type": {

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -240,6 +240,7 @@ With the `github` connection strategy, `options` supports the following argument
 
 * `client_id` - (Optional) GitHub client ID.
 * `client_secret` - (Optional) GitHub client secret.
+* `scopes` - Permissions to grant connection. Available values: `admin_org`, `admin_public_key`, `admin_repo_hook`, `delete_repo`, `email`, `follow`, `gist`, `notifications`, `profile`, `public_repo`, `read_org`, `read_public_key`, `read_repo_hook`, `read_user`, `repo`, `repo_deployment`, `repo_status`, `write_org`, `write_public_key`, `write_repo_hook`
 * `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
 * `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
 


### PR DESCRIPTION
## Description

Issue #177 highlighted some confusion around configuring scopes for Github connections. The Go SDK appears to perform some conversions so the names of the scopes aren't quite obvious. Adding a validation function here is not possible because the [Terraform provider SDK does not support it for lists and sets](https://github.com/hashicorp/terraform-plugin-sdk/issues/156) so documentation will need to suffice.

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over