### PR TITLE
Ignore 404 error when fetching universal login content in branding

### DIFF
--- a/test/data/recordings/TestAccBranding.yaml
+++ b/test/data/recordings/TestAccBranding.yaml
@@ -6,21 +6,21 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 99
+      content_length: 100
       transfer_encoding: [ ]
       trailer: { }
       host: terraform-provider-auth0-dev.eu.auth0.com
       remote_addr: ""
       request_uri: ""
       body: |
-        {"favicon_url":"https://mycompany.org/favicon.ico","logo_url":"https://mycompany.org/v1/logo.png"}
+        {"flags":{"enable_custom_domain_in_emails":true},"session_lifetime":168,"idle_session_lifetime":72}
       form: { }
       headers:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: PATCH
     response:
       proto: HTTP/2.0
@@ -30,7 +30,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"},"is_custom_theme_set":false,"is_custom_template_set":false},"session_cookie":{"mode":"persistent"}}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -55,8 +55,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: GET
     response:
       proto: HTTP/2.0
@@ -66,7 +66,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -78,22 +78,22 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 5
+      content_length: 99
       transfer_encoding: [ ]
       trailer: { }
       host: terraform-provider-auth0-dev.eu.auth0.com
       remote_addr: ""
       request_uri: ""
       body: |
-        null
+        {"favicon_url":"https://mycompany.org/favicon.ico","logo_url":"https://mycompany.org/v1/logo.png"}
       form: { }
       headers:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
-      method: GET
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+      method: PATCH
     response:
       proto: HTTP/2.0
       proto_major: 2
@@ -102,7 +102,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -127,7 +127,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.11.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
       method: GET
     response:
@@ -138,7 +138,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -163,7 +163,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.11.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: GET
     response:
@@ -174,7 +174,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -199,7 +199,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.11.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
       method: GET
     response:
@@ -210,7 +210,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -235,7 +235,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.11.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: GET
     response:
@@ -246,7 +246,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -258,22 +258,22 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 213
+      content_length: 5
       transfer_encoding: [ ]
       trailer: { }
       host: terraform-provider-auth0-dev.eu.auth0.com
       remote_addr: ""
       request_uri: ""
       body: |
-        {"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","logo_url":"https://mycompany.org/v2/logo.png","font":{"url":"https://mycompany.org/font/myfont.ttf"}}
+        null
       form: { }
       headers:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.11.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
-      method: PATCH
+      method: GET
     response:
       proto: HTTP/2.0
       proto_major: 2
@@ -282,7 +282,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -294,36 +294,36 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 165
+      content_length: 74
       transfer_encoding: [ ]
       trailer: { }
       host: terraform-provider-auth0-dev.eu.auth0.com
       remote_addr: ""
       request_uri: ""
       body: |
-        "\u003c!DOCTYPE html\u003e\u003chtml\u003e\u003chead\u003e{%- auth0:head -%}\u003c/head\u003e\u003cbody\u003e{%- auth0:widget -%}\u003c/body\u003e\u003c/html\u003e"
+        {"flags":{"enable_custom_domain_in_emails":false},"session_lifetime":168}
       form: { }
       headers:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
-      method: PUT
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: PATCH
     response:
       proto: HTTP/2.0
       proto_major: 2
       proto_minor: 0
       transfer_encoding: [ ]
       trailer: { }
-      content_length: 0
-      uncompressed: false
-      body: ""
+      content_length: -1
+      uncompressed: true
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"},"is_custom_theme_set":false,"is_custom_template_set":false},"session_cookie":{"mode":"persistent"}}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
-      status: 204 No Content
-      code: 204
+      status: 200 OK
+      code: 200
       duration: 1ms
   - id: 9
     request:
@@ -343,8 +343,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: GET
     response:
       proto: HTTP/2.0
@@ -354,7 +354,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -366,22 +366,22 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 5
+      content_length: 211
       transfer_encoding: [ ]
       trailer: { }
       host: terraform-provider-auth0-dev.eu.auth0.com
       remote_addr: ""
       request_uri: ""
       body: |
-        null
+        {"colors":{"primary":"#0059d6","page_background":"#00FF00"},"favicon_url":"https://mycompany.org/favicon.ico","logo_url":"https://mycompany.org/v2/logo.png","font":{"url":"https://example.com/font/myfont.ttf"}}
       form: { }
       headers:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
-      method: GET
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+      method: PATCH
     response:
       proto: HTTP/2.0
       proto_major: 2
@@ -390,7 +390,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      body: '{"colors":{"primary":"#0059d6","page_background":"#00FF00"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://example.com/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -402,36 +402,36 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 5
+      content_length: 246
       transfer_encoding: [ ]
       trailer: { }
       host: terraform-provider-auth0-dev.eu.auth0.com
       remote_addr: ""
       request_uri: ""
       body: |
