### PR TITLE
[DXCDT-190] Add support for multiple OAuth2 compatible strategies

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -854,9 +854,10 @@ func readConnection(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	}
 
 	connectionOptions, diags := flattenConnectionOptions(d, connection.Options)
-	if diags != nil {
+	if diags.HasError() {
 		return diags
 	}
+
 	result := multierror.Append(
 		d.Set("name", connection.Name),
 		d.Set("display_name", connection.DisplayName),
@@ -878,7 +879,8 @@ func readConnection(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		result = multierror.Append(result, d.Set("show_as_button", connection.ShowAsButton))
 	}
 
-	return diag.FromErr(result.ErrorOrNil())
+	diags = append(diags, diag.FromErr(result.ErrorOrNil())...)
+	return diags
 }
 
 func updateConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -823,19 +823,21 @@ func connectionSchemaUpgradeV1(
 }
 
 func createConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	connection, err := expandConnection(d)
-	if err != nil {
-		return diag.FromErr(err)
+	connection, diagnostics := expandConnection(d)
+	if diagnostics.HasError() {
+		return diagnostics
 	}
 
 	api := m.(*management.Management)
 	if err := api.Connection.Create(connection); err != nil {
-		return diag.FromErr(err)
+		diagnostics = append(diagnostics, diag.FromErr(err)...)
+		return diagnostics
 	}
 
 	d.SetId(auth0.StringValue(connection.ID))
 
-	return readConnection(ctx, d, m)
+	diagnostics = append(diagnostics, readConnection(ctx, d, m)...)
+	return diagnostics
 }
 
 func readConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -880,17 +882,19 @@ func readConnection(ctx context.Context, d *schema.ResourceData, m interface{}) 
 }
 
 func updateConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	connection, err := expandConnection(d)
