### PR TITLE
Prevent erasing connection.options.configuration by mistake

### DIFF
--- a/internal/provider/resource_auth0_connection.go
+++ b/internal/provider/resource_auth0_connection.go
@@ -237,7 +237,7 @@ var connectionSchema = map[string]*schema.Schema{
 				},
 				"configuration": {
 					Type:      schema.TypeMap,
-					Elem:      &schema.Schema{Type: schema.TypeString},
+					Elem:      schema.TypeString,
 					Sensitive: true,
 					Optional:  true,
 					Description: "A case-sensitive map of key value pairs used as configuration variables " +


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

As noted in https://github.com/auth0/terraform-provider-auth0/issues/251, out of bound configuration changes are unreported and this unfortunately can cause destructive behavior if we apply the config without checking for unmanaged configuration secrets. These get encrypted and the API will return the values encrypted and not the same as we specify in the config so we can only check for unmanaged keys but not the actual values. We now send an error to the user blocking applying if we find unmanaged config keys. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
