### PR TITLE
Add custom_client_ip_header and tls_policy to custom_domain resource

### DIFF
--- a/docs/resources/custom_domain.md
+++ b/docs/resources/custom_domain.md
@@ -25,6 +25,11 @@ resource "auth0_custom_domain" "my_custom_domain" {
 - `domain` (String) Name of the custom domain.
 - `type` (String) Provisioning type for the custom domain. Options include `auth0_managed_certs` and `self_managed_certs`.
 
+### Optional
+
+- `custom_client_ip_header` (String) The HTTP header to fetch the client's IP address. Cannot be set on auth0_managed domains.
+- `tls_policy` (String) TLS policy for the custom domain. Available options are: `compatible` or `recommended`. Compatible includes TLS 1.0, 1.1, 1.2, and recommended only includes TLS 1.2. Cannot be set on self_managed domains.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/internal/provider/resource_auth0_custom_domain_test.go
+++ b/internal/provider/resource_auth0_custom_domain_test.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 	"testing"
 
@@ -47,35 +46,135 @@ func init() {
 	})
 }
 
-func TestAccCustomDomain(t *testing.T) {
-	if os.Getenv("AUTH0_DOMAIN") != recorder.RecordingsDomain {
-		t.Skip()
-	}
+const testAccCreateSelfManagedCustomDomain = `
+resource "auth0_custom_domain" "my_custom_domain" {
+	domain = "{{.testName}}.auth.terraform-provider-auth0.com"
+	type = "self_managed_certs"
+}
+`
 
+const testAccUpdateSelfManagedCustomDomain = `
+resource "auth0_custom_domain" "my_custom_domain" {
+	domain = "{{.testName}}.auth.terraform-provider-auth0.com"
+	type = "self_managed_certs"
+	custom_client_ip_header = "true-client-ip"
+}
+`
+
+const testAccUpdateSelfManagedCustomDomainWithEmptyClientIPHeader = `
+resource "auth0_custom_domain" "my_custom_domain" {
+	domain = "{{.testName}}.auth.terraform-provider-auth0.com"
+	type = "self_managed_certs"
+	custom_client_ip_header = ""
+}
+`
+
+const testAccCreateAuth0ManagedCustomDomain = `
+resource "auth0_custom_domain" "my_custom_domain" {
+	domain = "{{.testName}}.auth.terraform-provider-auth0.com"
+	type = "auth0_managed_certs"
+}
+`
+
+const testAccUpdateAuth0ManagedCustomDomain = `
+resource "auth0_custom_domain" "my_custom_domain" {
+	domain = "{{.testName}}.auth.terraform-provider-auth0.com"
+	type = "auth0_managed_certs"
+	tls_policy = "recommended"
+}
+`
+
+func TestAccCustomDomain(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testProviders(httpRecorder),
 		Steps: []resource.TestStep{
 			{
-				Config: template.ParseTestName(testAccCustomDomain, strings.ToLower(t.Name())),
+				Config: template.ParseTestName(testAccCreateSelfManagedCustomDomain, strings.ToLower(t.Name())),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"auth0_custom_domain.my_custom_domain",
 						"domain",
-						fmt.Sprintf("%s.auth.uat.terraform-provider-auth0.com", strings.ToLower(t.Name())),
+						fmt.Sprintf("%s.auth.terraform-provider-auth0.com", strings.ToLower(t.Name())),
+					),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "type", "self_managed_certs"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "status", "pending_verification"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "origin_domain_name", ""),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "primary", "true"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "verification.#", "1"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "custom_client_ip_header", ""),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "tls_policy", ""),
+				),
+			},
+			{
+				Config: template.ParseTestName(testAccUpdateSelfManagedCustomDomain, strings.ToLower(t.Name())),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"auth0_custom_domain.my_custom_domain",
+						"domain",
+						fmt.Sprintf("%s.auth.terraform-provider-auth0.com", strings.ToLower(t.Name())),
+					),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "type", "self_managed_certs"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "status", "pending_verification"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "origin_domain_name", ""),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "primary", "true"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "verification.#", "1"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "custom_client_ip_header", "true-client-ip"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "tls_policy", ""),
+				),
+			},
+			{
+				Config: template.ParseTestName(testAccUpdateSelfManagedCustomDomainWithEmptyClientIPHeader, strings.ToLower(t.Name())),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"auth0_custom_domain.my_custom_domain",
+						"domain",
+						fmt.Sprintf("%s.auth.terraform-provider-auth0.com", strings.ToLower(t.Name())),
+					),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "type", "self_managed_certs"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "status", "pending_verification"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "origin_domain_name", ""),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "primary", "true"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "verification.#", "1"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "custom_client_ip_header", ""),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "tls_policy", ""),
+				),
+			},
+			{
+				Config: template.ParseTestName(testAccCreateAuth0ManagedCustomDomain, strings.ToLower(t.Name())),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"auth0_custom_domain.my_custom_domain",
+						"domain",
+						fmt.Sprintf("%s.auth.terraform-provider-auth0.com", strings.ToLower(t.Name())),
 					),
 					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "type", "auth0_managed_certs"),
 					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "status", "pending_verification"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "origin_domain_name", ""),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "primary", "true"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "verification.#", "1"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "custom_client_ip_header", ""),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "tls_policy", "recommended"),
