### PR TITLE
Throw error when encountering untracked action secrets

### DIFF
--- a/auth0/resource_auth0_action.go
+++ b/auth0/resource_auth0_action.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -160,6 +161,7 @@ func readAction(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 		d.Set("dependencies", flattenActionDependencies(action.Dependencies)),
 		d.Set("runtime", action.Runtime),
 	)
+
 	if action.DeployedVersion != nil {
 		result = multierror.Append(result, d.Set("version_id", action.DeployedVersion.GetID()))
 	}
@@ -171,6 +173,12 @@ func updateAction(ctx context.Context, d *schema.ResourceData, m interface{}) di
 	action := expandAction(d)
 
 	api := m.(*management.Management)
+
+	diagnostics := preventErasingUnmanagedSecrets(d, api)
+	if diagnostics.HasError() {
+		return diagnostics
+	}
+
 	if err := api.Action.Update(d.Id(), action); err != nil {
 		return diag.FromErr(err)
 	}
@@ -249,6 +257,61 @@ func deployAction(ctx context.Context, d *schema.ResourceData, m interface{}) di
 	}
 
 	return diag.FromErr(d.Set("version_id", actionVersion.GetID()))
+}
+
+func preventErasingUnmanagedSecrets(d *schema.ResourceData, api *management.Management) diag.Diagnostics {
+	if !d.HasChange("secrets") {
+		return nil
+	}
+
+	preUpdateAction, err := api.Action.Read(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	oldSecrets, newSecrets := d.GetChange("secrets")
+
+	return checkForUnmanagedActionSecrets(
+		oldSecrets.([]interface{}),
+		newSecrets.([]interface{}),
+		preUpdateAction.Secrets,
+	)
+}
+
+func checkForUnmanagedActionSecrets(
+	oldSecretsFromConfig []interface{},
+	newSecretsFromConfig []interface{},
+	secretsFromAPI []*management.ActionSecret,
+) diag.Diagnostics {
+	secretKeysInConfigMap := make(map[string]bool, len(secretsFromAPI))
+
+	for _, oldSecret := range oldSecretsFromConfig {
+		secretKeyName := oldSecret.(map[string]interface{})["name"].(string)
+		secretKeysInConfigMap[secretKeyName] = true
+	}
+
+	for _, newSecret := range newSecretsFromConfig {
+		secretKeyName := newSecret.(map[string]interface{})["name"].(string)
+		secretKeysInConfigMap[secretKeyName] = true
+	}
+
+	var warnings diag.Diagnostics
+	for _, secret := range secretsFromAPI {
+		if _, ok := secretKeysInConfigMap[secret.GetName()]; !ok {
+			warnings = append(warnings, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unmanaged Action Secret",
+				Detail: fmt.Sprintf(
+					"Found unmanaged action secret with key: %s. "+
+						"Add this secret to your configuration so it does not get wiped.",
+					secret.GetName(),
+				),
+				AttributePath: cty.Path{cty.GetAttrStep{Name: "secrets"}},
+			})
+		}
+	}
+
+	return warnings
 }
 
 func expandAction(d *schema.ResourceData) *management.Action {

--- a/auth0/resource_auth0_action.go
+++ b/auth0/resource_auth0_action.go
@@ -295,10 +295,10 @@ func checkForUnmanagedActionSecrets(
 		secretKeysInConfigMap[secretKeyName] = true
 	}
 
-	var warnings diag.Diagnostics
+	var diagnostics diag.Diagnostics
 	for _, secret := range secretsFromAPI {
 		if _, ok := secretKeysInConfigMap[secret.GetName()]; !ok {
-			warnings = append(warnings, diag.Diagnostic{
+			diagnostics = append(diagnostics, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Unmanaged Action Secret",
 				Detail: fmt.Sprintf(
@@ -311,7 +311,7 @@ func checkForUnmanagedActionSecrets(
 		}
 	}
 
-	return warnings
+	return diagnostics
 }
 
 func expandAction(d *schema.ResourceData) *management.Action {

--- a/auth0/resource_auth0_action_test.go
+++ b/auth0/resource_auth0_action_test.go
@@ -201,23 +201,20 @@ resource auth0_action my_action {
 
 func TestCheckForUntrackedActionSecrets(t *testing.T) {
 	var testCases = []struct {
-		name                  string
-		givenOldSecretsConfig []interface{}
-		givenNewSecretsConfig []interface{}
-		givenActionSecrets    []*management.ActionSecret
-		expectedDiagnostics   diag.Diagnostics
+		name                 string
+		givenSecretsInConfig []interface{}
+		givenActionSecrets   []*management.ActionSecret
+		expectedDiagnostics  diag.Diagnostics
 	}{
 		{
-			name:                  "action has no secrets",
-			givenOldSecretsConfig: []interface{}{},
-			givenNewSecretsConfig: []interface{}{},
-			givenActionSecrets:    []*management.ActionSecret{},
-			expectedDiagnostics:   diag.Diagnostics(nil),
+			name:                 "action has no secrets",
+			givenSecretsInConfig: []interface{}{},
+			givenActionSecrets:   []*management.ActionSecret{},
+			expectedDiagnostics:  diag.Diagnostics(nil),
 		},
 		{
-			name:                  "action has no untracked secrets",
-			givenOldSecretsConfig: []interface{}{},
-			givenNewSecretsConfig: []interface{}{
+			name: "action has no untracked secrets",
+			givenSecretsInConfig: []interface{}{
 				map[string]interface{}{
 					"name": "secretName",
 				},
@@ -230,9 +227,8 @@ func TestCheckForUntrackedActionSecrets(t *testing.T) {
 			expectedDiagnostics: diag.Diagnostics(nil),
 		},
 		{
-			name:                  "action has untracked secrets",
-			givenOldSecretsConfig: []interface{}{},
-			givenNewSecretsConfig: []interface{}{
+			name: "action has untracked secrets",
+			givenSecretsInConfig: []interface{}{
 				map[string]interface{}{
 					"name": "secretName",
 				},
@@ -260,8 +256,7 @@ func TestCheckForUntrackedActionSecrets(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			actualDiagnostics := checkForUnmanagedActionSecrets(
-				testCase.givenOldSecretsConfig,
-				testCase.givenNewSecretsConfig,
+				testCase.givenSecretsInConfig,
 				testCase.givenActionSecrets,
 			)
 

--- a/auth0/resource_auth0_action_test.go
+++ b/auth0/resource_auth0_action_test.go
@@ -245,8 +245,9 @@ func TestCheckForUntrackedActionSecrets(t *testing.T) {
 				{
 					Severity: diag.Error,
 					Summary:  "Unmanaged Action Secret",
-					Detail: "Found unmanaged action secret with key: anotherSecretName. " +
-						"Add this secret to your configuration so it does not get wiped.",
+					Detail: "Detected an action secret not managed though Terraform: anotherSecretName. " +
+						"If you proceed, this secret will get deleted. It is required to add this secret to " +
+						"your action configuration to prevent unintentionally destructive results.",
 					AttributePath: cty.Path{cty.GetAttrStep{Name: "secrets"}},
 				},
 			},

--- a/auth0/testdata/recordings/TestAccAction.yaml
+++ b/auth0/testdata/recordings/TestAccAction.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"code":"exports.onExecutePostLogin = async (event, api) =\u003e {};"}
+      {"name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"code":"exports.onExecutePostLogin = async (event, api) =\u003e {};","secrets":[{"name":"foo","value":"111111"}]}
     form: {}
     headers:
       Content-Type:
@@ -13,8 +13,8 @@ interactions:
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions
     method: POST
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:35.739896116Z","code":"exports.onExecutePostLogin
-      = async (event, api) => {};","dependencies":[],"runtime":"node16","status":"pending","secrets":[],"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:50.874486144Z","code":"exports.onExecutePostLogin
+      = async (event, api) => {};","dependencies":[],"runtime":"node16","status":"pending","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:50.874486144Z"}],"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -30,11 +30,11 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:35.739896116Z","code":"exports.onExecutePostLogin
-      = async (event, api) => {};","dependencies":[],"runtime":"node16","status":"built","secrets":[],"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:50.874486144Z","code":"exports.onExecutePostLogin
+      = async (event, api) => {};","dependencies":[],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:50.874486144Z"}],"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -50,11 +50,11 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:35.739896116Z","code":"exports.onExecutePostLogin
-      = async (event, api) => {};","dependencies":[],"runtime":"node16","status":"built","secrets":[],"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:50.874486144Z","code":"exports.onExecutePostLogin
+      = async (event, api) => {};","dependencies":[],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:50.874486144Z"}],"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -70,11 +70,11 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:35.739896116Z","code":"exports.onExecutePostLogin
-      = async (event, api) => {};","dependencies":[],"runtime":"node16","status":"built","secrets":[],"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:50.874486144Z","code":"exports.onExecutePostLogin
+      = async (event, api) => {};","dependencies":[],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:50.874486144Z"}],"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -83,18 +83,38 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"code":"exports.onContinuePostLogin = async (event, api) =\u003e {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","secrets":[{"name":"foo","value":"123456"}]}
+      null
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
+    method: GET
+  response:
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:50.874486144Z","code":"exports.onExecutePostLogin
+      = async (event, api) => {};","dependencies":[],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:50.874486144Z"}],"all_changes_deployed":false}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      {"name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"code":"exports.onContinuePostLogin = async (event, api) =\u003e {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","secrets":[{"name":"foo","value":"123456"},{"name":"bar","value":"654321"}]}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: PATCH
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:38.269876373Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"pending","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.184782746Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"pending","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -110,11 +130,11 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:38.269876373Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.184782746Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -130,11 +150,11 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:38.269876373Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.184782746Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -150,11 +170,11 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:38.269876373Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.184782746Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -170,11 +190,11 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:38.269876373Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.184782746Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -190,11 +210,11 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:38.269876373Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.184782746Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -210,11 +230,11 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:38.269876373Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.184782746Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -230,11 +250,11 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a/deploy
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3/deploy
     method: POST
   response:
-    body: '{"code":"exports.onContinuePostLogin = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","deployed":false,"number":1,"secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.273224131Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}],"action":{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test
-      Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:38.261576292Z","all_changes_deployed":false}}'
+    body: '{"code":"exports.onContinuePostLogin = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","deployed":false,"number":1,"secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.191490926Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}],"action":{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test
+      Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.174102016Z","all_changes_deployed":false}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -250,13 +270,13 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:38.269876373Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-18T16:15:56.402718376Z","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","deployed":true,"number":1,"built_at":"2022-07-18T16:15:56.402718376Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":true}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.184782746Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-20T12:49:12.305518429Z","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","deployed":true,"number":1,"built_at":"2022-07-20T12:49:12.305518429Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":true}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -272,13 +292,13 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:38.269876373Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-18T16:15:56.402718376Z","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","deployed":true,"number":1,"built_at":"2022-07-18T16:15:56.402718376Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":true}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.184782746Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-20T12:49:12.305518429Z","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","deployed":true,"number":1,"built_at":"2022-07-20T12:49:12.305518429Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":true}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -294,13 +314,35 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:38.269876373Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-18T16:15:56.402718376Z","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","deployed":true,"number":1,"built_at":"2022-07-18T16:15:56.402718376Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":true}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.184782746Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-20T12:49:12.305518429Z","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","deployed":true,"number":1,"built_at":"2022-07-20T12:49:12.305518429Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":true}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
+    method: GET
+  response:
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:48:54.184782746Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-20T12:49:12.305518429Z","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","deployed":true,"number":1,"built_at":"2022-07-20T12:49:12.305518429Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":true}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -316,13 +358,13 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: PATCH
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:59.118528440Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"pending","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-18T16:15:56.402718376Z","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","deployed":true,"number":1,"built_at":"2022-07-18T16:15:56.402718376Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:49:15.146110722Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"pending","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-20T12:49:12.305518429Z","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","deployed":true,"number":1,"built_at":"2022-07-20T12:49:12.305518429Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -338,13 +380,13 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:59.118528440Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-18T16:15:56.402718376Z","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","deployed":true,"number":1,"built_at":"2022-07-18T16:15:56.402718376Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:49:15.146110722Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-20T12:49:12.305518429Z","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","deployed":true,"number":1,"built_at":"2022-07-20T12:49:12.305518429Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -360,13 +402,13 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:59.118528440Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-18T16:15:56.402718376Z","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","deployed":true,"number":1,"built_at":"2022-07-18T16:15:56.402718376Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:49:15.146110722Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-20T12:49:12.305518429Z","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","deployed":true,"number":1,"built_at":"2022-07-20T12:49:12.305518429Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -382,13 +424,13 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:59.118528440Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-18T16:15:56.402718376Z","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","deployed":true,"number":1,"built_at":"2022-07-18T16:15:56.402718376Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:49:15.146110722Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-20T12:49:12.305518429Z","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","deployed":true,"number":1,"built_at":"2022-07-20T12:49:12.305518429Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -404,13 +446,13 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:59.118528440Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-18T16:15:56.402718376Z","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","deployed":true,"number":1,"built_at":"2022-07-18T16:15:56.402718376Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:49:15.146110722Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-20T12:49:12.305518429Z","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","deployed":true,"number":1,"built_at":"2022-07-20T12:49:12.305518429Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -426,13 +468,13 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:59.118528440Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"building","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-18T16:15:56.402718376Z","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","deployed":true,"number":1,"built_at":"2022-07-18T16:15:56.402718376Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:49:15.146110722Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","code":"exports.onContinuePostLogin
+      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-20T12:49:12.305518429Z","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"909d3d1d-6e0d-4b5c-b93d-072ce9933e44","deployed":true,"number":1,"built_at":"2022-07-20T12:49:12.305518429Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:12.191490926Z","updated_at":"2022-07-20T12:49:12.306761397Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -448,33 +490,11 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
-    method: GET
-  response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:59.118528440Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","code":"exports.onContinuePostLogin
-      = async (event, api) => {};","runtime":"node16","status":"BUILT","number":1,"build_time":"2022-07-18T16:15:56.402718376Z","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {};","dependencies":[{"name":"auth0","version":"2.41.0"}],"id":"7216cd23-98e4-4929-8c94-f4f867fa5355","deployed":true,"number":1,"built_at":"2022-07-18T16:15:56.402718376Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:15:56.273224131Z","updated_at":"2022-07-18T16:15:56.403384581Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":false}'
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    status: 200 OK
-    code: 200
-    duration: 1ms
-- request:
-    body: |
-      null
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a/deploy
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3/deploy
     method: POST
   response:
-    body: '{"code":"exports.onContinuePostLogin = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"id":"8a857474-c075-4c77-b07a-4da095ec3776","deployed":false,"number":2,"secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:16:16.857248748Z","updated_at":"2022-07-18T16:16:16.857248748Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}],"action":{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test
-      Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:59.100232582Z","all_changes_deployed":false}}'
+    body: '{"code":"exports.onContinuePostLogin = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"id":"71da3873-af66-4a95-8a91-5f0c8d025162","deployed":false,"number":2,"secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:24.667822314Z","updated_at":"2022-07-20T12:49:24.667822314Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}],"action":{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test
+      Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:49:15.139361268Z","all_changes_deployed":false}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -490,13 +510,13 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:59.118528440Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"8a857474-c075-4c77-b07a-4da095ec3776","code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","runtime":"node16","status":"BUILT","number":2,"build_time":"2022-07-18T16:16:16.993137368Z","created_at":"2022-07-18T16:16:16.857248748Z","updated_at":"2022-07-18T16:16:16.994821563Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"id":"8a857474-c075-4c77-b07a-4da095ec3776","deployed":true,"number":2,"built_at":"2022-07-18T16:16:16.993137368Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:16:16.857248748Z","updated_at":"2022-07-18T16:16:16.994821563Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":true}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:49:15.146110722Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"71da3873-af66-4a95-8a91-5f0c8d025162","code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","runtime":"node16","status":"BUILT","number":2,"build_time":"2022-07-20T12:49:24.814832869Z","created_at":"2022-07-20T12:49:24.667822314Z","updated_at":"2022-07-20T12:49:24.816217777Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"id":"71da3873-af66-4a95-8a91-5f0c8d025162","deployed":true,"number":2,"built_at":"2022-07-20T12:49:24.814832869Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:24.667822314Z","updated_at":"2022-07-20T12:49:24.816217777Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":true}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -512,13 +532,13 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: GET
   response:
-    body: '{"id":"5da3ec0c-c03e-4859-babf-b687b28d0a6a","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-18T16:15:35.719244518Z","updated_at":"2022-07-18T16:15:59.118528440Z","code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"current_version":{"id":"8a857474-c075-4c77-b07a-4da095ec3776","code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","runtime":"node16","status":"BUILT","number":2,"build_time":"2022-07-18T16:16:16.993137368Z","created_at":"2022-07-18T16:16:16.857248748Z","updated_at":"2022-07-18T16:16:16.994821563Z"},"deployed_version":{"code":"exports.onContinuePostLogin
-      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"id":"8a857474-c075-4c77-b07a-4da095ec3776","deployed":true,"number":2,"built_at":"2022-07-18T16:16:16.993137368Z","secrets":[{"name":"foo","updated_at":"2022-07-18T16:15:38.269876373Z"}],"status":"built","created_at":"2022-07-18T16:16:16.857248748Z","updated_at":"2022-07-18T16:16:16.994821563Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":true}'
+    body: '{"id":"b940a6d4-ee7e-4e13-b456-84d2fe6350f3","name":"Test Action TestAccAction","supported_triggers":[{"id":"post-login","version":"v3"}],"created_at":"2022-07-20T12:48:50.859629600Z","updated_at":"2022-07-20T12:49:15.146110722Z","code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"runtime":"node16","status":"built","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"current_version":{"id":"71da3873-af66-4a95-8a91-5f0c8d025162","code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","runtime":"node16","status":"BUILT","number":2,"build_time":"2022-07-20T12:49:24.814832869Z","created_at":"2022-07-20T12:49:24.667822314Z","updated_at":"2022-07-20T12:49:24.816217777Z"},"deployed_version":{"code":"exports.onContinuePostLogin
+      = async (event, api) => {\n\tconsole.log(event)\n};\"\n","dependencies":[{"name":"auth0","version":"2.42.0"}],"id":"71da3873-af66-4a95-8a91-5f0c8d025162","deployed":true,"number":2,"built_at":"2022-07-20T12:49:24.814832869Z","secrets":[{"name":"foo","updated_at":"2022-07-20T12:48:54.184782746Z"},{"name":"bar","updated_at":"2022-07-20T12:48:54.184782746Z"}],"status":"built","created_at":"2022-07-20T12:49:24.667822314Z","updated_at":"2022-07-20T12:49:24.816217777Z","runtime":"node16","supported_triggers":[{"id":"post-login","version":"v3"}]},"all_changes_deployed":true}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -533,7 +553,7 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/5da3ec0c-c03e-4859-babf-b687b28d0a6a
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/actions/actions/b940a6d4-ee7e-4e13-b456-84d2fe6350f3
     method: DELETE
   response:
     body: ""


### PR DESCRIPTION
## Description

Fixes #52 

Although we can already update and create secrets as this was patched before the repo transfer, because we cannot import the values of the secrets we run the risk of erasing the secrets that are found already in the Auth0 Dashboard for the action. 

In this PR we are trying to prevent that from happening in case there are secrets that are not managed through terraform by throwing an error while updating. 

<!-- Describe the purpose of this PR along with any background information and the impacts of the proposed change. 
For the benefit of the community, please do not assume prior context. -->

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over