### PR TITLE
[DXCDT-169] Add bot detection within the attack protection resource

### DIFF
--- a/auth0/resource_auth0_attack_protection_test.go
+++ b/auth0/resource_auth0_attack_protection_test.go
@@ -24,6 +24,8 @@ func TestAccAttackProtection(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "suspicious_ip_throttling.0.enabled", "true"),
 					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "suspicious_ip_throttling.0.pre_login.0.rate", "864000"),
 					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "suspicious_ip_throttling.0.pre_login.0.max_attempts", "100"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "bot_detection.0.response.0.policy", "always_on"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "bot_detection.0.response.0.selected", "auth0"),
 				),
 			},
 			{
@@ -32,6 +34,10 @@ func TestAccAttackProtection(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "breached_password_detection.0.enabled", "false"),
 					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "suspicious_ip_throttling.0.shields.0", "admin_notification"),
 					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "brute_force_protection.0.max_attempts", "11"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "bot_detection.0.response.0.policy", "high_risk"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "bot_detection.0.response.0.selected", "recaptcha_v2"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "bot_detection.0.response.0.providers.0.recaptcha_v2.0.secret", "someSecret"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection_tests", "bot_detection.0.response.0.providers.0.recaptcha_v2.0.site_key", "someSiteKey"),
 				),
 			},
 		},
@@ -63,6 +69,12 @@ resource "auth0_attack_protection" "my_protection_tests" {
       rate         = 1200
     }
   }
