### PR TITLE
Fix versions in user agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,16 +70,9 @@ install: build ## Install the provider as a terraform plugin. Usage: "make insta
 	@mkdir -p "${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/$(VERSION)/${GO_OS}_${GO_ARCH}"
 	@mv "${BUILD_DIR}/${BINARY}_v$(VERSION)" "${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/$(VERSION)/${GO_OS}_${GO_ARCH}"
 
-clean: ## Clean up installed provider binary. Usage: "make clean VERSION=0.2.0"
-	${call print_warning, "Cleaning installed provider binary: ${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/$(VERSION)"}
-	@if [ -z "$(VERSION)" ]; \
-    	then \
-    	  echo "Please provide a version. Example: make clean VERSION=0.2.0" && exit 1; \
-     	fi
-	@if [ -d "${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/$(VERSION)" ]; \
-	then \
-	  rm -rf "${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/$(VERSION)"; \
- 	fi
+clean: ## Clean up locally installed provider binaries."
+	${call print_warning, "Cleaning locally installed provider binaries"}
+	@rm -rf "${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}"
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Code Style

--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -88,15 +88,15 @@ func Provider() *schema.Provider {
 		},
 	}
 
-	provider.ConfigureContextFunc = ConfigureProvider(provider.TerraformVersion)
+	provider.ConfigureContextFunc = configureProvider(&provider.TerraformVersion)
 
 	return provider
 }
 
 // ConfigureProvider will configure the *schema.Provider so that *management.Management
 // client is stored and passed into the subsequent resources as the meta parameter.
-func ConfigureProvider(
-	terraformVersion string,
+func configureProvider(
+	terraformVersion *string,
 ) func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	return func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		providerVersion := version.ProviderVersion
@@ -108,7 +108,7 @@ func ConfigureProvider(
 			providerVersion,
 			sdkVersion,
 			terraformSDKVersion,
-			terraformVersion,
+			*terraformVersion,
 		)
 
 		domain := data.Get("domain").(string)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# set -x
+
+# Usage:
+#
+#   release.sh X.X.X
+#
+# Creates a new version of the package. This script creates a new release branch
+# where it updates the version variable. It then creates a matching tag and
+# pushes both to GitHub.
+
+# The file holding a version variable.
+VERSION_FILE=version/version.go
+
+function create_release_branch {
+  local version="$1"
+  git checkout -b "releases/${version}"
+}
+
+function update_version {
+  local version="$1"
+  sed -i.backup "s/var ProviderVersion =.*/var ProviderVersion = \"${version}\"/" "${VERSION_FILE}"
+  rm -rf "${VERSION_FILE}.backup"
+}
+
+function commit_changes {
+  local version="$1"
+  git add "${VERSION_FILE}"
+  git commit -m "v${version}"
+  git tag -a "v${version}" -m "v${version}"
+}
+
+function push_changes {
+  local version="$1"
+  git push origin "releases/${version}"
+  git push origin "v${version}"
+}
+
+function main {
+  local version="$1"
+  if [[ $version = v* ]]; then
+    echo "version should be in the format X.Y.Z"
+    exit 1
+  fi
+  if git rev-parse "v$version" > /dev/null 2>&1; then
+    echo "version $version already exists"
+    exit 1
+  fi
+
+  local current_branch=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
+
+  create_release_branch $version
+  update_version $version
+  commit_changes $version
+  push_changes $version
+
+  git checkout $current_branch
+}
+
+main "$@"


### PR DESCRIPTION
## Description

This PR aims at fixing the request's `User-Agent` field as right now we send the following:

```
"userAgent": "Terraform-Provider-Auth0/dev (Go-Auth0-SDK/0.6.1; Terraform-SDK/1.16.1; Terraform/)",
```

When we should be sending something like:

```
"userAgent": "Terraform-Provider-Auth0/0.31.0 (Go-Auth0-SDK/0.6.1; Terraform-SDK/1.16.1; Terraform/1.2.2)",
```

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over