### PR TITLE
DXCDT-351: Only send changed fields when updating a user

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -43,14 +43,14 @@ resource "auth0_role" "admin" {
 - `blocked` (Boolean) Indicates whether the user is blocked or not.
 - `email` (String) Email address of the user.
 - `email_verified` (Boolean) Indicates whether the email address has been verified.
-- `family_name` (String) Family name of the user.
-- `given_name` (String) Given name of the user.
-- `name` (String) Name of the user.
-- `nickname` (String) Preferred nickname or alias of the user.
+- `family_name` (String) Family name of the user. This value can only be updated if the connection is a database connection (using the Auth0 store), a passwordless connection (email or sms) or has disabled 'Sync user profile attributes at each login'. For more information, see: [Configure Identity Provider Connection for User Profile Updates](https://auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0).
+- `given_name` (String) Given name of the user. This value can only be updated if the connection is a database connection (using the Auth0 store), a passwordless connection (email or sms) or has disabled 'Sync user profile attributes at each login'. For more information, see: [Configure Identity Provider Connection for User Profile Updates](https://auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0).
+- `name` (String) Name of the user. This value can only be updated if the connection is a database connection (using the Auth0 store), a passwordless connection (email or sms) or has disabled 'Sync user profile attributes at each login'. For more information, see: [Configure Identity Provider Connection for User Profile Updates](https://auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0).
+- `nickname` (String) Preferred nickname or alias of the user. This value can only be updated if the connection is a database connection (using the Auth0 store), a passwordless connection (email or sms) or has disabled 'Sync user profile attributes at each login'. For more information, see: [Configure Identity Provider Connection for User Profile Updates](https://auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0).
 - `password` (String, Sensitive) Initial password for this user. Required for non-passwordless connections (SMS and email).
 - `phone_number` (String) Phone number for the user; follows the E.164 recommendation. Used for SMS connections.
 - `phone_verified` (Boolean) Indicates whether the phone number has been verified.
-- `picture` (String) Picture of the user.
+- `picture` (String) Picture of the user. This value can only be updated if the connection is a database connection (using the Auth0 store), a passwordless connection (email or sms) or has disabled 'Sync user profile attributes at each login'. For more information, see: [Configure Identity Provider Connection for User Profile Updates](https://auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0).
 - `roles` (Set of String) Set of IDs of roles assigned to the user.
 - `user_id` (String) ID of the user.
 - `user_metadata` (String) Custom fields that store info about the user that does not impact a user's core functionality. Examples include work address, home address, and user preferences.

--- a/internal/provider/resource_auth0_user.go
+++ b/internal/provider/resource_auth0_user.go
@@ -259,41 +259,53 @@ func deleteUser(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 func expandUser(d *schema.ResourceData) (*management.User, error) {
 	config := d.GetRawConfig()
 
-	user := &management.User{
-		Connection: value.String(config.GetAttr("connection_name")),
-		Name:       value.String(config.GetAttr("name")),
-		GivenName:  value.String(config.GetAttr("given_name")),
-		FamilyName: value.String(config.GetAttr("family_name")),
-		Nickname:   value.String(config.GetAttr("nickname")),
-		Picture:    value.String(config.GetAttr("picture")),
-		Blocked:    value.Bool(config.GetAttr("blocked")),
-	}
+	user := &management.User{}
 
 	if d.IsNewResource() {
 		user.ID = value.String(config.GetAttr("user_id"))
 	}
-	if d.IsNewResource() || d.HasChange("email") {
+	if d.HasChange("email") {
 		user.Email = value.String(config.GetAttr("email"))
 	}
-	if d.IsNewResource() || d.HasChange("username") {
+	if d.HasChange("username") {
 		user.Username = value.String(config.GetAttr("username"))
 	}
-	if d.IsNewResource() || d.HasChange("password") {
+	if d.HasChange("password") {
 		user.Password = value.String(config.GetAttr("password"))
 	}
-	if d.IsNewResource() || d.HasChange("phone_number") {
+	if d.HasChange("phone_number") {
 		user.PhoneNumber = value.String(config.GetAttr("phone_number"))
 	}
-	if d.IsNewResource() || d.HasChange("email_verified") {
+	if d.HasChange("email_verified") {
 		user.EmailVerified = value.Bool(config.GetAttr("email_verified"))
 	}
-	if d.IsNewResource() || d.HasChange("verify_email") {
+	if d.HasChange("verify_email") {
 		user.VerifyEmail = value.Bool(config.GetAttr("verify_email"))
 	}
-	if d.IsNewResource() || d.HasChange("phone_verified") {
+	if d.HasChange("phone_verified") {
 		user.PhoneVerified = value.Bool(config.GetAttr("phone_verified"))
 	}
-
+	if d.HasChange("given_name") {
+		user.GivenName = value.String(config.GetAttr("given_name"))
+	}
+	if d.HasChange("family_name") {
+		user.FamilyName = value.String(config.GetAttr("family_name"))
+	}
+	if d.HasChange("nickname") {
+		user.Nickname = value.String(config.GetAttr("nickname"))
+	}
+	if d.HasChange("name") {
+		user.Name = value.String(config.GetAttr("name"))
+	}
+	if d.HasChange("picture") {
+		user.Picture = value.String(config.GetAttr("picture"))
+	}
+	if d.HasChange("blocked") {
+		user.Blocked = value.Bool(config.GetAttr("blocked"))
+	}
+	if d.HasChange("connection_name") {
+		user.Connection = value.String(config.GetAttr("connection_name"))
+	}
 	if d.HasChange("user_metadata") {
 		userMetadata, err := expandMetadata(d, "user")
 		if err != nil {
@@ -301,7 +313,6 @@ func expandUser(d *schema.ResourceData) (*management.User, error) {
 		}
 		user.UserMetadata = &userMetadata
 	}
-
 	if d.HasChange("app_metadata") {
 		appMetadata, err := expandMetadata(d, "app")
 		if err != nil {

--- a/internal/provider/resource_auth0_user.go
+++ b/internal/provider/resource_auth0_user.go
@@ -50,26 +50,38 @@ func newUser() *schema.Resource {
 				Description: "Username of the user. Only valid if the connection requires a username.",
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Name of the user.",
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: "Name of the user. This value can only be updated if the connection is a " +
+					"database connection (using the Auth0 store), a passwordless connection (email or sms) or " +
+					"has disabled 'Sync user profile attributes at each login'. For more information, see: " +
+					"[Configure Identity Provider Connection for User Profile Updates](https://auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0).",
 			},
 			"family_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Family name of the user.",
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "Family name of the user. This value can only be updated if the connection is a " +
+					"database connection (using the Auth0 store), a passwordless connection (email or sms) or " +
+					"has disabled 'Sync user profile attributes at each login'. For more information, see: " +
+					"[Configure Identity Provider Connection for User Profile Updates](https://auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0).",
 			},
 			"given_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Given name of the user.",
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "Given name of the user. This value can only be updated if the connection is a " +
+					"database connection (using the Auth0 store), a passwordless connection (email or sms) or " +
+					"has disabled 'Sync user profile attributes at each login'. For more information, see: " +
+					"[Configure Identity Provider Connection for User Profile Updates](https://auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0).",
 			},
 			"nickname": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Preferred nickname or alias of the user.",
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: "Preferred nickname or alias of the user. This value can only be updated if the connection is a " +
+					"database connection (using the Auth0 store), a passwordless connection (email or sms) or " +
+					"has disabled 'Sync user profile attributes at each login'. For more information, see: " +
+					"[Configure Identity Provider Connection for User Profile Updates](https://auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0).",
 			},
 			"password": {
 				Type:        schema.TypeString,
@@ -126,10 +138,13 @@ func newUser() *schema.Resource {
 				Description: "Indicates whether the user is blocked or not.",
 			},
 			"picture": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Picture of the user.",
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: "Picture of the user. This value can only be updated if the connection is a " +
+					"database connection (using the Auth0 store), a passwordless connection (email or sms) or " +
+					"has disabled 'Sync user profile attributes at each login'. For more information, see: " +
+					"[Configure Identity Provider Connection for User Profile Updates](https://auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0).",
 			},
 			"roles": {
 				Type:        schema.TypeSet,


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

We're trying to always push an update to the Users API with `name`, `given_name`, `family_name` and `nickname` within the payload.

These unfortunately cannot be present in the payload if the connection is not a db or passwordless connection or if the Sync user profile attributes at each login is toggled on. For more info you can read [auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0](https://auth0.com/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0).


### 📚 References

- https://github.com/auth0/terraform-provider-auth0/issues/400

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