+  bot_detection {
+    response {
+      policy   = "always_on"
+      selected = "auth0"
+    }
+  }
 }
 `
 
@@ -89,6 +101,18 @@ resource "auth0_attack_protection" "my_protection_tests" {
     pre_user_registration {
       max_attempts = 50
       rate         = 1200
+    }
+  }
+  bot_detection {
+    response {
+      policy   = "high_risk"
+      selected = "recaptcha_v2"
+      providers {
+        recaptcha_v2 {
+          secret = "someSecret"
+          site_key = "someSiteKey"
+        }
+      }
     }
   }
 }

--- a/auth0/testdata/recordings/TestAccAttackProtection.yaml
+++ b/auth0/testdata/recordings/TestAccAttackProtection.yaml
@@ -9,7 +9,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
     method: PATCH
   response:
@@ -28,7 +28,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
     method: PATCH
   response:
@@ -47,7 +47,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
     method: PATCH
   response:
@@ -60,13 +60,32 @@ interactions:
     duration: 1ms
 - request:
     body: |
+      {"policy":"always_on","selected":"auth0"}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/anomaly/captchas
+    method: POST
+  response:
+    body: '{"selected":"auth0","policy":"always_on","providers":{"auth0":{},"recaptcha_v2":{"siteKey":"someSiteKey","secret":"someSecret"},"recaptcha_enterprise":{"siteKey":"someSiteKey","apiKey":"someApiKey","projectId":"someID"}}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
       {}
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
     method: GET
   response:
@@ -85,7 +104,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
     method: GET
   response:
@@ -104,11 +123,30 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
     method: GET
   response:
     body: '{"enabled":true,"shields":[],"admin_notification_frequency":[],"method":"standard"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/anomaly/captchas
+    method: GET
+  response:
+    body: '{"selected":"auth0","policy":"always_on","providers":{"auth0":{},"recaptcha_v2":{"siteKey":"someSiteKey","secret":"someSecret"},"recaptcha_enterprise":{"siteKey":"someSiteKey","apiKey":"someApiKey","projectId":"someID"}}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -123,7 +161,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
     method: GET
   response:
@@ -142,7 +180,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
     method: GET
   response:
@@ -161,11 +199,30 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
     method: GET
   response:
     body: '{"enabled":true,"shields":[],"admin_notification_frequency":[],"method":"standard"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/anomaly/captchas
+    method: GET
+  response:
+    body: '{"selected":"auth0","policy":"always_on","providers":{"auth0":{},"recaptcha_v2":{"siteKey":"someSiteKey","secret":"someSecret"},"recaptcha_enterprise":{"siteKey":"someSiteKey","apiKey":"someApiKey","projectId":"someID"}}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -180,7 +237,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
     method: GET
   response:
@@ -199,7 +256,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
     method: GET
   response:
@@ -218,11 +275,30 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
     method: GET
   response:
     body: '{"enabled":true,"shields":[],"admin_notification_frequency":[],"method":"standard"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/anomaly/captchas
+    method: GET
+  response:
+    body: '{"selected":"auth0","policy":"always_on","providers":{"auth0":{},"recaptcha_v2":{"siteKey":"someSiteKey","secret":"someSecret"},"recaptcha_enterprise":{"siteKey":"someSiteKey","apiKey":"someApiKey","projectId":"someID"}}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -237,7 +313,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
     method: PATCH
   response:
@@ -256,7 +332,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
     method: PATCH
   response:
@@ -275,7 +351,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
     method: PATCH
   response:
@@ -288,13 +364,32 @@ interactions:
     duration: 1ms
 - request:
     body: |
+      {"policy":"high_risk","selected":"recaptcha_v2"}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/anomaly/captchas
+    method: POST
+  response:
+    body: '{"selected":"recaptcha_v2","policy":"high_risk","providers":{"auth0":{},"recaptcha_v2":{"siteKey":"someSiteKey","secret":"someSecret"},"recaptcha_enterprise":{"siteKey":"someSiteKey","apiKey":"someApiKey","projectId":"someID"}}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
       {}
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
     method: GET
   response:
@@ -313,7 +408,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
     method: GET
   response:
@@ -332,11 +427,30 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
     method: GET
   response:
     body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/anomaly/captchas
+    method: GET
+  response:
+    body: '{"selected":"recaptcha_v2","policy":"high_risk","providers":{"auth0":{},"recaptcha_v2":{"siteKey":"someSiteKey","secret":"someSecret"},"recaptcha_enterprise":{"siteKey":"someSiteKey","apiKey":"someApiKey","projectId":"someID"}}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -351,7 +465,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
     method: GET
   response:
@@ -370,7 +484,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
     method: GET
   response:
@@ -389,11 +503,30 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Go-Auth0-SDK/0.6.3
+      - Go-Auth0-SDK/latest
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
     method: GET
   response:
     body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/anomaly/captchas
+    method: GET
+  response:
+    body: '{"selected":"recaptcha_v2","policy":"high_risk","providers":{"auth0":{},"recaptcha_v2":{"siteKey":"someSiteKey","secret":"someSecret"},"recaptcha_enterprise":{"siteKey":"someSiteKey","apiKey":"someApiKey","projectId":"someID"}}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/auth0/terraform-provider-auth0
 go 1.18
 
 require (
-	github.com/auth0/go-auth0 v0.8.0
+	github.com/auth0/go-auth0 v0.0.0-20220709181212-59788d1a044f
 	github.com/dnaeon/go-vcr/v2 v2.0.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/auth0/go-auth0 v0.8.0 h1:x5Z6q++NUtdaSyzoHMaMRjH/SpiWS5rLTQ8ZX0AsRRE=
-github.com/auth0/go-auth0 v0.8.0/go.mod h1:kxxGNgF592VPvWSNPVWNbmWHs+R9c0MZCTuW+T3NgZw=
+github.com/auth0/go-auth0 v0.0.0-20220709181212-59788d1a044f h1:a8hNq9h2BCzDNVOAL9aYGtH9o+dWW7CYdeiG6UtHzcU=
+github.com/auth0/go-auth0 v0.0.0-20220709181212-59788d1a044f/go.mod h1:kxxGNgF592VPvWSNPVWNbmWHs+R9c0MZCTuW+T3NgZw=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=


### PR DESCRIPTION
## Description


Add ability to manage bot detection response settings within the attack protection resource.

<!-- Describe the purpose of this PR along with any background information and the impacts of the proposed change. 
For the benefit of the community, please do not assume prior context. -->

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over