### PR TITLE
Fix how we expand client.addons.samlp

### DIFF
--- a/internal/provider/resource_auth0_client.go
+++ b/internal/provider/resource_auth0_client.go
@@ -886,28 +886,70 @@ func expandClient(d *schema.ResourceData) *management.Client {
 		}
 
 		List(d, "samlp").Elem(func(d ResourceData) {
-			client.Addons["samlp"] = map[string]interface{}{
-				"audience":                       String(d, "audience"),
-				"authnContextClassRef":           String(d, "authn_context_class_ref"),
-				"binding":                        String(d, "binding"),
-				"signingCert":                    String(d, "signing_cert"),
-				"createUpnClaim":                 Bool(d, "create_upn_claim"),
-				"destination":                    String(d, "destination"),
-				"digestAlgorithm":                String(d, "digest_algorithm"),
-				"includeAttributeNameFormat":     Bool(d, "include_attribute_name_format"),
-				"lifetimeInSeconds":              Int(d, "lifetime_in_seconds"),
-				"mapIdentities":                  Bool(d, "map_identities"),
-				"mappings":                       Map(d, "mappings"),
-				"mapUnknownClaimsAsIs":           Bool(d, "map_unknown_claims_as_is"),
-				"nameIdentifierFormat":           String(d, "name_identifier_format"),
-				"nameIdentifierProbes":           Slice(d, "name_identifier_probes"),
-				"passthroughClaimsWithNoMapping": Bool(d, "passthrough_claims_with_no_mapping"),
-				"recipient":                      String(d, "recipient"),
-				"signatureAlgorithm":             String(d, "signature_algorithm"),
-				"signResponse":                   Bool(d, "sign_response"),
-				"typedAttributes":                Bool(d, "typed_attributes"),
-				"logout":                         mapFromState(Map(d, "logout")),
+			samlp := make(map[string]interface{})
+
+			if audience := String(d, "audience"); audience != nil && *audience != "" {
+				samlp["audience"] = audience
 			}
+			if authnContextClassRef := String(d, "authn_context_class_ref"); authnContextClassRef != nil && *authnContextClassRef != "" {
+				samlp["authnContextClassRef"] = authnContextClassRef
+			}
+			if binding := String(d, "binding"); binding != nil && *binding != "" {
+				samlp["binding"] = binding
+			}
+			if signingCert := String(d, "signing_cert"); signingCert != nil && *signingCert != "" {
+				samlp["signingCert"] = signingCert
+			}
+			if destination := String(d, "destination"); destination != nil && *destination != "" {
+				samlp["destination"] = destination
+			}
+			if digestAlgorithm := String(d, "digest_algorithm"); digestAlgorithm != nil && *digestAlgorithm != "" {
+				samlp["digestAlgorithm"] = digestAlgorithm
+			}
+			if nameIdentifierFormat := String(d, "name_identifier_format"); nameIdentifierFormat != nil && *nameIdentifierFormat != "" {
+				samlp["nameIdentifierFormat"] = nameIdentifierFormat
+			}
+			if recipient := String(d, "recipient"); recipient != nil && *recipient != "" {
+				samlp["recipient"] = recipient
+			}
+			if signatureAlgorithm := String(d, "signature_algorithm"); signatureAlgorithm != nil && *signatureAlgorithm != "" {
+				samlp["signatureAlgorithm"] = signatureAlgorithm
+			}
+			if createUpnClaim := Bool(d, "create_upn_claim"); createUpnClaim != nil {
+				samlp["createUpnClaim"] = createUpnClaim
+			}
+			if includeAttributeNameFormat := Bool(d, "include_attribute_name_format"); includeAttributeNameFormat != nil {
+				samlp["includeAttributeNameFormat"] = includeAttributeNameFormat
+			}
+			if mapIdentities := Bool(d, "map_identities"); mapIdentities != nil {
+				samlp["mapIdentities"] = mapIdentities
+			}
+			if mapUnknownClaimsAsIs := Bool(d, "map_unknown_claims_as_is"); mapUnknownClaimsAsIs != nil {
+				samlp["mapUnknownClaimsAsIs"] = mapUnknownClaimsAsIs
+			}
+			if passthroughClaimsWithNoMapping := Bool(d, "passthrough_claims_with_no_mapping"); passthroughClaimsWithNoMapping != nil {
+				samlp["passthroughClaimsWithNoMapping"] = passthroughClaimsWithNoMapping
+			}
+			if signResponse := Bool(d, "sign_response"); signResponse != nil {
+				samlp["signResponse"] = signResponse
+			}
+			if typedAttributes := Bool(d, "typed_attributes"); typedAttributes != nil {
+				samlp["typedAttributes"] = typedAttributes
+			}
+			if lifetimeInSeconds := Int(d, "lifetime_in_seconds"); lifetimeInSeconds != nil {
+				samlp["lifetimeInSeconds"] = lifetimeInSeconds
+			}
+			if mappings := Map(d, "mappings"); mappings != nil {
+				samlp["mappings"] = mappings
+			}
+			if nameIdentifierProbes := Slice(d, "name_identifier_probes"); nameIdentifierProbes != nil {
+				samlp["nameIdentifierProbes"] = nameIdentifierProbes
+			}
+			if logout := mapFromState(Map(d, "logout")); logout != nil {
+				samlp["logout"] = logout
+			}
+
+			client.Addons["samlp"] = samlp
 		})
 	})
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This fixes https://github.com/auth0/terraform-provider-auth0/issues/314 by making sure we don't send null to the API in case some fields are not set.

The ideal solution would involve changes in the Go SDK as well by adding types for all the possible Addons instead of having the field as map[string]interface{}, so we could add omitempty json tags. For now this is an intermediary fix before applying these changes to the go SDK.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
