### PR TITLE
Add new auth0_organization_connection resource

### DIFF
--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -77,6 +77,7 @@ func Provider() *schema.Provider {
 			"auth0_branding":                   newBranding(),
 			"auth0_guardian":                   newGuardian(),
 			"auth0_organization":               newOrganization(),
+			"auth0_organization_connection":    newOrganizationConnection(),
 			"auth0_organization_member":        newOrganizationMember(),
 			"auth0_action":                     newAction(),
 			"auth0_trigger_binding":            newTriggerBinding(),

--- a/auth0/resource_auth0_organization.go
+++ b/auth0/resource_auth0_organization.go
@@ -61,6 +61,9 @@ func newOrganization() *schema.Resource {
 			"connections": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
+				Deprecated: "This attribute will be removed in the future. " +
+					"Please use the auth0_organization_connection resource instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"connection_id": {

--- a/auth0/resource_auth0_organization.go
+++ b/auth0/resource_auth0_organization.go
@@ -62,8 +62,9 @@ func newOrganization() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				Deprecated: "This attribute will be removed in the future. " +
-					"Please use the auth0_organization_connection resource instead.",
+				Deprecated: "Management of organizations through this property has been deprecated in favor of the " +
+					"`auth0_organization_connection` resource and will be deleted in future versions. It is " +
+					"advised to migrate all managed organization connections to the new resource type.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"connection_id": {

--- a/auth0/resource_auth0_organization_connection.go
+++ b/auth0/resource_auth0_organization_connection.go
@@ -1,0 +1,118 @@
+package auth0
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func newOrganizationConnection() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: createOrganizationConnection,
+		ReadContext:   readOrganizationConnection,
+		UpdateContext: updateOrganizationConnection,
+		DeleteContext: deleteOrganizationConnection,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"organization_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"connection_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"assign_membership_on_login": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"strategy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func createOrganizationConnection(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := meta.(*management.Management)
+
+	organizationID := data.Get("organization_id").(string)
+	organizationConnection := &management.OrganizationConnection{
+		ConnectionID:            String(data, "connection_id"),
+		AssignMembershipOnLogin: Bool(data, "assign_membership_on_login"),
+	}
+
+	if err := api.Organization.AddConnection(organizationID, organizationConnection); err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(resource.UniqueId())
+
+	return readOrganizationConnection(ctx, data, meta)
+}
+
+func readOrganizationConnection(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := meta.(*management.Management)
+
+	organizationID := data.Get("organization_id").(string)
+	connectionID := data.Get("connection_id").(string)
+	organizationConnection, err := api.Organization.Connection(organizationID, connectionID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	result := multierror.Append(
+		data.Set("assign_membership_on_login", organizationConnection.GetAssignMembershipOnLogin()),
+		data.Set("name", organizationConnection.GetConnection().GetName()),
+		data.Set("strategy", organizationConnection.GetConnection().GetStrategy()),
+	)
+
+	return diag.FromErr(result.ErrorOrNil())
+}
+
+func updateOrganizationConnection(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := meta.(*management.Management)
+
+	organizationID := data.Get("organization_id").(string)
+	connectionID := data.Get("connection_id").(string)
+	organizationConnection := &management.OrganizationConnection{
+		AssignMembershipOnLogin: Bool(data, "assign_membership_on_login"),
+	}
+	if err := api.Organization.UpdateConnection(organizationID, connectionID, organizationConnection); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return readOrganizationConnection(ctx, data, meta)
+}
+
+func deleteOrganizationConnection(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := meta.(*management.Management)
+
+	organizationID := data.Get("organization_id").(string)
+	connectionID := data.Get("connection_id").(string)
+
+	if err := api.Organization.DeleteConnection(organizationID, connectionID); err != nil {
+		if err, ok := err.(management.Error); ok && err.Status() == http.StatusNotFound {
+			data.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
+	}
+
+	data.SetId("")
+
+	return nil
+}

--- a/auth0/resource_auth0_organization_connection.go
+++ b/auth0/resource_auth0_organization_connection.go
@@ -13,6 +13,7 @@ import (
 
 func newOrganizationConnection() *schema.Resource {
 	return &schema.Resource{
+		Description:   "With this resource, you can manage enabled connections on an organization.",
 		CreateContext: createOrganizationConnection,
 		ReadContext:   readOrganizationConnection,
 		UpdateContext: updateOrganizationConnection,
@@ -22,25 +23,32 @@ func newOrganizationConnection() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"organization_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the organization to enable the connection for.",
 			},
 			"connection_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of the connection to enable for the organization.",
 			},
 			"assign_membership_on_login": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+				Description: "When true, all users that log in with this connection will be automatically granted " +
+					"membership in the organization. When false, users must be granted membership in the organization" +
+					" before logging in with this connection.",
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the enabled connection.",
 			},
 			"strategy": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The strategy of the enabled connection.",
 			},
 		},
 	}

