### PR TITLE
ESD-25205: Fix concurrency issue in association resources

### DIFF
--- a/internal/mutex/mutex.go
+++ b/internal/mutex/mutex.go
@@ -1,0 +1,50 @@
+package mutex
+
+import (
+	"log"
+	"sync"
+)
+
+// KeyValue is a simple key/value
+// store for arbitrary mutexes.
+type KeyValue struct {
+	lock  sync.Mutex
+	store map[string]*sync.Mutex
+}
+
+// Lock the mutex for the given key.
+func (m *KeyValue) Lock(key string) {
+	log.Printf("[DEBUG] Locking mutex for key: %q", key)
+	defer log.Printf("[DEBUG] Locked mutex for key: %q", key)
+
+	m.get(key).Lock()
+}
+
+// Unlock the mutex for the given key.
+func (m *KeyValue) Unlock(key string) {
+	log.Printf("[DEBUG] Unlocking mutex for key: %q", key)
+	defer log.Printf("[DEBUG] Unlocked mutex for key: %q", key)
+
+	m.get(key).Unlock()
+}
+
+// Returns a mutex for the given key.
+func (m *KeyValue) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+	}
+
+	return mutex
+}
+
+// New returns a properly initialized KeyValue mutex.
+func New() *KeyValue {
+	return &KeyValue{
+		store: make(map[string]*sync.Mutex),
+	}
+}

--- a/internal/mutex/mutex_test.go
+++ b/internal/mutex/mutex_test.go
@@ -23,7 +23,7 @@ func TestKeyValueLock(t *testing.T) {
 	}
 }
 
