### PR TITLE
Issue 388: relax validation rules on initiate_login_uri to match API

### DIFF
--- a/internal/provider/resource_auth0_client.go
+++ b/internal/provider/resource_auth0_client.go
@@ -604,10 +604,10 @@ func newClient() *schema.Resource {
 				},
 			},
 			"initiate_login_uri": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
 				ValidateFunc: validation.IsURLWithHTTPS,
-				Description: "Initiate login URI, must be HTTPS.",
+				Description:  "Initiate login URI, must be HTTPS.",
 			},
 			"native_social_login": {
 				Type:     schema.TypeList,

--- a/internal/provider/resource_auth0_client.go
+++ b/internal/provider/resource_auth0_client.go
@@ -606,9 +606,7 @@ func newClient() *schema.Resource {
 			"initiate_login_uri": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ValidateFunc: validation.All(
-					validation.IsURLWithScheme([]string{"https"}),
-				),
+				ValidateFunc: validation.IsURLWithHTTPS,
 				Description: "Initiate login URI, must be HTTPS.",
 			},
 			"native_social_login": {

--- a/internal/provider/resource_auth0_client.go
+++ b/internal/provider/resource_auth0_client.go
@@ -9,8 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
-	internalValidation "github.com/auth0/terraform-provider-auth0/internal/validation"
 )
 
 func newClient() *schema.Resource {
@@ -610,7 +608,6 @@ func newClient() *schema.Resource {
 				Optional: true,
 				ValidateFunc: validation.All(
 					validation.IsURLWithScheme([]string{"https"}),
-					internalValidation.IsURLWithNoFragment,
 				),
 				Description: "Initiate login URI, must be HTTPS.",
 			},

--- a/internal/provider/resource_auth0_client_test.go
+++ b/internal/provider/resource_auth0_client_test.go
@@ -61,13 +61,6 @@ resource "auth0_client" "my_client" {
 }
 `
 
-const testAccClientValidationOnInitiateLoginURIWithFragment = `
-resource "auth0_client" "my_client" {
-	name = "Acceptance Test - Initiate Login URI - {{.testName}}"
-	initiate_login_uri = "https://example.com/login#fragment"
-}
-`
-
 func TestAccClientInitiateLoginUriValidation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testProviders(nil),
@@ -75,10 +68,6 @@ func TestAccClientInitiateLoginUriValidation(t *testing.T) {
 			{
 				Config:      template.ParseTestName(testAccClientValidationOnInitiateLoginURIWithHTTP, t.Name()),
 				ExpectError: regexp.MustCompile("to have a url with schema"),
-			},
-			{
-				Config:      template.ParseTestName(testAccClientValidationOnInitiateLoginURIWithFragment, t.Name()),
-				ExpectError: regexp.MustCompile("to have a url with an empty fragment"),
 			},
 		},
 	})


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR relaxes the validation rules on `initiate_login_uri` field on `auth0_client` resource to match what the Auth0 API accepts.

### 📚 References

* [Issue 388](https://github.com/auth0/terraform-provider-auth0/issues/388)

### 🔬 Testing

Tested locally by adding a URL containing a fragment to `initiate_login_uri` and verifying that it both passes validation and actually applies to a client on Auth0.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