--- a/auth0/resource_auth0_organization_connection_test.go
+++ b/auth0/resource_auth0_organization_connection_test.go
@@ -1,0 +1,92 @@
+package auth0
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/auth0/terraform-provider-auth0/auth0/internal/template"
+)
+
+const testAccOrganizationConnectionGivenAnOrgAndAConnection = `
+resource auth0_connection my_connection {
+	name = "Acceptance-Test-Connection-First-{{.testName}}"
+	strategy = "auth0"
+}
+
+resource auth0_organization my_organization {
+	depends_on = [auth0_connection.my_connection]
+	name = "test-{{.testName}}"
+	display_name = "Acme Inc. {{.testName}}"
+}
+`
+
+const TestAccOrganizationConnectionCreate = testAccOrganizationConnectionGivenAnOrgAndAConnection + `
+resource auth0_organization_connection my_org_conn {
+	organization_id = auth0_organization.my_organization.id
+	connection_id = auth0_connection.my_connection.id
+}
+`
+
+const TestAccOrganizationConnectionUpdate = testAccOrganizationConnectionGivenAnOrgAndAConnection + `
+resource auth0_organization_connection my_org_conn {
+	organization_id = auth0_organization.my_organization.id
+	connection_id = auth0_connection.my_connection.id
+	assign_membership_on_login = true
+}
+`
+
+func TestAccOrganizationConnection(t *testing.T) {
+	httpRecorder := configureHTTPRecorder(t)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testProviders(httpRecorder),
+		Steps: []resource.TestStep{
+			{
+				Config: template.ParseTestName(TestAccOrganizationConnectionCreate, strings.ToLower(t.Name())),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("auth0_organization_connection.my_org_conn", "organization_id"),
+					resource.TestCheckResourceAttrSet("auth0_organization_connection.my_org_conn", "connection_id"),
+					resource.TestCheckResourceAttr(
+						"auth0_organization_connection.my_org_conn",
+						"name",
+						"Acceptance-Test-Connection-First-"+strings.ToLower(t.Name()),
+					),
+					resource.TestCheckResourceAttr(
+						"auth0_organization_connection.my_org_conn",
+						"strategy",
+						"auth0",
+					),
+					resource.TestCheckResourceAttr(
+						"auth0_organization_connection.my_org_conn",
+						"assign_membership_on_login",
+						"false",
+					),
+				),
+			},
+			{
+				Config: template.ParseTestName(TestAccOrganizationConnectionUpdate, strings.ToLower(t.Name())),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("auth0_organization_connection.my_org_conn", "organization_id"),
+					resource.TestCheckResourceAttrSet("auth0_organization_connection.my_org_conn", "connection_id"),
+					resource.TestCheckResourceAttr(
+						"auth0_organization_connection.my_org_conn",
+						"name",
+						"Acceptance-Test-Connection-First-"+strings.ToLower(t.Name()),
+					),
+					resource.TestCheckResourceAttr(
+						"auth0_organization_connection.my_org_conn",
+						"strategy",
+						"auth0",
+					),
+					resource.TestCheckResourceAttr(
+						"auth0_organization_connection.my_org_conn",
+						"assign_membership_on_login",
+						"true",
+					),
+				),
+			},
+		},
+	})
+}

--- a/auth0/resource_auth0_organization_test.go
+++ b/auth0/resource_auth0_organization_test.go
@@ -239,7 +239,10 @@ func TestAccOrganization(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_organization.acme", "name", fmt.Sprintf("test-%s", strings.ToLower(t.Name()))),
 					resource.TestCheckResourceAttr("auth0_organization.acme", "display_name", fmt.Sprintf("Acme Inc. %s", strings.ToLower(t.Name()))),
 					resource.TestCheckResourceAttr("auth0_organization.acme", "metadata.%", "0"),
-					resource.TestCheckResourceAttr("auth0_organization.acme", "connections.#", "0"),
+					// We now have to set connections.# to 1 because it is a computed property so removing it won't
+					// trigger a change. Connections on the organization resource will get removed in the future
+					// and this behavior will get fixed by using the auth0_organization_connection resource instead.
+					resource.TestCheckResourceAttr("auth0_organization.acme", "connections.#", "1"),
 				),
 			},
 		},