-	if err != nil {
-		return diag.FromErr(err)
+	connection, diagnostics := expandConnection(d)
+	if diagnostics.HasError() {
+		return diagnostics
 	}
 
 	api := m.(*management.Management)
 	if err := api.Connection.Update(d.Id(), connection); err != nil {
-		return diag.FromErr(err)
+		diagnostics = append(diagnostics, diag.FromErr(err)...)
+		return diagnostics
 	}
 
-	return readConnection(ctx, d, m)
+	diagnostics = append(diagnostics, readConnection(ctx, d, m)...)
+	return diagnostics
 }
 
 func deleteConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -1640,3 +1640,61 @@ EOF
 	}
 }
 `
+
+func TestAccConnectionTwitter(t *testing.T) {
+	httpRecorder := configureHTTPRecorder(t)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testProviders(httpRecorder),
+		Steps: []resource.TestStep{
+			{
+				Config: template.ParseTestName(testAccConnectionTwitterConfig, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "name", fmt.Sprintf("Acceptance-Test-Twitter-%s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "strategy", "twitter"),
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "options.0.client_id", "someClientID"),
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "options.0.client_secret", "someClientSecret"),
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "options.0.scopes.#", "0"),
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "options.0.set_user_root_attributes", "on_each_login"),
+				),
+			},
+			{
+				Config: template.ParseTestName(testAccConnectionTwitterConfigUpdate, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "name", fmt.Sprintf("Acceptance-Test-Twitter-%s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "strategy", "twitter"),
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "options.0.client_id", "someClientID"),
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "options.0.client_secret", "someClientSecret"),
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "options.0.scopes.#", "1"),
+					resource.TestCheckTypeSetElemAttr("auth0_connection.twitter", "options.0.scopes.*", "basic_profile"),
+					resource.TestCheckResourceAttr("auth0_connection.twitter", "options.0.set_user_root_attributes", "on_each_login"),
+				),
+			},
+		},
+	})
+}
+
+const testAccConnectionTwitterConfig = `
+resource "auth0_connection" "twitter" {
+	name = "Acceptance-Test-Twitter-{{.testName}}"
+	strategy = "twitter"
+	options {
+		client_id = "someClientID"
+		client_secret = "someClientSecret"
+		set_user_root_attributes = "on_each_login"
+	}
+}
+`
+
+const testAccConnectionTwitterConfigUpdate = `
+resource "auth0_connection" "twitter" {
+	name = "Acceptance-Test-Twitter-{{.testName}}"
+	strategy = "twitter"
+	options {
+		client_id = "someClientID"
+		client_secret = "someClientSecret"
+		set_user_root_attributes = "on_each_login"
+		scopes = ["basic_profile"]
+	}
+}
+`

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -2,7 +2,6 @@ package auth0
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
@@ -12,13 +11,12 @@ import (
 )
 
 func flattenConnectionOptions(d ResourceData, options interface{}) ([]interface{}, diag.Diagnostics) {
-	var m interface{}
-	var diags diag.Diagnostics
-
 	if options == nil {
-		return nil, diags
+		return nil, nil
 	}
 
+	var m interface{}
+	var diags diag.Diagnostics
 	switch connectionOptions := options.(type) {
 	case *management.ConnectionOptions:
 		m, diags = flattenConnectionOptionsAuth0(d, connectionOptions)
@@ -55,11 +53,8 @@ func flattenConnectionOptions(d ResourceData, options interface{}) ([]interface{
 	case *management.ConnectionOptionsSAML:
 		m, diags = flattenConnectionOptionsSAML(d, connectionOptions)
 	}
-	if diags != nil {
-		return nil, diags
-	}
 
-	return []interface{}{m}, err
+	return []interface{}{m}, diags
 }
 
 func flattenConnectionOptionsGitHub(options *management.ConnectionOptionsGitHub) (interface{}, diag.Diagnostics) {
@@ -916,14 +911,14 @@ func expandConnectionOptionsEmail(d ResourceData) (*management.ConnectionOptions
 		}
 	})
 
-	var err error
-	options.UpstreamParams, err = JSON(d, "upstream_params")
-
 	if authParamsMap := Map(d, "auth_params"); authParamsMap != nil {
 		options.AuthParams = authParamsMap
 	}
 
-	return options, nil
+	var err error
+	options.UpstreamParams, err = JSON(d, "upstream_params")
+
+	return options, diag.FromErr(err)
 }
 
 func expandConnectionOptionsAD(d ResourceData) (*management.ConnectionOptionsAD, diag.Diagnostics) {

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -59,7 +59,7 @@ func flattenConnectionOptions(d ResourceData, options interface{}) ([]interface{
 		return nil, diags
 	}
 
-	return []interface{}{m}, nil
+	return []interface{}{m}, err
 }
 
 func flattenConnectionOptionsGitHub(options *management.ConnectionOptionsGitHub) (interface{}, diag.Diagnostics) {
@@ -535,7 +535,7 @@ func flattenConnectionOptionsSAML(d ResourceData, options *management.Connection
 	return m, nil
 }
 
-func expandConnection(d ResourceData) (*management.Connection, error) {
+func expandConnection(d ResourceData) (*management.Connection, diag.Diagnostics) {
 	connection := &management.Connection{
 		Name:               String(d, "name", IsNewResource()),
 		DisplayName:        String(d, "display_name"),
@@ -552,70 +552,89 @@ func expandConnection(d ResourceData) (*management.Connection, error) {
 		}
 	}
 
+	var diagnostics diag.Diagnostics
 	strategy := d.Get("strategy").(string)
-	switch strategy {
-	case management.ConnectionStrategyGoogleApps,
-		management.ConnectionStrategyOIDC,
-		management.ConnectionStrategyAD,
-		management.ConnectionStrategyAzureAD,
-		management.ConnectionStrategySAML,
-		management.ConnectionStrategyADFS:
-		connection.ShowAsButton = Bool(d, "show_as_button")
-	}
-
-	var err error
+	showAsButton := Bool(d, "show_as_button")
 	List(d, "options").Elem(func(d ResourceData) {
 		switch strategy {
 		case management.ConnectionStrategyAuth0:
-			connection.Options, err = expandConnectionOptionsAuth0(d)
+			connection.Options, diagnostics = expandConnectionOptionsAuth0(d)
 		case management.ConnectionStrategyGoogleOAuth2:
-			connection.Options, err = expandConnectionOptionsGoogleOAuth2(d)
+			connection.Options, diagnostics = expandConnectionOptionsGoogleOAuth2(d)
 		case management.ConnectionStrategyGoogleApps:
-			connection.Options, err = expandConnectionOptionsGoogleApps(d)
-		case management.ConnectionStrategyOAuth2:
-			connection.Options, err = expandConnectionOptionsOAuth2(d)
+			connection.ShowAsButton = showAsButton
+			connection.Options, diagnostics = expandConnectionOptionsGoogleApps(d)
+		case management.ConnectionStrategyOAuth2,
+			management.ConnectionStrategyDropbox,
+			management.ConnectionStrategyBitBucket,
+			management.ConnectionStrategyPaypal,
+			management.ConnectionStrategyTwitter,
+			management.ConnectionStrategyAmazon,
+			management.ConnectionStrategyYahoo,
+			management.ConnectionStrategyBox,
+			management.ConnectionStrategyWordpress,
+			management.ConnectionStrategyDiscord,
+			management.ConnectionStrategyImgur,
+			management.ConnectionStrategySpotify,
+			management.ConnectionStrategyShopify,
+			management.ConnectionStrategyFigma,
+			management.ConnectionStrategySlack,
+			management.ConnectionStrategyDigitalOcean,
+			management.ConnectionStrategyTwitch,
+			management.ConnectionStrategyVimeo,
+			management.ConnectionStrategyCustom:
+			connection.Options, diagnostics = expandConnectionOptionsOAuth2(d)
 		case management.ConnectionStrategyFacebook:
-			connection.Options, err = expandConnectionOptionsFacebook(d)
+			connection.Options, diagnostics = expandConnectionOptionsFacebook(d)
 		case management.ConnectionStrategyApple:
-			connection.Options, err = expandConnectionOptionsApple(d)
+			connection.Options, diagnostics = expandConnectionOptionsApple(d)
 		case management.ConnectionStrategyLinkedin:
-			connection.Options, err = expandConnectionOptionsLinkedin(d)
+			connection.Options, diagnostics = expandConnectionOptionsLinkedin(d)
 		case management.ConnectionStrategyGitHub:
-			connection.Options, err = expandConnectionOptionsGitHub(d)
+			connection.Options, diagnostics = expandConnectionOptionsGitHub(d)
 		case management.ConnectionStrategyWindowsLive:
-			connection.Options, err = expandConnectionOptionsWindowsLive(d)
+			connection.Options, diagnostics = expandConnectionOptionsWindowsLive(d)
 		case management.ConnectionStrategySalesforce,
 			management.ConnectionStrategySalesforceCommunity,
 			management.ConnectionStrategySalesforceSandbox:
-			connection.Options, err = expandConnectionOptionsSalesforce(d)
+			connection.Options, diagnostics = expandConnectionOptionsSalesforce(d)
 		case management.ConnectionStrategySMS:
-			connection.Options, err = expandConnectionOptionsSMS(d)
+			connection.Options, diagnostics = expandConnectionOptionsSMS(d)
 		case management.ConnectionStrategyOIDC:
-			connection.Options, err = expandConnectionOptionsOIDC(d)
+			connection.ShowAsButton = showAsButton
+			connection.Options, diagnostics = expandConnectionOptionsOIDC(d)
 		case management.ConnectionStrategyAD:
-			connection.Options, err = expandConnectionOptionsAD(d)
+			connection.ShowAsButton = showAsButton
+			connection.Options, diagnostics = expandConnectionOptionsAD(d)
 		case management.ConnectionStrategyAzureAD:
-			connection.Options, err = expandConnectionOptionsAzureAD(d)
+			connection.ShowAsButton = showAsButton
+			connection.Options, diagnostics = expandConnectionOptionsAzureAD(d)
 		case management.ConnectionStrategyEmail:
-			connection.Options, err = expandConnectionOptionsEmail(d)
+			connection.Options, diagnostics = expandConnectionOptionsEmail(d)
 		case management.ConnectionStrategySAML:
-			connection.Options, err = expandConnectionOptionsSAML(d)
+			connection.ShowAsButton = showAsButton
+			connection.Options, diagnostics = expandConnectionOptionsSAML(d)
 		case management.ConnectionStrategyADFS:
-			connection.Options, err = expandConnectionOptionsADFS(d)
+			connection.ShowAsButton = showAsButton
+			connection.Options, diagnostics = expandConnectionOptionsADFS(d)
 		default:
-			log.Printf("[WARN]: Unsupported connection strategy %s", strategy)
-			log.Printf("[WARN]: Raise an issue with the auth0 provider in order to support it:")
-			log.Printf("[WARN]: 	https://github.com/auth0/terraform-provider-auth0/issues/new")
+			diagnostics = append(diagnostics, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unsupported Connection Strategy",
+				Detail: fmt.Sprintf(
+					"Raise an issue at %s in order to have the following connection strategy supported: %q",
+					"https://github.com/auth0/terraform-provider-auth0/issues/new",
+					strategy,
+				),
+				AttributePath: cty.Path{cty.GetAttrStep{Name: "strategy"}},
+			})
 		}
 	})
-	if err != nil {
-		return nil, err
-	}
 
-	return connection, nil
+	return connection, diagnostics
 }
 
-func expandConnectionOptionsGitHub(d ResourceData) (*management.ConnectionOptionsGitHub, error) {
+func expandConnectionOptionsGitHub(d ResourceData) (*management.ConnectionOptionsGitHub, diag.Diagnostics) {
 	options := &management.ConnectionOptionsGitHub{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
@@ -627,14 +646,11 @@ func expandConnectionOptionsGitHub(d ResourceData) (*management.ConnectionOption
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsAuth0(d ResourceData) (*management.ConnectionOptions, error) {
+func expandConnectionOptionsAuth0(d ResourceData) (*management.ConnectionOptions, diag.Diagnostics) {
 	options := &management.ConnectionOptions{
 		PasswordPolicy:     String(d, "password_policy"),
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
@@ -691,14 +707,11 @@ func expandConnectionOptionsAuth0(d ResourceData) (*management.ConnectionOptions
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsGoogleOAuth2(d ResourceData) (*management.ConnectionOptionsGoogleOAuth2, error) {
+func expandConnectionOptionsGoogleOAuth2(d ResourceData) (*management.ConnectionOptionsGoogleOAuth2, diag.Diagnostics) {
 	options := &management.ConnectionOptionsGoogleOAuth2{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
@@ -711,14 +724,11 @@ func expandConnectionOptionsGoogleOAuth2(d ResourceData) (*management.Connection
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsGoogleApps(d ResourceData) (*management.ConnectionOptionsGoogleApps, error) {
+func expandConnectionOptionsGoogleApps(d ResourceData) (*management.ConnectionOptionsGoogleApps, diag.Diagnostics) {
 	options := &management.ConnectionOptionsGoogleApps{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
@@ -735,14 +745,11 @@ func expandConnectionOptionsGoogleApps(d ResourceData) (*management.ConnectionOp
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsOAuth2(d ResourceData) (*management.ConnectionOptionsOAuth2, error) {
+func expandConnectionOptionsOAuth2(d ResourceData) (*management.ConnectionOptionsOAuth2, diag.Diagnostics) {
 	options := &management.ConnectionOptionsOAuth2{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
@@ -759,14 +766,11 @@ func expandConnectionOptionsOAuth2(d ResourceData) (*management.ConnectionOption
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsFacebook(d ResourceData) (*management.ConnectionOptionsFacebook, error) {
+func expandConnectionOptionsFacebook(d ResourceData) (*management.ConnectionOptionsFacebook, diag.Diagnostics) {
 	options := &management.ConnectionOptionsFacebook{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
@@ -778,14 +782,11 @@ func expandConnectionOptionsFacebook(d ResourceData) (*management.ConnectionOpti
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsApple(d ResourceData) (*management.ConnectionOptionsApple, error) {
+func expandConnectionOptionsApple(d ResourceData) (*management.ConnectionOptionsApple, diag.Diagnostics) {
 	options := &management.ConnectionOptionsApple{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
@@ -799,14 +800,11 @@ func expandConnectionOptionsApple(d ResourceData) (*management.ConnectionOptions
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsLinkedin(d ResourceData) (*management.ConnectionOptionsLinkedin, error) {
+func expandConnectionOptionsLinkedin(d ResourceData) (*management.ConnectionOptionsLinkedin, diag.Diagnostics) {
 	options := &management.ConnectionOptionsLinkedin{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
@@ -819,14 +817,11 @@ func expandConnectionOptionsLinkedin(d ResourceData) (*management.ConnectionOpti
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsSalesforce(d ResourceData) (*management.ConnectionOptionsSalesforce, error) {
+func expandConnectionOptionsSalesforce(d ResourceData) (*management.ConnectionOptionsSalesforce, diag.Diagnostics) {
 	options := &management.ConnectionOptionsSalesforce{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
@@ -839,14 +834,11 @@ func expandConnectionOptionsSalesforce(d ResourceData) (*management.ConnectionOp
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsWindowsLive(d ResourceData) (*management.ConnectionOptionsWindowsLive, error) {
+func expandConnectionOptionsWindowsLive(d ResourceData) (*management.ConnectionOptionsWindowsLive, diag.Diagnostics) {
 	options := &management.ConnectionOptionsWindowsLive{
 		ClientID:           String(d, "client_id"),
 		ClientSecret:       String(d, "client_secret"),
@@ -859,14 +851,11 @@ func expandConnectionOptionsWindowsLive(d ResourceData) (*management.ConnectionO
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsSMS(d ResourceData) (*management.ConnectionOptionsSMS, error) {
+func expandConnectionOptionsSMS(d ResourceData) (*management.ConnectionOptionsSMS, diag.Diagnostics) {
 	options := &management.ConnectionOptionsSMS{
 		Name:                 String(d, "name"),
 		From:                 String(d, "from"),
@@ -901,14 +890,11 @@ func expandConnectionOptionsSMS(d ResourceData) (*management.ConnectionOptionsSM
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsEmail(d ResourceData) (*management.ConnectionOptionsEmail, error) {
+func expandConnectionOptionsEmail(d ResourceData) (*management.ConnectionOptionsEmail, diag.Diagnostics) {
 	options := &management.ConnectionOptionsEmail{
 		Name:          String(d, "name"),
 		DisableSignup: Bool(d, "disable_signup"),
@@ -932,9 +918,6 @@ func expandConnectionOptionsEmail(d ResourceData) (*management.ConnectionOptions
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
 	if authParamsMap := Map(d, "auth_params"); authParamsMap != nil {
 		options.AuthParams = authParamsMap
@@ -943,7 +926,7 @@ func expandConnectionOptionsEmail(d ResourceData) (*management.ConnectionOptions
 	return options, nil
 }
 
-func expandConnectionOptionsAD(d ResourceData) (*management.ConnectionOptionsAD, error) {
+func expandConnectionOptionsAD(d ResourceData) (*management.ConnectionOptionsAD, diag.Diagnostics) {
 	options := &management.ConnectionOptionsAD{
 		DomainAliases:        Set(d, "domain_aliases").List(),
 		TenantDomain:         String(d, "tenant_domain"),
@@ -959,14 +942,11 @@ func expandConnectionOptionsAD(d ResourceData) (*management.ConnectionOptionsAD,
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsAzureAD(d ResourceData) (*management.ConnectionOptionsAzureAD, error) {
+func expandConnectionOptionsAzureAD(d ResourceData) (*management.ConnectionOptionsAzureAD, diag.Diagnostics) {
 	options := &management.ConnectionOptionsAzureAD{
 		ClientID:            String(d, "client_id"),
 		ClientSecret:        String(d, "client_secret"),
@@ -990,14 +970,11 @@ func expandConnectionOptionsAzureAD(d ResourceData) (*management.ConnectionOptio
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsOIDC(d ResourceData) (*management.ConnectionOptionsOIDC, error) {
+func expandConnectionOptionsOIDC(d ResourceData) (*management.ConnectionOptionsOIDC, diag.Diagnostics) {
 	options := &management.ConnectionOptionsOIDC{
 		ClientID:              String(d, "client_id"),
 		ClientSecret:          String(d, "client_secret"),
@@ -1019,14 +996,11 @@ func expandConnectionOptionsOIDC(d ResourceData) (*management.ConnectionOptionsO
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsSAML(d ResourceData) (*management.ConnectionOptionsSAML, error) {
+func expandConnectionOptionsSAML(d ResourceData) (*management.ConnectionOptionsSAML, diag.Diagnostics) {
 	options := &management.ConnectionOptionsSAML{
 		Debug:              Bool(d, "debug"),
 		SigningCert:        String(d, "signing_cert"),
@@ -1065,20 +1039,17 @@ func expandConnectionOptionsSAML(d ResourceData) (*management.ConnectionOptionsS
 	})
 
 	var err error
+
 	options.FieldsMap, err = JSON(d, "fields_map")
-	if err != nil {
-		return nil, err
-	}
+	diagnostics := diag.FromErr(err)
 
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
+	diagnostics = append(diagnostics, diag.FromErr(err)...)
 
-	return options, nil
+	return options, diagnostics
 }
 
-func expandConnectionOptionsADFS(d ResourceData) (*management.ConnectionOptionsADFS, error) {
+func expandConnectionOptionsADFS(d ResourceData) (*management.ConnectionOptionsADFS, diag.Diagnostics) {
 	options := &management.ConnectionOptionsADFS{
 		TenantDomain:       String(d, "tenant_domain"),
 		DomainAliases:      Set(d, "domain_aliases").List(),
@@ -1091,11 +1062,8 @@ func expandConnectionOptionsADFS(d ResourceData) (*management.ConnectionOptionsA
 
 	var err error
 	options.UpstreamParams, err = JSON(d, "upstream_params")
-	if err != nil {
-		return nil, err
-	}
 
-	return options, nil
+	return options, diag.FromErr(err)
 }
 
 type scoper interface {

--- a/auth0/testdata/recordings/TestAccConnectionTwitter.yaml
+++ b/auth0/testdata/recordings/TestAccConnectionTwitter.yaml
@@ -1,0 +1,154 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"name":"Acceptance-Test-Twitter-TestAccConnectionTwitter","strategy":"twitter","options":{"client_id":"someClientID","client_secret":"someClientSecret","authorizationURL":null,"tokenURL":null,"set_user_root_attributes":"on_each_login","non_persistent_attrs":null}}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+    method: POST
+  response:
+    body: '{"id":"con_s65OZErWIB9PGD00","options":{"client_id":"someClientID","client_secret":"someClientSecret","authorizationURL":null,"tokenURL":null,"set_user_root_attributes":"on_each_login","non_persistent_attrs":null},"strategy":"twitter","name":"Acceptance-Test-Twitter-TestAccConnectionTwitter","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Twitter-TestAccConnectionTwitter"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 201 Created
+    code: 201
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_s65OZErWIB9PGD00
+    method: GET
+  response:
+    body: '{"id":"con_s65OZErWIB9PGD00","options":{"tokenURL":null,"client_id":"someClientID","client_secret":"someClientSecret","authorizationURL":null,"non_persistent_attrs":null,"set_user_root_attributes":"on_each_login"},"strategy":"twitter","name":"Acceptance-Test-Twitter-TestAccConnectionTwitter","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Twitter-TestAccConnectionTwitter"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_s65OZErWIB9PGD00
+    method: GET
+  response:
+    body: '{"id":"con_s65OZErWIB9PGD00","options":{"tokenURL":null,"client_id":"someClientID","client_secret":"someClientSecret","authorizationURL":null,"non_persistent_attrs":null,"set_user_root_attributes":"on_each_login"},"strategy":"twitter","name":"Acceptance-Test-Twitter-TestAccConnectionTwitter","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Twitter-TestAccConnectionTwitter"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_s65OZErWIB9PGD00
+    method: GET
+  response:
+    body: '{"id":"con_s65OZErWIB9PGD00","options":{"tokenURL":null,"client_id":"someClientID","client_secret":"someClientSecret","authorizationURL":null,"non_persistent_attrs":null,"set_user_root_attributes":"on_each_login"},"strategy":"twitter","name":"Acceptance-Test-Twitter-TestAccConnectionTwitter","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Twitter-TestAccConnectionTwitter"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      {"is_domain_connection":false,"options":{"client_id":"someClientID","client_secret":"someClientSecret","authorizationURL":null,"tokenURL":null,"scope":"basic_profile","set_user_root_attributes":"on_each_login","non_persistent_attrs":null,"pkce_enabled":false}}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_s65OZErWIB9PGD00
+    method: PATCH
+  response:
+    body: '{"id":"con_s65OZErWIB9PGD00","options":{"scope":"basic_profile","tokenURL":null,"client_id":"someClientID","pkce_enabled":false,"client_secret":"someClientSecret","authorizationURL":null,"non_persistent_attrs":null,"set_user_root_attributes":"on_each_login"},"strategy":"twitter","name":"Acceptance-Test-Twitter-TestAccConnectionTwitter","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Twitter-TestAccConnectionTwitter"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_s65OZErWIB9PGD00
+    method: GET
+  response:
+    body: '{"id":"con_s65OZErWIB9PGD00","options":{"scope":"basic_profile","tokenURL":null,"client_id":"someClientID","pkce_enabled":false,"client_secret":"someClientSecret","authorizationURL":null,"non_persistent_attrs":null,"set_user_root_attributes":"on_each_login"},"strategy":"twitter","name":"Acceptance-Test-Twitter-TestAccConnectionTwitter","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Twitter-TestAccConnectionTwitter"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_s65OZErWIB9PGD00
+    method: GET
+  response:
+    body: '{"id":"con_s65OZErWIB9PGD00","options":{"scope":"basic_profile","tokenURL":null,"client_id":"someClientID","pkce_enabled":false,"client_secret":"someClientSecret","authorizationURL":null,"non_persistent_attrs":null,"set_user_root_attributes":"on_each_login"},"strategy":"twitter","name":"Acceptance-Test-Twitter-TestAccConnectionTwitter","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Twitter-TestAccConnectionTwitter"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/latest
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_s65OZErWIB9PGD00
+    method: DELETE
+  response:
+    body: '{"deleted_at":"2022-07-14T17:04:00.091Z"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 202 Accepted
+    code: 202
+    duration: 1ms

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/auth0/terraform-provider-auth0
 go 1.18
 
 require (
-	github.com/auth0/go-auth0 v0.9.0
+	github.com/auth0/go-auth0 v0.9.1
 	github.com/dnaeon/go-vcr/v2 v2.0.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJE
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/auth0/go-auth0 v0.9.0 h1:+jiMnvXSsu9v6eZUy6MrgqBN0nw4wK8mBivtoLeD3Pk=
-github.com/auth0/go-auth0 v0.9.0/go.mod h1:kxxGNgF592VPvWSNPVWNbmWHs+R9c0MZCTuW+T3NgZw=
+github.com/auth0/go-auth0 v0.9.1 h1:sc9w+Znl53KXdgYFCLbFz93mW9aJlNK49u/KBsfbmUc=
+github.com/auth0/go-auth0 v0.9.1/go.mod h1:kxxGNgF592VPvWSNPVWNbmWHs+R9c0MZCTuW+T3NgZw=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=


### PR DESCRIPTION
## Description


Fixes: https://github.com/auth0/terraform-provider-auth0/issues/224. 

Add support for multiple OAuth2 compatible strategies.

<!-- Describe the purpose of this PR along with any background information and the impacts of the proposed change. 
For the benefit of the community, please do not assume prior context. -->

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over