-        null
+        "\u003c!DOCTYPE html\u003e\u003chtml\u003e\u003chead\u003e{%- auth0:head -%}\u003c/head\u003eThis is getting updated but it should not be read cuz the tenant flag is disabled\u003cbody\u003e{%- auth0:widget -%}\u003c/body\u003e\u003c/html\u003e"
       form: { }
       headers:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
-      method: GET
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
+      method: PUT
     response:
       proto: HTTP/2.0
       proto_major: 2
       proto_minor: 0
       transfer_encoding: [ ]
       trailer: { }
-      content_length: -1
-      uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
+      content_length: 2
+      uncompressed: false
+      body: '{}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
-      status: 200 OK
-      code: 200
+      status: 201 Created
+      code: 201
       duration: 1ms
   - id: 12
     request:
@@ -451,8 +451,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
       method: GET
     response:
       proto: HTTP/2.0
@@ -462,7 +462,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      body: '{"colors":{"primary":"#0059d6","page_background":"#00FF00"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://example.com/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -487,8 +487,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: GET
     response:
       proto: HTTP/2.0
@@ -498,7 +498,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#00FF00"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -523,7 +523,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.11.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: GET
     response:
@@ -534,7 +534,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#00FF00"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -546,22 +546,22 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 185
+      content_length: 5
       transfer_encoding: [ ]
       trailer: { }
       host: terraform-provider-auth0-dev.eu.auth0.com
       remote_addr: ""
       request_uri: ""
       body: |
-        {"colors":{"primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","logo_url":"https://mycompany.org/v3/logo.png","font":{"url":"https://mycompany.org/font/myfont.ttf"}}
+        null
       form: { }
       headers:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.11.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
-      method: PATCH
+      method: GET
     response:
       proto: HTTP/2.0
       proto_major: 2
@@ -570,7 +570,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v3/logo.png"}'
+      body: '{"colors":{"primary":"#0059d6","page_background":"#00FF00"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://example.com/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -595,8 +595,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: GET
     response:
       proto: HTTP/2.0
@@ -606,7 +606,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v3/logo.png"}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#00FF00"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -631,8 +631,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
       method: GET
     response:
       proto: HTTP/2.0
@@ -642,7 +642,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v3/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      body: '{"colors":{"primary":"#0059d6","page_background":"#00FF00"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://example.com/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -654,22 +654,22 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 5
+      content_length: 73
       transfer_encoding: [ ]
       trailer: { }
       host: terraform-provider-auth0-dev.eu.auth0.com
       remote_addr: ""
       request_uri: ""
       body: |
-        null
+        {"flags":{"enable_custom_domain_in_emails":true},"session_lifetime":168}
       form: { }
       headers:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
-      method: GET
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: PATCH
     response:
       proto: HTTP/2.0
       proto_major: 2
@@ -678,7 +678,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v3/logo.png"}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#00FF00"},"is_custom_theme_set":false,"is_custom_template_set":true},"session_cookie":{"mode":"persistent"}}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -703,7 +703,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.11.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: GET
     response:
@@ -714,7 +714,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v3/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#00FF00"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -726,22 +726,22 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 5
+      content_length: 213
       transfer_encoding: [ ]
       trailer: { }
       host: terraform-provider-auth0-dev.eu.auth0.com
       remote_addr: ""
       request_uri: ""
       body: |
-        null
+        {"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","logo_url":"https://mycompany.org/v2/logo.png","font":{"url":"https://mycompany.org/font/myfont.ttf"}}
       form: { }
       headers:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.11.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
-      method: GET
+      method: PATCH
     response:
       proto: HTTP/2.0
       proto_major: 2
@@ -750,7 +750,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v3/logo.png"}'
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -762,6 +762,42 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
+      content_length: 165
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        "\u003c!DOCTYPE html\u003e\u003chtml\u003e\u003chead\u003e{%- auth0:head -%}\u003c/head\u003e\u003cbody\u003e{%- auth0:widget -%}\u003c/body\u003e\u003c/html\u003e"
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
+      method: PUT
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: 0
+      uncompressed: false
+      body: ""
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 204 No Content
+      code: 204
+      duration: 1ms
+  - id: 22
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
       content_length: 5
       transfer_encoding: [ ]
       trailer: { }
@@ -775,8 +811,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
       method: GET
     response:
       proto: HTTP/2.0
@@ -786,43 +822,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v3/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 200 OK
-      code: 200
-      duration: 1ms
-  - id: 22
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
-      content_length: 99
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        {"favicon_url":"https://mycompany.org/favicon.ico","logo_url":"https://mycompany.org/v1/logo.png"}
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
-      method: PATCH
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -847,8 +847,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: GET
     response:
       proto: HTTP/2.0
@@ -858,7 +858,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -883,8 +883,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
       method: GET
     response:
       proto: HTTP/2.0
@@ -894,7 +894,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      body: '{"body":"<!DOCTYPE html><html><head>{%- auth0:head -%}</head><body>{%- auth0:widget -%}</body></html>"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -919,8 +919,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: GET
     response:
       proto: HTTP/2.0