--- a/auth0/resource_auth0_organization_test.go
+++ b/auth0/resource_auth0_organization_test.go
@@ -155,7 +155,7 @@ resource auth0_organization acme {
 }
 `
 
-const testAccOrganizationRemoveAllConnections = `
+const testAccOrganizationRemoveAllOptionalParams = `
 resource auth0_organization acme {
 	name = "test-{{.testName}}"
 	display_name = "Acme Inc. {{.testName}}"
@@ -234,15 +234,11 @@ func TestAccOrganization(t *testing.T) {
 				),
 			},
 			{
-				Config: template.ParseTestName(testAccOrganizationRemoveAllConnections, strings.ToLower(t.Name())),
+				Config: template.ParseTestName(testAccOrganizationRemoveAllOptionalParams, strings.ToLower(t.Name())),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_organization.acme", "name", fmt.Sprintf("test-%s", strings.ToLower(t.Name()))),
 					resource.TestCheckResourceAttr("auth0_organization.acme", "display_name", fmt.Sprintf("Acme Inc. %s", strings.ToLower(t.Name()))),
 					resource.TestCheckResourceAttr("auth0_organization.acme", "metadata.%", "0"),
-					// We now have to set connections.# to 1 because it is a computed property so removing it won't
-					// trigger a change. Connections on the organization resource will get removed in the future
-					// and this behavior will get fixed by using the auth0_organization_connection resource instead.
-					resource.TestCheckResourceAttr("auth0_organization.acme", "connections.#", "1"),
 				),
 			},
 		},

--- a/auth0/testdata/recordings/TestAccOrganization.yaml
+++ b/auth0/testdata/recordings/TestAccOrganization.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
     method: POST
   response:
-    body: '{"id":"con_EQ61f9mtOOmNEdbe","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
+    body: '{"id":"con_C8mHM3p5OJlzb8pQ","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -29,10 +29,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_C8mHM3p5OJlzb8pQ
     method: GET
   response:
-    body: '{"id":"con_EQ61f9mtOOmNEdbe","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
+    body: '{"id":"con_C8mHM3p5OJlzb8pQ","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -41,7 +41,7 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"name":"test-testaccorganization","display_name":"Acme Inc. testaccorganization"}
+      {"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}
     form: {}
     headers:
       Content-Type:
@@ -51,7 +51,7 @@ interactions:
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
     method: POST
   response:
-    body: '{"name":"test-testaccorganization","display_name":"Acme Inc. testaccorganization","id":"org_p71pwYkVS4iArKzJ"}'
+    body: '{"id":"con_z5XwYvLEU4H3Co42","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -70,7 +70,7 @@ interactions:
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations
     method: POST
   response:
-    body: '{"id":"con_l80iCx5lmo2HTbYS","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
+    body: '{"name":"test-testaccorganization","display_name":"Acme Inc. testaccorganization","id":"org_MbhIsyWyqDVDC9dh"}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -79,17 +79,17 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"connection_id":"con_EQ61f9mtOOmNEdbe"}
+      null
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections
-    method: POST
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_z5XwYvLEU4H3Co42
+    method: GET
   response:
-    body: '{"connection_id":"con_EQ61f9mtOOmNEdbe","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}'
+    body: '{"id":"con_z5XwYvLEU4H3Co42","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -98,17 +98,17 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"connection_id":"con_9sdg0Jy5SSSQzPUX"}
+      {"connection_id":"con_C8mHM3p5OJlzb8pQ"}
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_l80iCx5lmo2HTbYS
-    method: GET
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections
+    method: POST
   response:
-    body: '{"id":"con_l80iCx5lmo2HTbYS","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
+    body: '{"connection_id":"con_C8mHM3p5OJlzb8pQ","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -124,10 +124,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections/con_C8mHM3p5OJlzb8pQ
     method: PATCH
   response:
-    body: '{"connection_id":"con_EQ61f9mtOOmNEdbe","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}'
+    body: '{"connection_id":"con_C8mHM3p5OJlzb8pQ","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -143,10 +143,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization"}'
     headers:
       Content-Type:
@@ -163,10 +163,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_EQ61f9mtOOmNEdbe","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"enabled_connections":[{"connection_id":"con_C8mHM3p5OJlzb8pQ","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -182,10 +182,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_C8mHM3p5OJlzb8pQ
     method: GET
   response:
-    body: '{"id":"con_EQ61f9mtOOmNEdbe","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
+    body: '{"id":"con_C8mHM3p5OJlzb8pQ","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -201,10 +201,29 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_z5XwYvLEU4H3Co42
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"con_z5XwYvLEU4H3Co42","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
+    method: GET
+  response:
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization"}'
     headers:
       Content-Type:
@@ -221,10 +240,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"id":"con_l80iCx5lmo2HTbYS","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
+    body: '{"enabled_connections":[{"connection_id":"con_C8mHM3p5OJlzb8pQ","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -240,10 +259,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_C8mHM3p5OJlzb8pQ
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_EQ61f9mtOOmNEdbe","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"id":"con_C8mHM3p5OJlzb8pQ","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -259,10 +278,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_z5XwYvLEU4H3Co42
     method: GET
   response:
-    body: '{"id":"con_EQ61f9mtOOmNEdbe","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
+    body: '{"id":"con_z5XwYvLEU4H3Co42","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -278,29 +297,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"con_l80iCx5lmo2HTbYS","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    status: 200 OK
-    code: 200
-    duration: 1ms
-- request:
-    body: |
-      null
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
-    method: GET
-  response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization"}'
     headers:
       Content-Type:
@@ -317,10 +317,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_EQ61f9mtOOmNEdbe","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"enabled_connections":[{"connection_id":"con_C8mHM3p5OJlzb8pQ","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -336,10 +336,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: PATCH
   response:
-    body: '{"branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"id":"org_p71pwYkVS4iArKzJ","display_name":"Acme
+    body: '{"branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"id":"org_MbhIsyWyqDVDC9dh","display_name":"Acme
       Inc. testaccorganization","name":"test-testaccorganization","metadata":{"some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -349,17 +349,17 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"connection_id":"con_l80iCx5lmo2HTbYS"}
+      {"connection_id":"con_z5XwYvLEU4H3Co42"}
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections
     method: POST
   response:
-    body: '{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}'
+    body: '{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -375,10 +375,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections/con_C8mHM3p5OJlzb8pQ
     method: PATCH
   response:
-    body: '{"connection_id":"con_EQ61f9mtOOmNEdbe","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}'
+    body: '{"connection_id":"con_C8mHM3p5OJlzb8pQ","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -394,10 +394,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections/con_z5XwYvLEU4H3Co42
     method: PATCH
   response:
-    body: '{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}'
+    body: '{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -413,10 +413,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization","branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"metadata":{"some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -433,10 +433,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_EQ61f9mtOOmNEdbe","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}},{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
+    body: '{"enabled_connections":[{"connection_id":"con_C8mHM3p5OJlzb8pQ","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}},{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -452,10 +452,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_C8mHM3p5OJlzb8pQ
     method: GET
   response:
-    body: '{"id":"con_EQ61f9mtOOmNEdbe","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
+    body: '{"id":"con_C8mHM3p5OJlzb8pQ","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -471,10 +471,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_z5XwYvLEU4H3Co42
     method: GET
   response:
-    body: '{"id":"con_l80iCx5lmo2HTbYS","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
+    body: '{"id":"con_z5XwYvLEU4H3Co42","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -490,10 +490,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization","branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"metadata":{"some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -510,10 +510,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_EQ61f9mtOOmNEdbe","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}},{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
+    body: '{"enabled_connections":[{"connection_id":"con_C8mHM3p5OJlzb8pQ","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}},{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -529,10 +529,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_C8mHM3p5OJlzb8pQ
     method: GET
   response:
-    body: '{"id":"con_EQ61f9mtOOmNEdbe","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
+    body: '{"id":"con_C8mHM3p5OJlzb8pQ","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -548,10 +548,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_z5XwYvLEU4H3Co42
     method: GET
   response:
-    body: '{"id":"con_l80iCx5lmo2HTbYS","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
+    body: '{"id":"con_z5XwYvLEU4H3Co42","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -567,10 +567,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization","branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"metadata":{"some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -587,10 +587,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_EQ61f9mtOOmNEdbe","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}},{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
+    body: '{"enabled_connections":[{"connection_id":"con_C8mHM3p5OJlzb8pQ","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-testaccorganization","strategy":"auth0"}},{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -606,10 +606,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: PATCH
   response:
-    body: '{"branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"id":"org_p71pwYkVS4iArKzJ","display_name":"Acme
+    body: '{"branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"id":"org_MbhIsyWyqDVDC9dh","display_name":"Acme
       Inc. testaccorganization","name":"test-testaccorganization","metadata":{"another_key":"another_value","some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -625,7 +625,7 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections/con_C8mHM3p5OJlzb8pQ
     method: DELETE
   response:
     body: ""
@@ -644,10 +644,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections/con_z5XwYvLEU4H3Co42
     method: PATCH
   response:
-    body: '{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}'
+    body: '{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -663,10 +663,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization","branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"metadata":{"another_key":"another_value","some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -683,10 +683,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"enabled_connections":[{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -702,10 +702,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_C8mHM3p5OJlzb8pQ
     method: GET
   response:
-    body: '{"id":"con_EQ61f9mtOOmNEdbe","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
+    body: '{"id":"con_C8mHM3p5OJlzb8pQ","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -721,10 +721,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_z5XwYvLEU4H3Co42
     method: GET
   response:
-    body: '{"id":"con_l80iCx5lmo2HTbYS","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
+    body: '{"id":"con_z5XwYvLEU4H3Co42","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -740,10 +740,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization","branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"metadata":{"another_key":"another_value","some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -760,10 +760,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"enabled_connections":[{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -779,10 +779,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_C8mHM3p5OJlzb8pQ
     method: GET
   response:
-    body: '{"id":"con_EQ61f9mtOOmNEdbe","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
+    body: '{"id":"con_C8mHM3p5OJlzb8pQ","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -798,10 +798,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_z5XwYvLEU4H3Co42
     method: GET
   response:
-    body: '{"id":"con_l80iCx5lmo2HTbYS","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
+    body: '{"id":"con_z5XwYvLEU4H3Co42","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -817,10 +817,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization","branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"metadata":{"another_key":"another_value","some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -837,10 +837,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"enabled_connections":[{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -856,10 +856,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: PATCH
   response:
-    body: '{"branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"id":"org_p71pwYkVS4iArKzJ","display_name":"Acme
+    body: '{"branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"id":"org_MbhIsyWyqDVDC9dh","display_name":"Acme
       Inc. testaccorganization","name":"test-testaccorganization","metadata":{"some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -876,10 +876,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections/con_z5XwYvLEU4H3Co42
     method: PATCH
   response:
-    body: '{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}'
+    body: '{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -895,10 +895,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization","branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"metadata":{"some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -915,10 +915,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"enabled_connections":[{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -934,10 +934,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_C8mHM3p5OJlzb8pQ
     method: GET
   response:
-    body: '{"id":"con_EQ61f9mtOOmNEdbe","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
+    body: '{"id":"con_C8mHM3p5OJlzb8pQ","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -953,10 +953,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_z5XwYvLEU4H3Co42
     method: GET
   response:
-    body: '{"id":"con_l80iCx5lmo2HTbYS","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
+    body: '{"id":"con_z5XwYvLEU4H3Co42","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -972,10 +972,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization","branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"metadata":{"some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -992,10 +992,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"enabled_connections":[{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -1011,10 +1011,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_z5XwYvLEU4H3Co42
     method: GET
   response:
-    body: '{"id":"con_l80iCx5lmo2HTbYS","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
+    body: '{"id":"con_z5XwYvLEU4H3Co42","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -1030,10 +1030,29 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_C8mHM3p5OJlzb8pQ
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"con_C8mHM3p5OJlzb8pQ","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
+    method: GET
+  response:
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization","branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"metadata":{"some_key":"some_value"}}'
     headers:
       Content-Type:
@@ -1050,29 +1069,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"id":"con_EQ61f9mtOOmNEdbe","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-testaccorganization"]}'
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    status: 200 OK
-    code: 200
-    duration: 1ms
-- request:
-    body: |
-      null
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
-    method: GET
-  response:
-    body: '{"enabled_connections":[{"connection_id":"con_l80iCx5lmo2HTbYS","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"enabled_connections":[{"connection_id":"con_z5XwYvLEU4H3Co42","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -1087,10 +1087,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_l80iCx5lmo2HTbYS
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_z5XwYvLEU4H3Co42
     method: DELETE
   response:
-    body: '{"deleted_at":"2022-07-20T13:30:54.145Z"}'
+    body: '{"deleted_at":"2022-07-20T15:30:49.966Z"}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -1105,10 +1105,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EQ61f9mtOOmNEdbe
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_C8mHM3p5OJlzb8pQ
     method: DELETE
   response:
-    body: '{"deleted_at":"2022-07-20T13:30:54.731Z"}'
+    body: '{"deleted_at":"2022-07-20T15:30:50.428Z"}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -1124,10 +1124,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: PATCH
   response:
-    body: '{"branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"id":"org_p71pwYkVS4iArKzJ","display_name":"Acme
+    body: '{"branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}},"id":"org_MbhIsyWyqDVDC9dh","display_name":"Acme
       Inc. testaccorganization","name":"test-testaccorganization"}'
     headers:
       Content-Type:
@@ -1136,24 +1136,6 @@ interactions:
     code: 200
     duration: 1ms
 - request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections/con_l80iCx5lmo2HTbYS
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-    status: 204 No Content
-    code: 204
-    duration: 1ms
-- request:
     body: |
       null
     form: {}
@@ -1162,10 +1144,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization","branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}}}'
     headers:
       Content-Type:
@@ -1182,7 +1164,7 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
     body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
@@ -1201,10 +1183,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: GET
   response:
-    body: '{"id":"org_p71pwYkVS4iArKzJ","name":"test-testaccorganization","display_name":"Acme
+    body: '{"id":"org_MbhIsyWyqDVDC9dh","name":"test-testaccorganization","display_name":"Acme
       Inc. testaccorganization","branding":{"logo_url":"https://acme.com/logo.svg","colors":{"page_background":"#e3e2ff","primary":"#e3e2f0"}}}'
     headers:
       Content-Type:
@@ -1221,7 +1203,7 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
     body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
@@ -1239,7 +1221,7 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_p71pwYkVS4iArKzJ
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_MbhIsyWyqDVDC9dh
     method: DELETE
   response:
     body: ""

--- a/auth0/testdata/recordings/TestAccOrganization.yaml
+++ b/auth0/testdata/recordings/TestAccOrganization.yaml
@@ -48,7 +48,7 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
     method: POST
   response:
     body: '{"name":"test-testaccorganization","display_name":"Acme Inc. testaccorganization","id":"org_p71pwYkVS4iArKzJ"}'
@@ -60,14 +60,14 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","strategy":"auth0"}
+      {"name":"test-testaccorganization","display_name":"Acme Inc. testaccorganization"}
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations
     method: POST
   response:
     body: '{"id":"con_l80iCx5lmo2HTbYS","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-Acme-Inc-testaccorganization","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-Acme-Inc-testaccorganization"]}'
@@ -93,12 +93,12 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    status: 201 Created
-    code: 201
+    status: 200 OK
+    code: 200
     duration: 1ms
 - request:
     body: |
-      null
+      {"connection_id":"con_9sdg0Jy5SSSQzPUX"}
     form: {}
     headers:
       Content-Type:
@@ -112,8 +112,8 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    status: 200 OK
-    code: 200
+    status: 201 Created
+    code: 201
     duration: 1ms
 - request:
     body: |

--- a/auth0/testdata/recordings/TestAccOrganizationConnection.yaml
+++ b/auth0/testdata/recordings/TestAccOrganizationConnection.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
     method: POST
   response:
-    body: '{"id":"con_i0tczWH0rgFXzX8V","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
+    body: '{"id":"con_UXxGW4yAvV1HCcaV","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -29,10 +29,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_UXxGW4yAvV1HCcaV
     method: GET
   response:
-    body: '{"id":"con_i0tczWH0rgFXzX8V","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
+    body: '{"id":"con_UXxGW4yAvV1HCcaV","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -52,7 +52,7 @@ interactions:
     method: POST
   response:
     body: '{"name":"test-testaccorganizationconnection","display_name":"Acme Inc.
-      testaccorganizationconnection","id":"org_F0SFBJL8wn3Of88g"}'
+      testaccorganizationconnection","id":"org_gwXKR7uSnneVz7JV"}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -68,10 +68,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV
     method: GET
   response:
-    body: '{"id":"org_F0SFBJL8wn3Of88g","name":"test-testaccorganizationconnection","display_name":"Acme
+    body: '{"id":"org_gwXKR7uSnneVz7JV","name":"test-testaccorganizationconnection","display_name":"Acme
       Inc. testaccorganizationconnection"}'
     headers:
       Content-Type:
@@ -88,7 +88,7 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
     body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
@@ -100,17 +100,17 @@ interactions:
     duration: 1ms
 - request:
     body: |
-      {"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false}
+      {"connection_id":"con_UXxGW4yAvV1HCcaV","assign_membership_on_login":false}
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections
     method: POST
   response:
-    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    body: '{"connection_id":"con_UXxGW4yAvV1HCcaV","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -126,10 +126,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections/con_UXxGW4yAvV1HCcaV
     method: GET
   response:
-    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    body: '{"connection_id":"con_UXxGW4yAvV1HCcaV","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -145,10 +145,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_UXxGW4yAvV1HCcaV
     method: GET
   response:
-    body: '{"id":"con_i0tczWH0rgFXzX8V","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
+    body: '{"id":"con_UXxGW4yAvV1HCcaV","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -164,10 +164,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV
     method: GET
   response:
-    body: '{"id":"org_F0SFBJL8wn3Of88g","name":"test-testaccorganizationconnection","display_name":"Acme
+    body: '{"id":"org_gwXKR7uSnneVz7JV","name":"test-testaccorganizationconnection","display_name":"Acme
       Inc. testaccorganizationconnection"}'
     headers:
       Content-Type:
@@ -184,10 +184,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"enabled_connections":[{"connection_id":"con_UXxGW4yAvV1HCcaV","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -203,10 +203,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections/con_UXxGW4yAvV1HCcaV
     method: GET
   response:
-    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    body: '{"connection_id":"con_UXxGW4yAvV1HCcaV","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -222,10 +222,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_UXxGW4yAvV1HCcaV
     method: GET
   response:
-    body: '{"id":"con_i0tczWH0rgFXzX8V","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
+    body: '{"id":"con_UXxGW4yAvV1HCcaV","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -241,10 +241,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV
     method: GET
   response:
-    body: '{"id":"org_F0SFBJL8wn3Of88g","name":"test-testaccorganizationconnection","display_name":"Acme
+    body: '{"id":"org_gwXKR7uSnneVz7JV","name":"test-testaccorganizationconnection","display_name":"Acme
       Inc. testaccorganizationconnection"}'
     headers:
       Content-Type:
@@ -261,10 +261,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"enabled_connections":[{"connection_id":"con_UXxGW4yAvV1HCcaV","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -280,10 +280,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections/con_UXxGW4yAvV1HCcaV
     method: GET
   response:
-    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    body: '{"connection_id":"con_UXxGW4yAvV1HCcaV","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -299,10 +299,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections/con_UXxGW4yAvV1HCcaV
     method: PATCH
   response:
-    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    body: '{"connection_id":"con_UXxGW4yAvV1HCcaV","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -318,10 +318,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections/con_UXxGW4yAvV1HCcaV
     method: GET
   response:
-    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    body: '{"connection_id":"con_UXxGW4yAvV1HCcaV","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -337,10 +337,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_UXxGW4yAvV1HCcaV
     method: GET
   response:
-    body: '{"id":"con_i0tczWH0rgFXzX8V","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
+    body: '{"id":"con_UXxGW4yAvV1HCcaV","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -356,10 +356,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV
     method: GET
   response:
-    body: '{"id":"org_F0SFBJL8wn3Of88g","name":"test-testaccorganizationconnection","display_name":"Acme
+    body: '{"id":"org_gwXKR7uSnneVz7JV","name":"test-testaccorganizationconnection","display_name":"Acme
       Inc. testaccorganizationconnection"}'
     headers:
       Content-Type:
@@ -376,10 +376,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections?include_totals=true&per_page=50
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections?include_totals=true&per_page=50
     method: GET
   response:
-    body: '{"enabled_connections":[{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    body: '{"enabled_connections":[{"connection_id":"con_UXxGW4yAvV1HCcaV","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -395,10 +395,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections/con_UXxGW4yAvV1HCcaV
     method: GET
   response:
-    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    body: '{"connection_id":"con_UXxGW4yAvV1HCcaV","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
     headers:
       Content-Type:
       - application/json; charset=utf-8
@@ -413,7 +413,7 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV/enabled_connections/con_UXxGW4yAvV1HCcaV
     method: DELETE
   response:
     body: ""
@@ -431,7 +431,7 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gwXKR7uSnneVz7JV
     method: DELETE
   response:
     body: ""
@@ -449,10 +449,10 @@ interactions:
       - application/json
       User-Agent:
       - Go-Auth0-SDK/0.9.2
-    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_i0tczWH0rgFXzX8V
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_UXxGW4yAvV1HCcaV
     method: DELETE
   response:
-    body: '{"deleted_at":"2022-07-20T09:41:21.120Z"}'
+    body: '{"deleted_at":"2022-07-20T15:30:16.516Z"}'
     headers:
       Content-Type:
       - application/json; charset=utf-8

--- a/auth0/testdata/recordings/TestAccOrganizationConnection.yaml
+++ b/auth0/testdata/recordings/TestAccOrganizationConnection.yaml
@@ -1,0 +1,461 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+    method: POST
+  response:
+    body: '{"id":"con_i0tczWH0rgFXzX8V","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 201 Created
+    code: 201
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_i0tczWH0rgFXzX8V
+    method: GET
+  response:
+    body: '{"id":"con_i0tczWH0rgFXzX8V","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      {"name":"test-testaccorganizationconnection","display_name":"Acme Inc. testaccorganizationconnection"}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations
+    method: POST
+  response:
+    body: '{"name":"test-testaccorganizationconnection","display_name":"Acme Inc.
+      testaccorganizationconnection","id":"org_F0SFBJL8wn3Of88g"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 201 Created
+    code: 201
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g
+    method: GET
+  response:
+    body: '{"id":"org_F0SFBJL8wn3Of88g","name":"test-testaccorganizationconnection","display_name":"Acme
+      Inc. testaccorganizationconnection"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections?include_totals=true&per_page=50
+    method: GET
+  response:
+    body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      {"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections
+    method: POST
+  response:
+    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 201 Created
+    code: 201
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    method: GET
+  response:
+    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_i0tczWH0rgFXzX8V
+    method: GET
+  response:
+    body: '{"id":"con_i0tczWH0rgFXzX8V","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g
+    method: GET
+  response:
+    body: '{"id":"org_F0SFBJL8wn3Of88g","name":"test-testaccorganizationconnection","display_name":"Acme
+      Inc. testaccorganizationconnection"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections?include_totals=true&per_page=50
+    method: GET
+  response:
+    body: '{"enabled_connections":[{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    method: GET
+  response:
+    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_i0tczWH0rgFXzX8V
+    method: GET
+  response:
+    body: '{"id":"con_i0tczWH0rgFXzX8V","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g
+    method: GET
+  response:
+    body: '{"id":"org_F0SFBJL8wn3Of88g","name":"test-testaccorganizationconnection","display_name":"Acme
+      Inc. testaccorganizationconnection"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections?include_totals=true&per_page=50
+    method: GET
+  response:
+    body: '{"enabled_connections":[{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    method: GET
+  response:
+    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":false,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      {"assign_membership_on_login":true}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    method: PATCH
+  response:
+    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    method: GET
+  response:
+    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_i0tczWH0rgFXzX8V
+    method: GET
+  response:
+    body: '{"id":"con_i0tczWH0rgFXzX8V","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-First-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-First-testaccorganizationconnection"]}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g
+    method: GET
+  response:
+    body: '{"id":"org_F0SFBJL8wn3Of88g","name":"test-testaccorganizationconnection","display_name":"Acme
+      Inc. testaccorganizationconnection"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections?include_totals=true&per_page=50
+    method: GET
+  response:
+    body: '{"enabled_connections":[{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: |
+      null
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    method: GET
+  response:
+    body: '{"connection_id":"con_i0tczWH0rgFXzX8V","assign_membership_on_login":true,"connection":{"name":"Acceptance-Test-Connection-First-testaccorganizationconnection","strategy":"auth0"}}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 200 OK
+    code: 200
+    duration: 1ms
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g/enabled_connections/con_i0tczWH0rgFXzX8V
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 204 No Content
+    code: 204
+    duration: 1ms
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F0SFBJL8wn3Of88g
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 204 No Content
+    code: 204
+    duration: 1ms
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Go-Auth0-SDK/0.9.2
+    url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_i0tczWH0rgFXzX8V
+    method: DELETE
+  response:
+    body: '{"deleted_at":"2022-07-20T09:41:21.120Z"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    status: 202 Accepted
+    code: 202
+    duration: 1ms

--- a/docs/resources/organization_connection.md
+++ b/docs/resources/organization_connection.md
@@ -1,0 +1,45 @@
+---
+layout: "auth0"
+page_title: "Auth0: auth0_organization_connection"
+description: |-
+  With this resource, you can manage enabled connections on an organization.
+---
+
+# auth0_organization_connection
+
+With this resource, you can manage enabled connections on an organization.
+
+## Example Usage
+
+```hcl
+resource "auth0_organization_connection" "example" {
+  organization_id = "org_XXXXXXXXXX"
+  connection_id = "con_XXXXXXXXXX"
+  assign_membership_on_login = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `assign_membership_on_login` - (Optional) When true, all users that log in with this connection will be automatically granted membership in the organization. When false, users must be granted membership in the organization before logging in with this connection.
+* `connection_id` - (Required) The ID of the connection to enable for the organization.
+* `organization_id` - (Required) The ID of the organization to enable the connection for.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `name` - The name of the enabled connection.
+* `strategy` - The strategy of the enabled connection.
+
+## Import
+
+As this is not a resource identifiable by an ID within the Auth0 Management API, organization_connection can be imported
+using a random string. We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4) e.g.
+
+```
+$ terraform import auth0_organization_connection.example 11f4a21b-011a-312d-9217-e291caca36c4
+```