-func TestMutexKVUnlock(t *testing.T) {
+func TestKeyValueUnlock(t *testing.T) {
 	keyValueMutex := New()
 	keyValueMutex.Lock("foo")
 	keyValueMutex.Unlock("foo")
@@ -42,7 +42,7 @@ func TestMutexKVUnlock(t *testing.T) {
 	}
 }
 
-func TestMutexKVDifferentKeys(t *testing.T) {
+func TestKeyValueDifferentKeys(t *testing.T) {
 	keyValueMutex := New()
 	keyValueMutex.Lock("foo")
 

--- a/internal/mutex/mutex_test.go
+++ b/internal/mutex/mutex_test.go
@@ -1,0 +1,61 @@
+package mutex
+
+import (
+	"testing"
+	"time"
+)
+
+func TestKeyValueLock(t *testing.T) {
+	keyValueMutex := New()
+	keyValueMutex.Lock("foo")
+
+	doneChannel := make(chan struct{})
+	go func() {
+		keyValueMutex.Lock("foo")
+		close(doneChannel)
+	}()
+
+	select {
+	case <-doneChannel:
+		t.Fatal("Second lock was able to be taken. This shouldn't happen.")
+	case <-time.After(50 * time.Millisecond):
+		// Test passing.
+	}
+}
+
+func TestMutexKVUnlock(t *testing.T) {
+	keyValueMutex := New()
+	keyValueMutex.Lock("foo")
+	keyValueMutex.Unlock("foo")
+
+	doneChannel := make(chan struct{})
+	go func() {
+		keyValueMutex.Lock("foo")
+		close(doneChannel)
+	}()
+
+	select {
+	case <-doneChannel:
+		// Test passing.
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("Second lock blocked after unlock. This shouldn't happen.")
+	}
+}
+
+func TestMutexKVDifferentKeys(t *testing.T) {
+	keyValueMutex := New()
+	keyValueMutex.Lock("foo")
+
+	doneChannel := make(chan struct{})
+	go func() {
+		keyValueMutex.Lock("bar")
+		close(doneChannel)
+	}()
+
+	select {
+	case <-doneChannel:
+		// Test passing.
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("Second lock on a different key blocked. This shouldn't happen.")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -10,9 +10,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
+
+	"github.com/auth0/terraform-provider-auth0/internal/mutex"
 )
 
 var version = "dev"
+
+var globalMutex = mutex.New()
 
 // New returns a *schema.Provider.
 func New() *schema.Provider {

--- a/internal/provider/resource_auth0_connection_client.go
+++ b/internal/provider/resource_auth0_connection_client.go
@@ -87,6 +87,10 @@ func createConnectionClient(ctx context.Context, data *schema.ResourceData, meta
 	api := meta.(*management.Management)
 
 	connectionID := data.Get("connection_id").(string)
+
+	globalMutex.Lock(connectionID)
+	defer globalMutex.Unlock(connectionID)
+
 	connection, err := api.Connection.Read(connectionID)
 	if err != nil {
 		return diag.FromErr(err)
@@ -145,6 +149,10 @@ func deleteConnectionClient(_ context.Context, data *schema.ResourceData, meta i
 	api := meta.(*management.Management)
 
 	connectionID := data.Get("connection_id").(string)
+
+	globalMutex.Lock(connectionID)
+	defer globalMutex.Unlock(connectionID)
+
 	connection, err := api.Connection.Read(connectionID)
 	if err != nil {
 		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {

--- a/internal/provider/resource_auth0_connection_client.go
+++ b/internal/provider/resource_auth0_connection_client.go
@@ -89,10 +89,6 @@ func createConnectionClient(ctx context.Context, data *schema.ResourceData, meta
 	connectionID := data.Get("connection_id").(string)
 	connection, err := api.Connection.Read(connectionID)
 	if err != nil {
-		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {
-			data.SetId("")
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 
@@ -103,10 +99,6 @@ func createConnectionClient(ctx context.Context, data *schema.ResourceData, meta
 		connectionID,
 		&management.Connection{EnabledClients: &enabledClients},
 	); err != nil {
-		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {
-			data.SetId("")
-			return nil
-		}
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_auth0_organization_connection.go
+++ b/internal/provider/resource_auth0_organization_connection.go
@@ -94,6 +94,10 @@ func createOrganizationConnection(ctx context.Context, data *schema.ResourceData
 	api := meta.(*management.Management)
 
 	organizationID := data.Get("organization_id").(string)
+
+	globalMutex.Lock(organizationID)
+	defer globalMutex.Unlock(organizationID)
+
 	connectionID := data.Get("connection_id").(string)
 	assignMembershipOnLogin := data.Get("assign_membership_on_login").(bool)
 
@@ -139,6 +143,10 @@ func updateOrganizationConnection(ctx context.Context, data *schema.ResourceData
 	api := meta.(*management.Management)
 
 	organizationID := data.Get("organization_id").(string)
+
+	globalMutex.Lock(organizationID)
+	defer globalMutex.Unlock(organizationID)
+
 	connectionID := data.Get("connection_id").(string)
 	assignMembershipOnLogin := data.Get("assign_membership_on_login").(bool)
 
@@ -157,6 +165,10 @@ func deleteOrganizationConnection(ctx context.Context, data *schema.ResourceData
 	api := meta.(*management.Management)
 
 	organizationID := data.Get("organization_id").(string)
+
+	globalMutex.Lock(organizationID)
+	defer globalMutex.Unlock(organizationID)
+
 	connectionID := data.Get("connection_id").(string)
 
 	if err := api.Organization.DeleteConnection(organizationID, connectionID); err != nil {

--- a/internal/provider/resource_auth0_organization_connection.go
+++ b/internal/provider/resource_auth0_organization_connection.go
@@ -119,6 +119,10 @@ func readOrganizationConnection(ctx context.Context, data *schema.ResourceData, 
 
 	organizationConnection, err := api.Organization.Connection(organizationID, connectionID)
 	if err != nil {
+		if err, ok := err.(management.Error); ok && err.Status() == http.StatusNotFound {
+			data.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_auth0_organization_member.go
+++ b/internal/provider/resource_auth0_organization_member.go
@@ -159,6 +159,10 @@ func readOrganizationMember(ctx context.Context, d *schema.ResourceData, m inter
 
 	roles, err := api.Organization.MemberRoles(orgID, userID)
 	if err != nil {
+		if err, ok := err.(management.Error); ok && err.Status() == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_auth0_organization_member.go
+++ b/internal/provider/resource_auth0_organization_member.go
@@ -86,6 +86,9 @@ func createOrganizationMember(ctx context.Context, d *schema.ResourceData, m int
 	userID := d.Get("user_id").(string)
 	orgID := d.Get("organization_id").(string)
 
+	globalMutex.Lock(orgID)
+	defer globalMutex.Unlock(orgID)
+
 	if err := api.Organization.AddMembers(orgID, []string{userID}); err != nil {
 		return diag.FromErr(err)
 	}
@@ -104,8 +107,8 @@ func assignRoles(d *schema.ResourceData, api *management.Management) error {
 		return nil
 	}
 
-	orgID := d.Get("organization_id").(string)
 	userID := d.Get("user_id").(string)
+	orgID := d.Get("organization_id").(string)
 
 	toAdd, toRemove := value.Difference(d, "roles")
 
@@ -179,6 +182,11 @@ func readOrganizationMember(ctx context.Context, d *schema.ResourceData, m inter
 func updateOrganizationMember(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	api := m.(*management.Management)
 
+	orgID := d.Get("organization_id").(string)
+
+	globalMutex.Lock(orgID)
+	defer globalMutex.Unlock(orgID)
+
 	if err := assignRoles(d, api); err != nil {
 		return diag.FromErr(fmt.Errorf("failed to assign members to organization. %w", err))
 	}
@@ -189,8 +197,11 @@ func updateOrganizationMember(ctx context.Context, d *schema.ResourceData, m int
 func deleteOrganizationMember(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	api := m.(*management.Management)
 
-	orgID := d.Get("organization_id").(string)
 	userID := d.Get("user_id").(string)
+	orgID := d.Get("organization_id").(string)
+
+	globalMutex.Lock(orgID)
+	defer globalMutex.Unlock(orgID)
 
 	if err := api.Organization.DeleteMember(orgID, []string{userID}); err != nil {
 		if err, ok := err.(management.Error); ok && err.Status() == http.StatusNotFound {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

All the association resources are prone to concurrency issues when needing to operate on the same entity. In this PR we are introducing a global mutex to prevent such issues. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
