### PR TITLE
Change error level to Warning

### DIFF
--- a/internal/provider/structure_auth0_connection.go
+++ b/internal/provider/structure_auth0_connection.go
@@ -154,7 +154,7 @@ func checkForUnmanagedConfigurationSecrets(configFromTF, configFromAPI map[strin
 	for key := range configFromAPI {
 		if _, ok := configFromTF[key]; !ok {
 			warnings = append(warnings, diag.Diagnostic{
-				Severity: diag.Error,
+				Severity: diag.Warning,
 				Summary:  "Unmanaged Configuration Secret",
 				Detail: fmt.Sprintf("Detected a configuration secret not managed though terraform: %q. "+
 					"If you proceed, this configuration secret will get deleted. It is required to "+

--- a/internal/provider/structure_auth0_connection_test.go
+++ b/internal/provider/structure_auth0_connection_test.go
@@ -87,7 +87,7 @@ func TestCheckForUnmanagedConfigurationSecrets(t *testing.T) {
 			},
 			expectedDiagnostics: diag.Diagnostics{
 				diag.Diagnostic{
-					Severity:      diag.Error,
+					Severity:      diag.Warning,
 					Summary:       "Unmanaged Configuration Secret",
 					Detail:        "Detected a configuration secret not managed though terraform: \"anotherFoo\". If you proceed, this configuration secret will get deleted. It is required to add this configuration secret to your custom database settings to prevent unintentionally destructive results.",
 					AttributePath: cty.Path{cty.GetAttrStep{Name: "options.configuration"}},


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- An error in connection resource is currently set at error level Error, instead of Warning which is what it seems to me from the description.
- This also allows me to import an existing connection with configuration secrets into my terraform state.

### 📚 References

See https://github.com/auth0/terraform-provider-auth0/issues/323#issuecomment-1249872095 for a use case where this completely prevents work.

### 🔬 Testing

- Build the module locally and ran import using it, worked fine.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