+				),
+			},
+			{
+				Config: template.ParseTestName(testAccUpdateAuth0ManagedCustomDomain, strings.ToLower(t.Name())),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"auth0_custom_domain.my_custom_domain",
+						"domain",
+						fmt.Sprintf("%s.auth.terraform-provider-auth0.com", strings.ToLower(t.Name())),
+					),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "type", "auth0_managed_certs"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "status", "pending_verification"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "origin_domain_name", ""),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "primary", "true"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "verification.#", "1"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "custom_client_ip_header", ""),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "tls_policy", "recommended"),
 				),
 			},
 		},
 	})
 }
-
-const testAccCustomDomain = `
-resource "auth0_custom_domain" "my_custom_domain" {
-  domain = "{{.testName}}.auth.uat.terraform-provider-auth0.com"
-  type = "auth0_managed_certs"
-}
-`

--- a/test/data/recordings/TestAccCustomDomain.yaml
+++ b/test/data/recordings/TestAccCustomDomain.yaml
@@ -1,147 +1,685 @@
 ---
 version: 2
 interactions:
-  - id: 0
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
-      content_length: 100
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        {"domain":"testacccustomdomain.auth.uat.terraform-provider-auth0.com","type":"auth0_managed_certs"}
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/0.10.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains
-      method: POST
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: false
-      body: '{"custom_domain_id":"cd_qzstHJURrWCodlBe","domain":"testacccustomdomain.auth.uat.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"terraform-provider-auth0-dev-cd-qzsthjurrwcodlbe.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 201 Created
-      code: 201
-      duration: 1ms
-  - id: 1
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
-      content_length: 100
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        null
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/0.10.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_qzstHJURrWCodlBe
-      method: GET
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: false
-      body: '{"custom_domain_id":"cd_qzstHJURrWCodlBe","domain":"testacccustomdomain.auth.uat.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"terraform-provider-auth0-dev-cd-qzsthjurrwcodlbe.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 200 OK
-      code: 200
-      duration: 1ms
-  - id: 2
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
-      content_length: 100
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        null
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/0.10.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_qzstHJURrWCodlBe
-      method: GET
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: false
-      body: '{"custom_domain_id":"cd_qzstHJURrWCodlBe","domain":"testacccustomdomain.auth.uat.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"terraform-provider-auth0-dev-cd-qzsthjurrwcodlbe.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 200 OK
-      code: 200
-      duration: 1ms
-  - id: 3
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
-      content_length: 100
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        null
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/0.10.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_qzstHJURrWCodlBe
-      method: DELETE
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: false
-      body: ''
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 204 No Content
-      code: 204
-      duration: 1ms
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 95
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"domain":"testacccustomdomain.auth.terraform-provider-auth0.com","type":"self_managed_certs"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 390
+        uncompressed: false
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":null}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":null}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":null}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":null}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 45
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"custom_client_ip_header":"true-client-ip"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":"true-client-ip"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":"true-client-ip"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":"true-client-ip"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":"true-client-ip"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 31
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"custom_client_ip_header":""}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":""}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":""}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":""}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_4NComvppXPHyHQoj","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"self_managed_certs","verification":{"methods":[{"name":"txt","record":"14873719-a639-43d0-9fe9-773c2b956f2a","domain":"_cf-custom-hostname.testacccustomdomain.auth.terraform-provider-auth0.com"}]},"custom_client_ip_header":""}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_4NComvppXPHyHQoj
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 96
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"domain":"testacccustomdomain.auth.terraform-provider-auth0.com","type":"auth0_managed_certs"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 323
+        uncompressed: false
+        body: '{"custom_domain_id":"cd_5ZpinEMdthgSAg3Q","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"terraform-provider-auth0-dev-cd-5zpinemdthgsag3q.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_5ZpinEMdthgSAg3Q
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_5ZpinEMdthgSAg3Q","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"terraform-provider-auth0-dev-cd-5zpinemdthgsag3q.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_5ZpinEMdthgSAg3Q
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_5ZpinEMdthgSAg3Q","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"terraform-provider-auth0-dev-cd-5zpinemdthgsag3q.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_5ZpinEMdthgSAg3Q
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_5ZpinEMdthgSAg3Q","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"terraform-provider-auth0-dev-cd-5zpinemdthgsag3q.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_5ZpinEMdthgSAg3Q
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"custom_domain_id":"cd_5ZpinEMdthgSAg3Q","domain":"testacccustomdomain.auth.terraform-provider-auth0.com","primary":true,"status":"pending_verification","type":"auth0_managed_certs","verification":{"methods":[{"name":"cname","record":"terraform-provider-auth0-dev-cd-5zpinemdthgsag3q.edge.tenants.eu.auth0.com"}]},"tls_policy":"recommended"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.11.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/custom-domains/cd_5ZpinEMdthgSAg3Q
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 1ms


### PR DESCRIPTION
### 🔧 Changes

This PR is exposing the `custom_client_ip_header` [option](https://auth0.com/docs/api/management/v2/#!/Custom_Domains/post_custom_domains) for custom domains

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