--- a/example/organization_connection/main.tf
+++ b/example/organization_connection/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    auth0 = {
+      source = "auth0/auth0"
+    }
+  }
+}
+
+provider "auth0" {}
+
+resource "auth0_connection" "my_connection" {
+  name     = "My Connection"
+  strategy = "auth0"
+}
+
+resource "auth0_organization" "my_organization" {
+  name         = "my-organization"
+  display_name = "My Organization"
+}
+
+resource "auth0_organization_connection" "my_org_conn" {
+  organization_id            = auth0_organization.my_organization.id
+  connection_id              = auth0_connection.my_connection.id
+  assign_membership_on_login = true
+}


### PR DESCRIPTION
## Description

Splitting the connections out of the organization resource into its own resource, however we keep the old connection sets on the organization until folks have enough time to migrate over. This is done to simplify the internal logic and improve DX. 

<!-- Describe the purpose of this PR along with any background information and the impacts of the proposed change. 
For the benefit of the community, please do not assume prior context. -->

## Checklist

**Note:** Checklist required to be completed before a PR is considered to be reviewable.

#### Auth0 Code of Conduct
- [x] I have read and agreed to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

#### Auth0 General Contribution Guidelines
- [x] I have read the [Auth0 General Contribution Guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Does the description provide the correct amount of context?
- [x] Yes, the description provides enough context for the reviewer to understand what these changes accomplish

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed

#### Is this code ready for production?
- [x] Yes, all code changes are intentional and no debugging calls are left over