### PR TITLE
Fix up typo: function is a reserved keyword

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -216,7 +216,7 @@ resource "auth0_connection" "oauth2" {
     pkce_enabled           = true
     scripts = {
       fetchUserProfile = <<EOF
-        function function(accessToken, context, callback) {
+        function fetchUserProfile(accessToken, context, callback) {
           return callback(new Error("Whoops!"));
         }
       EOF

--- a/examples/resources/auth0_connection/resource_with_oauth2.tf
+++ b/examples/resources/auth0_connection/resource_with_oauth2.tf
@@ -12,7 +12,7 @@ resource "auth0_connection" "oauth2" {
     pkce_enabled           = true
     scripts = {
       fetchUserProfile = <<EOF
-        function function(accessToken, context, callback) {
+        function fetchUserProfile(accessToken, context, callback) {
           return callback(new Error("Whoops!"));
         }
       EOF


### PR DESCRIPTION
### 🔧 Changes

Small typo in the documentation means code errors as it uses a reserved keyword.

### 🔬 Testing

Just a fix to the documentation.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests => N/A
- [x] I have added documentation for all new/changed functionality => N/A