### PR TITLE
Remove deprecated options.app_domain in connection resource

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -245,12 +245,6 @@ var connectionSchema = map[string]*schema.Schema{
 					Optional:    true,
 					Description: "",
 				},
-				"app_domain": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Description: "",
-					Deprecated:  "Use domain instead",
-				},
 				"domain": {
 					Type:        schema.TypeString,
 					Optional:    true,

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -342,12 +342,12 @@ EOF
 With the `waad` connection strategy, `options` supports the following arguments:
 
 * `app_id` - (Optional) Azure AD app ID.
-* `app_domain` - (Optional) Azure AD domain name.
+* `domain` - (Optional) Azure AD domain name.
 * `client_id` - (Optional) Client ID for your Azure AD application.
 * `client_secret` - (Optional) Client secret for your Azure AD application.
 * `domain_aliases` - (Optional) List of the domains that can be authenticated using the Identity Provider. Only needed for Identifier First authentication flows.
 * `max_groups_to_retrieve` - (Optional) Maximum number of groups to retrieve.
-* `domain` - (Optional)
+* `tenant_domain` - (Optional)
 * `use_wsfed` - (Optional)
 * `waad_protocol` - (Optional)
 * `waad_common_endpoint` - (Optional) Indicates whether or not to use the common endpoint rather than the default endpoint. Typically enabled if you're using this for a multi-tenant application in Azure AD.

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -347,7 +347,7 @@ With the `waad` connection strategy, `options` supports the following arguments:
 * `client_secret` - (Optional) Client secret for your Azure AD application.
 * `domain_aliases` - (Optional) List of the domains that can be authenticated using the Identity Provider. Only needed for Identifier First authentication flows.
 * `max_groups_to_retrieve` - (Optional) Maximum number of groups to retrieve.
-* `tenant_domain` - (Optional)
+* `domain` - (Optional)
 * `use_wsfed` - (Optional)
 * `waad_protocol` - (Optional)
 * `waad_common_endpoint` - (Optional) Indicates whether or not to use the common endpoint rather than the default endpoint. Typically enabled if you're using this for a multi-tenant application in Azure AD.


### PR DESCRIPTION
## Description
Per the code, [app_domain is deprecated](https://github.com/auth0/terraform-provider-auth0/blob/main/auth0/resource_auth0_connection.go#L248-L252). I don't know enough about what `domain` is to be able to add any additional context, though.

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over