### PR TITLE
Fix issue with importing auth0_organization_connection

### DIFF
--- a/docs/resources/organization_connection.md
+++ b/docs/resources/organization_connection.md
@@ -51,11 +51,9 @@ resource "auth0_organization_connection" "my_org_conn" {
 Import is supported using the following syntax:
 
 ```shell
-# As this is not a resource identifiable by an ID within the Auth0 Management API,
-# organization connections can be imported using a random string.
-#
-# We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
+# This resource can be imported by specifying the
+# organization ID and connection ID separated by ":".
 #
 # Example:
-terraform import auth0_organization_connection.my_org_conn 11f4a21b-011a-312d-9217-e291caca36c4
+terraform import auth0_organization_connection.my_org_conn org_XXXXX:con_XXXXX
 ```

--- a/examples/resources/auth0_organization_connection/import.sh
+++ b/examples/resources/auth0_organization_connection/import.sh
@@ -1,7 +1,5 @@
-# As this is not a resource identifiable by an ID within the Auth0 Management API,
-# organization connections can be imported using a random string.
-#
-# We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
+# This resource can be imported by specifying the
+# organization ID and connection ID separated by ":".
 #
 # Example:
-terraform import auth0_organization_connection.my_org_conn 11f4a21b-011a-312d-9217-e291caca36c4
+terraform import auth0_organization_connection.my_org_conn org_XXXXX:con_XXXXX

--- a/internal/provider/resource_auth0_organization_connection_test.go
+++ b/internal/provider/resource_auth0_organization_connection_test.go
@@ -1,10 +1,14 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/auth0/terraform-provider-auth0/internal/template"
 )
@@ -89,4 +93,55 @@ func TestAccOrganizationConnection(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestImportOrganizationConnection(t *testing.T) {
+	var testCases = []struct {
+		testName               string
+		givenID                string
+		expectedOrganizationID string
+		expectedConnectionID   string
+		expectedError          error
+	}{
+		{
+			testName:               "it correctly parses the resource ID",
+			givenID:                "org_1234:conn_5678",
+			expectedOrganizationID: "org_1234",
+			expectedConnectionID:   "conn_5678",
+		},
+		{
+			testName:      "it fails when the given ID is empty",
+			givenID:       "",
+			expectedError: fmt.Errorf("ID cannot be empty"),
+		},
+		{
+			testName:      "it fails when the given ID does not have \":\" as a separator",
+			givenID:       "org_1234conn_5678",
+			expectedError: fmt.Errorf("ID must be formated as <organizationID>:<connectionID>"),
+		},
+		{
+			testName:      "it fails when the given ID has too many separators",
+			givenID:       "org_1234:conn_5678:",
+			expectedError: fmt.Errorf("ID must be formated as <organizationID>:<connectionID>"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			data := schema.TestResourceDataRaw(t, newOrganizationConnection().Schema, nil)
+			data.SetId(testCase.givenID)
+
+			actualData, err := importOrganizationConnection(context.Background(), data, nil)
+
+			if testCase.expectedError != nil {
+				assert.EqualError(t, err, testCase.expectedError.Error())
+				assert.Nil(t, actualData)
+				return
+			}
+
+			assert.Equal(t, actualData[0].Get("organization_id").(string), testCase.expectedOrganizationID)
+			assert.Equal(t, actualData[0].Get("connection_id").(string), testCase.expectedConnectionID)
+			assert.NotEqual(t, actualData[0].Id(), testCase.givenID)
+		})
+	}
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes


Raised in https://github.com/auth0/terraform-provider-auth0/issues/299, it appears that we were not able to import correctly the org_conn resource due to the fact that importing doesn't have access to the underlying terraform config, so we can't reuse the org ID and conn ID from there, we need to parse it from the ID and then pass it to the read func so it can find a value when doing `data.Get()`. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