@@ -930,7 +930,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"colors":{"page_background":"#000000","primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -955,8 +955,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
       method: GET
     response:
       proto: HTTP/2.0
@@ -966,7 +966,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -991,7 +991,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.11.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
       method: GET
     response:
@@ -1002,10 +1002,873 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"allowed_logout_urls":["https://mycompany.org/logoutCallback"],"change_password":{},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":false,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":true,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"page_background":"#000000","primary":"#0059d6"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
       status: 200 OK
       code: 200
+      duration: 1ms
+  - id: 28
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"body":"<!DOCTYPE html><html><head>{%- auth0:head -%}</head><body>{%- auth0:widget -%}</body></html>"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 29
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 30
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v2/logo.png"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 31
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v2/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 32
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"body":"<!DOCTYPE html><html><head>{%- auth0:head -%}</head><body>{%- auth0:widget -%}</body></html>"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 33
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 185
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        {"colors":{"primary":"#0059d6"},"favicon_url":"https://mycompany.org/favicon.ico","logo_url":"https://mycompany.org/v3/logo.png","font":{"url":"https://mycompany.org/font/myfont.ttf"}}
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+      method: PATCH
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v3/logo.png"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 34
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v3/logo.png"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 35
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: 120
+      uncompressed: false
+      body: '{"statusCode":429,"error":"Too Many Requests","message":"Global limit has been reached","errorCode":"too_many_requests"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 429 Too Many Requests
+      code: 429
+      duration: 1ms
+  - id: 36
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v3/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 37
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"body":"<!DOCTYPE html><html><head>{%- auth0:head -%}</head><body>{%- auth0:widget -%}</body></html>"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 38
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v3/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 39
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v3/logo.png"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 40
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v3/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 41
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"body":"<!DOCTYPE html><html><head>{%- auth0:head -%}</head><body>{%- auth0:widget -%}</body></html>"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 42
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v3/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 43
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v3/logo.png"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 44
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v3/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 45
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"body":"<!DOCTYPE html><html><head>{%- auth0:head -%}</head><body>{%- auth0:widget -%}</body></html>"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 46
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 99
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        {"favicon_url":"https://mycompany.org/favicon.ico","logo_url":"https://mycompany.org/v1/logo.png"}
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+      method: PATCH
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 47
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 48
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 49
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"colors":{"primary":"#0059d6","page_background":"#000000"},"favicon_url":"https://mycompany.org/favicon.ico","font":{"url":"https://mycompany.org/font/myfont.ttf"},"logo_url":"https://mycompany.org/v1/logo.png"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 50
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"allowed_logout_urls":[],"change_password":{"enabled":true,"html":"<html>Change Password</html>"},"default_audience":"","default_directory":"","default_redirection_uri":"https://example.com/login","enabled_locales":["de","fr"],"error_page":{"html":"<html>Error Page</html>","show_log_link":false,"url":"https://mycompany.org/error"},"flags":{"allow_changing_enable_sso":false,"allow_legacy_delegation_grant_types":true,"allow_legacy_ro_grant_types":true,"change_pwd_flow_v1":false,"disable_impersonation":true,"disable_management_api_sms_obfuscation":true,"enable_apis_section":false,"enable_client_connections":true,"enable_custom_domain_in_emails":true,"enable_dynamic_client_registration":false,"enable_legacy_logs_search_v2":false,"enable_public_signup_user_exists_error":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"use_scope_descriptions_for_consent":false,"no_disclose_enterprise_connections":false,"revoke_refresh_token_grant":false,"disable_fields_map_fix":true,"disable_clickjack_protection_headers":false,"enable_pipeline2":false},"friendly_name":"My Test Tenant","guardian_mfa_page":{"enabled":true,"html":"<html>MFA</html>"},"idle_session_lifetime":72,"picture_url":"https://mycompany.org/v1/logo.png","sandbox_version":"12","session_lifetime":168,"support_email":"support@mycompany.org","support_url":"https://mycompany.org/support","universal_login":{"colors":{"primary":"#0059d6","page_background":"#000000"}},"session_cookie":{"mode":"persistent"},"sandbox_versions_available":["16","12"]}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 51
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: ""
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.11.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/branding/templates/universal-login
+      method: DELETE
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: 0
+      uncompressed: false
+      body: ""
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 204 No Content
+      code: 204
       duration: 1ms


### PR DESCRIPTION
### 🔧 Changes

An issue with the branding resource got pointed out in https://github.com/auth0/terraform-provider-auth0/issues/358 after our v0.38.0 release. It turns out we removed by mistake a 404 ignore when fetching the universal login template, so we're adding it back now but also ensuring we properly add tests for that tenant flag check when flattening the struct. 

### 📚 References



### 🔬 Testing

We are adding additional test cases to cover this part. 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)