### PR TITLE
DXCDT-247: Update email provider if already existing when creating it

### DIFF
--- a/internal/provider/resource_auth0_email_test.go
+++ b/internal/provider/resource_auth0_email_test.go
@@ -1,9 +1,13 @@
 package provider
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
 )
@@ -113,6 +117,81 @@ func TestAccEmail(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_email.my_email_provider", "credentials.0.region", "eu"),
 				),
 			},
+			{
+				Config: `
+				resource "auth0_email" "my_email_provider" {
+					name = "mailgun"
+					enabled = false
+					default_from_address = ""
+					credentials {
+						api_key = "MAILGUNXXXXXXXXXXXXXXX"
+						domain = "example.com"
+						region = "eu"
+					}
+				}
+
+				resource "auth0_email" "no_conflict_email_provider" {
+					depends_on = [ auth0_email.my_email_provider ]
+
+					name = "mailgun"
+					enabled = false
+					default_from_address = ""
+					credentials {
+						api_key = "MAILGUNXXXXXXXXXXXXXXX"
+						domain = "example.com"
+						region = "eu"
+					}
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_email.my_email_provider", "name", "mailgun"),
+					resource.TestCheckResourceAttr("auth0_email.my_email_provider", "enabled", "false"),
+					resource.TestCheckResourceAttr("auth0_email.my_email_provider", "default_from_address", ""),
+					resource.TestCheckResourceAttr("auth0_email.my_email_provider", "credentials.0.domain", "example.com"),
+					resource.TestCheckResourceAttr("auth0_email.my_email_provider", "credentials.0.region", "eu"),
+					resource.TestCheckResourceAttr("auth0_email.no_conflict_email_provider", "name", "mailgun"),
+					resource.TestCheckResourceAttr("auth0_email.no_conflict_email_provider", "enabled", "false"),
+					resource.TestCheckResourceAttr("auth0_email.no_conflict_email_provider", "default_from_address", ""),
+					resource.TestCheckResourceAttr("auth0_email.no_conflict_email_provider", "credentials.0.domain", "example.com"),
+					resource.TestCheckResourceAttr("auth0_email.no_conflict_email_provider", "credentials.0.region", "eu"),
+				),
+			},
 		},
+	})
+}
+
+func TestEmailProviderIsConfigured(t *testing.T) {
+	t.Run("it returns true if the provider is configured", func(t *testing.T) {
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/emails/provider" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		testServer := httptest.NewServer(testHandler)
+
+		api, err := management.New(testServer.URL, management.WithInsecure())
+		assert.NoError(t, err)
+
+		actual := emailProviderIsConfigured(api)
+		assert.True(t, actual)
+	})
+
+	t.Run("it returns false if the provider is not configured", func(t *testing.T) {
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/emails/provider" {
+				http.NotFound(w, r)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		testServer := httptest.NewServer(testHandler)
+
+		api, err := management.New(testServer.URL, management.WithInsecure())
+		assert.NoError(t, err)
+
+		actual := emailProviderIsConfigured(api)
+		assert.False(t, actual)
 	})
 }

--- a/test/data/recordings/TestAccEmail.yaml
+++ b/test/data/recordings/TestAccEmail.yaml
@@ -6,6 +6,42 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"statusCode":404,"error":"Not Found","message":"There is not a configured email provider","errorCode":"inexistent_email_provider"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 404 Not Found
+      code: 404
+      duration: 1ms
+  - id: 1
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
       content_length: 211
       transfer_encoding: [ ]
       trailer: { }
@@ -19,7 +55,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
       method: POST
     response:
@@ -36,42 +72,6 @@ interactions:
           - application/json; charset=utf-8
       status: 201 Created
       code: 201
-      duration: 1ms
-  - id: 1
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
-      content_length: 5
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        null
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
-      method: GET
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: true
-      body: '{"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"region":"us-east-1"}}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 200 OK
-      code: 200
       duration: 1ms
   - id: 2
     request:
@@ -91,7 +91,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
       method: GET
     response:
@@ -127,7 +127,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
       method: GET
     response:
@@ -150,22 +150,22 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 211
+      content_length: 5
       transfer_encoding: [ ]
       trailer: { }
       host: terraform-provider-auth0-dev.eu.auth0.com
       remote_addr: ""
       request_uri: ""
       body: |
-        {"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"accessKeyId":"AKIAXXXXXXXXXXXXXXXY","secretAccessKey":"7e8c2148xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","region":"us-east-1"}}
+        null
       form: { }
       headers:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
-      method: PATCH
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+      method: GET
     response:
       proto: HTTP/2.0
       proto_major: 2
@@ -186,22 +186,22 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 5
+      content_length: 211
       transfer_encoding: [ ]
       trailer: { }
       host: terraform-provider-auth0-dev.eu.auth0.com
       remote_addr: ""
       request_uri: ""
       body: |
-        null
+        {"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"accessKeyId":"AKIAXXXXXXXXXXXXXXXY","secretAccessKey":"7e8c2148xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","region":"us-east-1"}}
       form: { }
       headers:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
-      method: GET
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
+      method: PATCH
     response:
       proto: HTTP/2.0
       proto_major: 2
@@ -235,7 +235,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
       method: GET
     response:
@@ -271,7 +271,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
       method: GET
     response:
@@ -294,42 +294,6 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 168
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        {"name":"mailgun","enabled":true,"default_from_address":"accounts@example.com","credentials":{"api_key":"MAILGUNXXXXXXXXXXXXXXX","region":"eu","domain":"example.com"}}
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
-      method: PATCH
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: true
-      body: '{"name":"mailgun","enabled":true,"default_from_address":"accounts@example.com","credentials":{"domain":"example.com","region":"eu"}}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 200 OK
-      code: 200
-      duration: 1ms
-  - id: 9
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
       content_length: 5
       transfer_encoding: [ ]
       trailer: { }
@@ -343,9 +307,45 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
       method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"region":"us-east-1"}}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 9
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 168
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        {"name":"mailgun","enabled":true,"default_from_address":"accounts@example.com","credentials":{"api_key":"MAILGUNXXXXXXXXXXXXXXX","region":"eu","domain":"example.com"}}
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
+      method: PATCH
     response:
       proto: HTTP/2.0
       proto_major: 2
@@ -379,7 +379,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
       method: GET
     response:
@@ -415,7 +415,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
       method: GET
     response:
@@ -438,42 +438,6 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 149
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        {"name":"mailgun","enabled":false,"default_from_address":"","credentials":{"api_key":"MAILGUNXXXXXXXXXXXXXXX","region":"eu","domain":"example.com"}}
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/latest
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
-      method: PATCH
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: true
-      body: '{"name":"mailgun","enabled":false,"default_from_address":"","credentials":{"domain":"example.com","region":"eu"}}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 200 OK
-      code: 200
-      duration: 1ms
-  - id: 13
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
       content_length: 5
       transfer_encoding: [ ]
       trailer: { }
@@ -487,9 +451,45 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
       method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"name":"mailgun","enabled":true,"default_from_address":"accounts@example.com","credentials":{"domain":"example.com","region":"eu"}}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 13
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 149
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        {"name":"mailgun","enabled":false,"default_from_address":"","credentials":{"api_key":"MAILGUNXXXXXXXXXXXXXXX","region":"eu","domain":"example.com"}}
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
+      method: PATCH
     response:
       proto: HTTP/2.0
       proto_major: 2
@@ -523,7 +523,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
       method: GET
     response:
@@ -546,6 +546,258 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"name":"mailgun","enabled":false,"default_from_address":"","credentials":{"domain":"example.com","region":"eu"}}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 16
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"name":"mailgun","enabled":false,"default_from_address":"","credentials":{"domain":"example.com","region":"eu"}}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 17
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"name":"mailgun","enabled":false,"default_from_address":"","credentials":{"domain":"example.com","region":"eu"}}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 18
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 149
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        {"name":"mailgun","enabled":false,"default_from_address":"","credentials":{"api_key":"MAILGUNXXXXXXXXXXXXXXX","region":"eu","domain":"example.com"}}
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
+      method: PATCH
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"name":"mailgun","enabled":false,"default_from_address":"","credentials":{"domain":"example.com","region":"eu"}}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 19
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"name":"mailgun","enabled":false,"default_from_address":"","credentials":{"domain":"example.com","region":"eu"}}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 20
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"name":"mailgun","enabled":false,"default_from_address":"","credentials":{"domain":"example.com","region":"eu"}}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 21
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"name":"mailgun","enabled":false,"default_from_address":"","credentials":{"domain":"example.com","region":"eu"}}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 22
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
       content_length: 0
       transfer_encoding: [ ]
       trailer: { }
@@ -558,7 +810,42 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/latest
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
+      method: DELETE
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: 0
+      uncompressed: false
+      body: ""
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 204 No Content
+      code: 204
+      duration: 1ms
+  - id: 23
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: ""
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
       method: DELETE
     response:

--- a/test/data/recordings/TestAccEmailTemplate.yaml
+++ b/test/data/recordings/TestAccEmailTemplate.yaml
@@ -6,42 +6,6 @@ interactions:
       proto: HTTP/1.1
       proto_major: 1
       proto_minor: 1
-      content_length: 211
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        {"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"accessKeyId":"AKIAXXXXXXXXXXXXXXXX","secretAccessKey":"7e8c2148xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","region":"us-east-1"}}
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/0.10.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
-      method: POST
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: false
-      body: '{"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"region":"us-east-1"}}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 201 Created
-      code: 201
-      duration: 1ms
-  - id: 1
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
       content_length: 5
       transfer_encoding: [ ]
       trailer: { }
@@ -55,7 +19,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/0.10.0
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
       method: GET
     response:
@@ -66,12 +30,48 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
+      body: '{"statusCode":404,"error":"Not Found","message":"There is not a configured email provider","errorCode":"inexistent_email_provider"}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 404 Not Found
+      code: 404
+      duration: 1ms
+  - id: 1
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 211
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        {"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"accessKeyId":"AKIAXXXXXXXXXXXXXXXX","secretAccessKey":"7e8c2148xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","region":"us-east-1"}}
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
+      method: POST
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: 112
+      uncompressed: false
       body: '{"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"region":"us-east-1"}}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
-      status: 200 OK
-      code: 200
+      status: 201 Created
+      code: 201
       duration: 1ms
   - id: 2
     request:
@@ -91,8 +91,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/0.10.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/email-templates/welcome_email
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
       method: GET
     response:
       proto: HTTP/2.0
@@ -102,7 +102,7 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"syntax":"liquid","body":"<html><body><h1>Welcome!</h1></body></html>","from":"welcome@example.com","subject":"Welcome","template":"welcome_email","resultUrl":"https://example.com/welcome","urlLifetimeInSeconds":3600,"includeEmailInRedirect":false,"enabled":false}'
+      body: '{"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"region":"us-east-1"}}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -110,42 +110,6 @@ interactions:
       code: 200
       duration: 1ms
   - id: 3
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
-      content_length: 325
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        {"template":"welcome_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eWelcome!\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"welcome@example.com","resultUrl":"https://example.com/welcome","subject":"Welcome","syntax":"liquid","urlLifetimeInSeconds":3600,"enabled":true,"includeEmailInRedirect":false}
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/0.10.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/email-templates/welcome_email
-      method: PATCH
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: true
-      body: '{"syntax":"liquid","body":"<html><body><h1>Welcome!</h1></body></html>","from":"welcome@example.com","subject":"Welcome","template":"welcome_email","resultUrl":"https://example.com/welcome","urlLifetimeInSeconds":3600,"includeEmailInRedirect":false,"enabled":true}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 200 OK
-      code: 200
-      duration: 1ms
-  - id: 4
     request:
       proto: HTTP/1.1
       proto_major: 1
@@ -163,8 +127,8 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/0.10.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/email-templates/welcome_email
       method: GET
     response:
       proto: HTTP/2.0
@@ -174,7 +138,43 @@ interactions:
       trailer: { }
       content_length: -1
       uncompressed: true
-      body: '{"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"region":"us-east-1"}}'
+      body: '{"syntax":"liquid","body":"<html><body><h1>Welcome!</h1></body></html>","from":"welcome@example.com","subject":"Welcome","template":"welcome_email","resultUrl":"https://example.com/welcome","urlLifetimeInSeconds":3600,"includeEmailInRedirect":false,"enabled":false}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 4
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 325
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        {"template":"welcome_email","body":"\u003chtml\u003e\u003cbody\u003e\u003ch1\u003eWelcome!\u003c/h1\u003e\u003c/body\u003e\u003c/html\u003e","from":"welcome@example.com","resultUrl":"https://example.com/welcome","subject":"Welcome","syntax":"liquid","urlLifetimeInSeconds":3600,"enabled":true,"includeEmailInRedirect":false}
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/email-templates/welcome_email
+      method: PATCH
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"syntax":"liquid","body":"<html><body><h1>Welcome!</h1></body></html>","from":"welcome@example.com","subject":"Welcome","template":"welcome_email","resultUrl":"https://example.com/welcome","urlLifetimeInSeconds":3600,"includeEmailInRedirect":false,"enabled":true}'
       headers:
         Content-Type:
           - application/json; charset=utf-8
@@ -199,7 +199,43 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/0.10.0
+          - Go-Auth0-SDK/0.12.0
+      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider?fields=name%2Cenabled%2Cdefault_from_address%2Ccredentials%2Csettings&include_fields=true
+      method: GET
+    response:
+      proto: HTTP/2.0
+      proto_major: 2
+      proto_minor: 0
+      transfer_encoding: [ ]
+      trailer: { }
+      content_length: -1
+      uncompressed: true
+      body: '{"name":"ses","enabled":true,"default_from_address":"accounts@example.com","credentials":{"region":"us-east-1"}}'
+      headers:
+        Content-Type:
+          - application/json; charset=utf-8
+      status: 200 OK
+      code: 200
+      duration: 1ms
+  - id: 6
+    request:
+      proto: HTTP/1.1
+      proto_major: 1
+      proto_minor: 1
+      content_length: 5
+      transfer_encoding: [ ]
+      trailer: { }
+      host: terraform-provider-auth0-dev.eu.auth0.com
+      remote_addr: ""
+      request_uri: ""
+      body: |
+        null
+      form: { }
+      headers:
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/email-templates/welcome_email
       method: GET
     response:
@@ -217,7 +253,7 @@ interactions:
       status: 200 OK
       code: 200
       duration: 1ms
-  - id: 6
+  - id: 7
     request:
       proto: HTTP/1.1
       proto_major: 1
@@ -235,7 +271,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/0.10.0
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/email-templates/welcome_email
       method: PATCH
     response:
@@ -253,7 +289,7 @@ interactions:
       status: 200 OK
       code: 200
       duration: 1ms
-  - id: 7
+  - id: 8
     request:
       proto: HTTP/1.1
       proto_major: 1
@@ -270,7 +306,7 @@ interactions:
         Content-Type:
           - application/json
         User-Agent:
-          - Go-Auth0-SDK/0.10.0
+          - Go-Auth0-SDK/0.12.0
       url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/emails/provider
       method: DELETE
     response:


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

As requested in https://github.com/auth0/terraform-provider-auth0/issues/330 we're improving the DX when managing email providers in the case that one was already configured in the Dashboard and we straight away want to run a terraform apply after writing our configuration, skipping the need of an import. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
