### PR TITLE
DXCDT-360: Extract sweepers into own pkg

### DIFF
--- a/internal/provider/data_source_auth0_client_test.go
+++ b/internal/provider/data_source_auth0_client_test.go
@@ -35,7 +35,7 @@ func TestAccDataClientByName(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories:         testProviders(httpRecorder),
+		ProviderFactories:         ProviderTestFactories(httpRecorder),
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
@@ -56,7 +56,7 @@ func TestAccDataClientById(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories:         testProviders(httpRecorder),
+		ProviderFactories:         ProviderTestFactories(httpRecorder),
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_auth0_global_client_test.go
+++ b/internal/provider/data_source_auth0_global_client_test.go
@@ -19,7 +19,7 @@ func TestAccDataGlobalClient(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClientConfigWithCustomLogin,

--- a/internal/provider/data_source_auth0_tenant_test.go
+++ b/internal/provider/data_source_auth0_tenant_test.go
@@ -31,7 +31,7 @@ func TestAccDataTenant(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccDataTenantConfig, t.Name()),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"sort"
@@ -18,7 +17,7 @@ import (
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
 )
 
-func testProviders(httpRecorder *recorder.Recorder) map[string]func() (*schema.Provider, error) {
+func ProviderTestFactories(httpRecorder *recorder.Recorder) map[string]func() (*schema.Provider, error) {
 	return map[string]func() (*schema.Provider, error){
 		"auth0": func() (*schema.Provider, error) {
 			provider := New()
@@ -84,26 +83,6 @@ func configureTestProvider(
 
 		return apiClient, nil
 	}
-}
-
-// Auth0 returns an instance of the Management
-// API Client used within test sweepers.
-func Auth0() (*management.Management, error) {
-	domain := os.Getenv("AUTH0_DOMAIN")
-	if domain == "" {
-		return nil, fmt.Errorf("failed to instantiate api client: AUTH0_DOMAIN is empty")
-	}
-
-	apiToken := os.Getenv("AUTH0_API_TOKEN")
-	authenticationOption := management.WithStaticToken(apiToken)
-	if apiToken == "" {
-		authenticationOption = management.WithClientCredentials(
-			os.Getenv("AUTH0_CLIENT_ID"),
-			os.Getenv("AUTH0_CLIENT_SECRET"),
-		)
-	}
-
-	return management.New(domain, authenticationOption)
 }
 
 func TestMain(m *testing.M) {

--- a/internal/provider/resource_auth0_action_test.go
+++ b/internal/provider/resource_auth0_action_test.go
@@ -109,7 +109,7 @@ func TestAccAction(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccActionConfigCreateWithOnlyRequiredFields, t.Name()),
@@ -219,7 +219,7 @@ func TestAccAction_FailedBuild(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccActionConfigCreateWithFailedBuild, t.Name()),

--- a/internal/provider/resource_auth0_attack_protection_test.go
+++ b/internal/provider/resource_auth0_attack_protection_test.go
@@ -58,7 +58,7 @@ func TestAccAttackProtectionBreachedPasswordDetection(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBreachedPasswordDetectionEnable,
@@ -162,7 +162,7 @@ func TestAccAttackProtectionBruteForceProtection(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBruteForceProtectionEnable,
@@ -266,7 +266,7 @@ func TestAccAttackProtectionSuspiciousIPThrottling(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSuspiciousIPThrottlingEnable,

--- a/internal/provider/resource_auth0_branding_test.go
+++ b/internal/provider/resource_auth0_branding_test.go
@@ -96,7 +96,7 @@ func TestAccBranding_WithNoCustomDomainsSet(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTenantDisallowsUniversalLoginCustomization,
@@ -113,7 +113,7 @@ func TestAccBranding(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTenantAllowsUniversalLoginCustomization + testAccBrandingConfigCreate,

--- a/internal/provider/resource_auth0_branding_theme_test.go
+++ b/internal/provider/resource_auth0_branding_theme_test.go
@@ -187,7 +187,7 @@ func TestAccBrandingTheme(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBrandingThemeCreate,

--- a/internal/provider/resource_auth0_client_grant_test.go
+++ b/internal/provider/resource_auth0_client_grant_test.go
@@ -73,7 +73,7 @@ func TestAccClientGrant(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccClientGrantConfigCreate, t.Name()),

--- a/internal/provider/resource_auth0_connection_client_test.go
+++ b/internal/provider/resource_auth0_connection_client_test.go
@@ -68,7 +68,7 @@ func TestAccConnectionClient(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccCreateConnectionClient, t.Name()),

--- a/internal/provider/resource_auth0_connection_test.go
+++ b/internal/provider/resource_auth0_connection_test.go
@@ -3,66 +3,25 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
-	"strings"
 	"testing"
 
-	"github.com/auth0/go-auth0/management"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
+	"github.com/auth0/terraform-provider-auth0/internal/sweep"
 	"github.com/auth0/terraform-provider-auth0/internal/template"
 )
 
 func init() {
-	resource.AddTestSweepers("auth0_connection", &resource.Sweeper{
-		Name: "auth0_connection",
-		F: func(_ string) error {
-			api, err := Auth0()
-			if err != nil {
-				return err
-			}
-
-			var page int
-			var result *multierror.Error
-			for {
-				connectionList, err := api.Connection.List(
-					management.IncludeFields("id", "name"),
-					management.Page(page),
-				)
-				if err != nil {
-					return err
-				}
-
-				for _, connection := range connectionList.Connections {
-					log.Printf("[DEBUG] ➝ %s", connection.GetName())
-
-					if strings.Contains(connection.GetName(), "Test") {
-						result = multierror.Append(
-							result,
-							api.Connection.Delete(connection.GetID()),
-						)
-						log.Printf("[DEBUG] ✗ %s", connection.GetName())
-					}
-				}
-				if !connectionList.HasNext() {
-					break
-				}
-				page++
-			}
-
-			return result.ErrorOrNil()
-		},
-	})
+	sweep.Connections()
 }
 
 func TestAccConnection(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionConfig, t.Name()),
@@ -210,7 +169,7 @@ func TestAccConnectionAD(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionADConfig, t.Name()),
@@ -263,7 +222,7 @@ func TestAccConnectionAzureAD(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionAzureADConfig, t.Name()),
@@ -331,7 +290,7 @@ func TestAccConnectionADFS(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionADFSConfig, t.Name()),
@@ -467,7 +426,7 @@ func TestAccConnectionOIDC(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionOIDCConfig, t.Name()),
@@ -584,7 +543,7 @@ func TestAccConnectionOkta(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionOktaConfig, t.Name()),
@@ -698,7 +657,7 @@ func TestAccConnectionOAuth2(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionOAuth2Config, t.Name()),
@@ -791,7 +750,7 @@ func TestAccConnectionSMS(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionSMSConfig, t.Name()),
@@ -842,7 +801,7 @@ func TestAccConnectionCustomSMS(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionCustomSMSConfig, t.Name()),
@@ -904,7 +863,7 @@ func TestAccConnectionEmail(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionEmailConfig, t.Name()),
@@ -1022,7 +981,7 @@ func TestAccConnectionSalesforce(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionSalesforceConfig, t.Name()),
@@ -1059,7 +1018,7 @@ func TestAccConnectionGoogleOAuth2(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionGoogleOAuth2Config, t.Name()),
@@ -1106,7 +1065,7 @@ func TestAccConnectionGoogleApps(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionGoogleApps, t.Name()),
@@ -1159,7 +1118,7 @@ func TestAccConnectionFacebook(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionFacebookConfig, t.Name()),
@@ -1226,7 +1185,7 @@ func TestAccConnectionApple(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionAppleConfig, t.Name()),
@@ -1300,7 +1259,7 @@ func TestAccConnectionLinkedin(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionLinkedinConfig, t.Name()),
@@ -1367,7 +1326,7 @@ func TestAccConnectionGitHub(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionGitHubConfig, t.Name()),
@@ -1428,7 +1387,7 @@ func TestAccConnectionWindowslive(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionWindowsliveConfig, t.Name()),
@@ -1498,7 +1457,7 @@ func TestAccConnectionConfiguration(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionConfigurationCreate, t.Name()),
@@ -1672,7 +1631,7 @@ func TestAccConnectionSAML(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testConnectionSAMLConfigCreate, t.Name()),
@@ -1850,7 +1809,7 @@ func TestAccConnectionTwitter(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccConnectionTwitterConfig, t.Name()),

--- a/internal/provider/resource_auth0_custom_domain_verification_test.go
+++ b/internal/provider/resource_auth0_custom_domain_verification_test.go
@@ -17,7 +17,7 @@ func TestAccCustomDomainVerificationWithAuth0ManagedCerts(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCustomDomainVerificationWithAuth0ManagedCerts,
@@ -72,7 +72,7 @@ func TestAccCustomDomainVerificationWithSelfManagedCerts(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCustomDomainVerificationWithSelfManagedCerts,

--- a/internal/provider/resource_auth0_email_template_test.go
+++ b/internal/provider/resource_auth0_email_template_test.go
@@ -3,34 +3,21 @@ package provider
 import (
 	"testing"
 
-	"github.com/auth0/go-auth0"
-	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
+	"github.com/auth0/terraform-provider-auth0/internal/sweep"
 )
 
 func init() {
-	resource.AddTestSweepers("auth0_email_template", &resource.Sweeper{
-		Name: "auth0_email_template",
-		F: func(_ string) (err error) {
-			api, err := Auth0()
-			if err != nil {
-				return
-			}
-			err = api.EmailTemplate.Update("welcome_email", &management.EmailTemplate{
-				Enabled: auth0.Bool(false),
-			})
-			return
-		},
-	})
+	sweep.EmailTemplates()
 }
 
 func TestAccEmailTemplate(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEmailTemplateConfig,

--- a/internal/provider/resource_auth0_email_test.go
+++ b/internal/provider/resource_auth0_email_test.go
@@ -10,19 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
+	"github.com/auth0/terraform-provider-auth0/internal/sweep"
 )
 
 func init() {
-	resource.AddTestSweepers("auth0_email", &resource.Sweeper{
-		Name: "auth0_email",
-		F: func(_ string) error {
-			api, err := Auth0()
-			if err != nil {
-				return err
-			}
-			return api.EmailProvider.Delete()
-		},
-	})
+	sweep.Email()
 }
 
 const testAccCreateSESEmailProvider = `
@@ -173,7 +165,7 @@ func TestAccEmail(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCreateSESEmailProvider,

--- a/internal/provider/resource_auth0_global_client_test.go
+++ b/internal/provider/resource_auth0_global_client_test.go
@@ -14,7 +14,7 @@ func TestAccGlobalClient(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalClientConfigWithCustomLogin,

--- a/internal/provider/resource_auth0_guardian_test.go
+++ b/internal/provider/resource_auth0_guardian_test.go
@@ -54,7 +54,7 @@ func TestAccGuardian(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGuardianEmailCreate,
@@ -175,7 +175,7 @@ func TestAccGuardianPhone(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGuardianPhoneWithCustomProviderAndNoOptions,
@@ -278,7 +278,7 @@ func TestAccGuardianWebAuthnRoaming(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigureWebAuthnRoamingCreate,
@@ -331,7 +331,7 @@ func TestAccGuardianWebAuthnPlatform(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigureWebAuthnPlatformCreate,
@@ -378,7 +378,7 @@ func TestAccGuardianDUO(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigureDUOCreate,
@@ -471,7 +471,7 @@ func TestAccGuardianPush(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfigurePushCreate,

--- a/internal/provider/resource_auth0_hook_test.go
+++ b/internal/provider/resource_auth0_hook_test.go
@@ -15,7 +15,7 @@ func TestAccHook(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccHookEmpty,
@@ -63,7 +63,7 @@ func TestAccHookSecrets(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccHookCreate, testAccHookSecrets),

--- a/internal/provider/resource_auth0_log_stream_test.go
+++ b/internal/provider/resource_auth0_log_stream_test.go
@@ -2,57 +2,26 @@ package provider
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
+	"github.com/auth0/terraform-provider-auth0/internal/sweep"
 	"github.com/auth0/terraform-provider-auth0/internal/template"
 )
 
 func init() {
-	resource.AddTestSweepers("auth0_log_stream", &resource.Sweeper{
-		Name: "auth0_log_stream",
-		F: func(_ string) error {
-			api, err := Auth0()
-			if err != nil {
-				return err
-			}
-
-			logStreams, err := api.LogStream.List()
-			if err != nil {
-				return err
-			}
-
-			var result *multierror.Error
-			for _, logStream := range logStreams {
-				log.Printf("[DEBUG] ➝ %s", logStream.GetName())
-
-				if strings.Contains(logStream.GetName(), "Test") {
-					result = multierror.Append(
-						result,
-						api.LogStream.Delete(logStream.GetID()),
-					)
-
-					log.Printf("[DEBUG] ✗ %v\n", logStream.GetName())
-				}
-			}
-
-			return result.ErrorOrNil()
-		},
-	})
+	sweep.LogStreams()
 }
 
 func TestAccLogStreamHTTP(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccLogStreamHTTPConfig, t.Name()),
@@ -225,7 +194,7 @@ func TestAccLogStreamEventBridge(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(logStreamAwsEventBridgeConfig, t.Name()),
@@ -300,7 +269,7 @@ func TestAccLogStreamEventGrid(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(logStreamAzureEventGridConfig, t.Name()),
@@ -351,7 +320,7 @@ resource "auth0_log_stream" "my_log_stream" {
 
 func TestAccLogStreamDataDogRegionValidation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(nil),
+		ProviderFactories: ProviderTestFactories(nil),
 		Steps: []resource.TestStep{
 			{
 				Config:      fmt.Sprintf(logStreamDatadogInvalidConfig, "uS"),
@@ -380,7 +349,7 @@ func TestAccLogStreamDatadog(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(logStreamDatadogConfig, t.Name()),
@@ -448,7 +417,7 @@ func TestAccLogStreamSplunk(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(logStreamSplunkConfig, t.Name()),
@@ -505,7 +474,7 @@ func TestAccLogStreamSegment(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(logStreamSegmentConfig, t.Name()),
@@ -608,7 +577,7 @@ func TestAccLogStreamSumo(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(logStreamSumoConfig, t.Name()),
@@ -711,7 +680,7 @@ func TestAccLogStreamMixpanel(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(logStreamMixpanelConfig, t.Name()),

--- a/internal/provider/resource_auth0_organization_connection_test.go
+++ b/internal/provider/resource_auth0_organization_connection_test.go
@@ -46,7 +46,7 @@ func TestAccOrganizationConnection(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(TestAccOrganizationConnectionCreate, strings.ToLower(t.Name())),

--- a/internal/provider/resource_auth0_organization_member_test.go
+++ b/internal/provider/resource_auth0_organization_member_test.go
@@ -20,7 +20,7 @@ func TestAccOrganizationMember(t *testing.T) {
 	testName := strings.ToLower(t.Name())
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{{
 			Config: template.ParseTestName(testAccOrganizationMembersAux+`
 			resource auth0_organization_member test_member {

--- a/internal/provider/resource_auth0_organization_test.go
+++ b/internal/provider/resource_auth0_organization_test.go
@@ -2,56 +2,18 @@ package provider
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"testing"
 
-	"github.com/auth0/go-auth0/management"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
+	"github.com/auth0/terraform-provider-auth0/internal/sweep"
 	"github.com/auth0/terraform-provider-auth0/internal/template"
 )
 
 func init() {
-	resource.AddTestSweepers("auth0_organization", &resource.Sweeper{
-		Name: "auth0_organization",
-		F: func(_ string) error {
-			api, err := Auth0()
-			if err != nil {
-				return err
-			}
-
-			var page int
-			var result *multierror.Error
-			for {
-				organizationList, err := api.Organization.List(management.Page(page))
-				if err != nil {
-					return err
-				}
-
-				for _, organization := range organizationList.Organizations {
-					log.Printf("[DEBUG] ➝ %s", organization.GetName())
-
-					if strings.Contains(organization.GetName(), "test") {
-						result = multierror.Append(
-							result,
-							api.Organization.Delete(organization.GetID()),
-						)
-
-						log.Printf("[DEBUG] ✗ %s", organization.GetName())
-					}
-				}
-				if !organizationList.HasNext() {
-					break
-				}
-				page++
-			}
-
-			return result.ErrorOrNil()
-		},
-	})
+	sweep.Organizations()
 }
 
 const testAccOrganizationGiven2Connections = `
@@ -151,7 +113,7 @@ func TestAccOrganization(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccOrganizationEmpty, strings.ToLower(t.Name())),

--- a/internal/provider/resource_auth0_prompt_custom_text_test.go
+++ b/internal/provider/resource_auth0_prompt_custom_text_test.go
@@ -12,7 +12,7 @@ func TestAccPromptCustomText(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPromptCustomTextCreate,

--- a/internal/provider/resource_auth0_prompt_test.go
+++ b/internal/provider/resource_auth0_prompt_test.go
@@ -42,7 +42,7 @@ func TestAccPrompt(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPromptEmpty,

--- a/internal/provider/resource_auth0_resource_server_test.go
+++ b/internal/provider/resource_auth0_resource_server_test.go
@@ -2,47 +2,25 @@ package provider
 
 import (
 	"fmt"
-	"log"
 	"os"
-	"strings"
 	"testing"
 
-	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
+	"github.com/auth0/terraform-provider-auth0/internal/sweep"
 	"github.com/auth0/terraform-provider-auth0/internal/template"
 )
 
 func init() {
-	resource.AddTestSweepers("auth0_resource_server", &resource.Sweeper{
-		Name: "auth0_resource_server",
-		F: func(_ string) error {
-			api, err := Auth0()
-			if err != nil {
-				return err
-			}
-
-			fn := func(rs *management.ResourceServer) {
-				log.Printf("[DEBUG] ➝ %s", rs.GetName())
-				if strings.Contains(rs.GetName(), "Test") {
-					if err := api.ResourceServer.Delete(rs.GetID()); err != nil {
-						log.Printf("[DEBUG] Failed to delete resource server with ID: %s", rs.GetID())
-					}
-					log.Printf("[DEBUG] ✗ %s", rs.GetName())
-				}
-			}
-
-			return api.ResourceServer.Stream(fn, management.IncludeFields("id", "name"))
-		},
-	})
+	sweep.ResourceServers()
 }
 
 func TestAccResourceServer(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccResourceServerConfigEmpty, t.Name()),
@@ -179,7 +157,7 @@ func TestAccResourceServerAuth0APIManagement(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: `

--- a/internal/provider/resource_auth0_rule_test.go
+++ b/internal/provider/resource_auth0_rule_test.go
@@ -15,7 +15,7 @@ func TestAccRule(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccRuleCreate, t.Name()),

--- a/internal/provider/resource_auth0_tenant_test.go
+++ b/internal/provider/resource_auth0_tenant_test.go
@@ -13,7 +13,7 @@ func TestAccTenant(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEmptyTenant,
@@ -185,7 +185,7 @@ func TestAccTenantDefaults(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config:        testAccEmptyTenant,

--- a/internal/provider/resource_auth0_trigger_binding_test.go
+++ b/internal/provider/resource_auth0_trigger_binding_test.go
@@ -14,7 +14,7 @@ func TestAccTriggerBinding(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testProviders(httpRecorder),
+		ProviderFactories: ProviderTestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccTriggerBindingConfigCreate, t.Name()),

--- a/internal/sweep/api_client.go
+++ b/internal/sweep/api_client.go
@@ -1,0 +1,28 @@
+package sweep
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/auth0/go-auth0/management"
+)
+
+// auth0API returns an instance of the Management
+// API Client used within test sweepers.
+func auth0API() (*management.Management, error) {
+	domain := os.Getenv("AUTH0_DOMAIN")
+	if domain == "" {
+		return nil, fmt.Errorf("failed to instantiate api client: AUTH0_DOMAIN is empty")
+	}
+
+	apiToken := os.Getenv("AUTH0_API_TOKEN")
+	authenticationOption := management.WithStaticToken(apiToken)
+	if apiToken == "" {
+		authenticationOption = management.WithClientCredentials(
+			os.Getenv("AUTH0_CLIENT_ID"),
+			os.Getenv("AUTH0_CLIENT_SECRET"),
+		)
+	}
+
+	return management.New(domain, authenticationOption)
+}

--- a/internal/sweep/clients.go
+++ b/internal/sweep/clients.go
@@ -1,0 +1,50 @@
+package sweep
+
+import (
+	"log"
+	"strings"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Clients will run a test sweeper to remove all Auth0 Clients created through tests.
+func Clients() {
+	resource.AddTestSweepers("auth0_client", &resource.Sweeper{
+		Name: "auth0_client",
+		F: func(_ string) error {
+			api, err := auth0API()
+			if err != nil {
+				return err
+			}
+
+			var page int
+			var result *multierror.Error
+			for {
+				clientList, err := api.Client.List(management.Page(page))
+				if err != nil {
+					return err
+				}
+
+				for _, client := range clientList.Clients {
+					log.Printf("[DEBUG] ➝ %s", client.GetName())
+
+					if strings.Contains(client.GetName(), "Test") {
+						result = multierror.Append(
+							result,
+							api.Client.Delete(client.GetClientID()),
+						)
+						log.Printf("[DEBUG] ✗ %s", client.GetName())
+					}
+				}
+				if !clientList.HasNext() {
+					break
+				}
+				page++
+			}
+
+			return result.ErrorOrNil()
+		},
+	})
+}

--- a/internal/sweep/connections.go
+++ b/internal/sweep/connections.go
@@ -1,0 +1,53 @@
+package sweep
+
+import (
+	"log"
+	"strings"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Connections will run a test sweeper to remove all Auth0 Connections created through tests.
+func Connections() {
+	resource.AddTestSweepers("auth0_connection", &resource.Sweeper{
+		Name: "auth0_connection",
+		F: func(_ string) error {
+			api, err := auth0API()
+			if err != nil {
+				return err
+			}
+
+			var page int
+			var result *multierror.Error
+			for {
+				connectionList, err := api.Connection.List(
+					management.IncludeFields("id", "name"),
+					management.Page(page),
+				)
+				if err != nil {
+					return err
+				}
+
+				for _, connection := range connectionList.Connections {
+					log.Printf("[DEBUG] ➝ %s", connection.GetName())
+
+					if strings.Contains(connection.GetName(), "Test") {
+						result = multierror.Append(
+							result,
+							api.Connection.Delete(connection.GetID()),
+						)
+						log.Printf("[DEBUG] ✗ %s", connection.GetName())
+					}
+				}
+				if !connectionList.HasNext() {
+					break
+				}
+				page++
+			}
+
+			return result.ErrorOrNil()
+		},
+	})
+}

--- a/internal/sweep/custom_domains.go
+++ b/internal/sweep/custom_domains.go
@@ -1,0 +1,43 @@
+package sweep
+
+import (
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// CustomDomains will run a test sweeper to remove all Auth0 Custom Domains created through tests.
+func CustomDomains() {
+	resource.AddTestSweepers("auth0_custom_domain", &resource.Sweeper{
+		Name: "auth0_custom_domain",
+		F: func(_ string) error {
+			api, err := auth0API()
+			if err != nil {
+				return err
+			}
+
+			domains, err := api.CustomDomain.List()
+			if err != nil {
+				return err
+			}
+
+			var result *multierror.Error
+			for _, domain := range domains {
+				log.Printf("[DEBUG] ➝ %s", domain.GetDomain())
+
+				if strings.Contains(domain.GetDomain(), "auth.uat.terraform-provider-auth0.com") {
+					result = multierror.Append(
+						result,
+						api.CustomDomain.Delete(domain.GetID()),
+					)
+
+					log.Printf("[DEBUG] ✗ %s", domain.GetDomain())
+				}
+			}
+
+			return result.ErrorOrNil()
+		},
+	})
+}

--- a/internal/sweep/email.go
+++ b/internal/sweep/email.go
@@ -1,0 +1,38 @@
+package sweep
+
+import (
+	"github.com/auth0/go-auth0"
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Email will run a test sweeper to remove the Auth0 Email Provider created through tests.
+func Email() {
+	resource.AddTestSweepers("auth0_email", &resource.Sweeper{
+		Name: "auth0_email",
+		F: func(_ string) error {
+			api, err := auth0API()
+			if err != nil {
+				return err
+			}
+			return api.EmailProvider.Delete()
+		},
+	})
+}
+
+// EmailTemplates will run a test sweeper to remove all Auth0 Email Templates created through tests.
+func EmailTemplates() {
+	resource.AddTestSweepers("auth0_email_template", &resource.Sweeper{
+		Name: "auth0_email_template",
+		F: func(_ string) (err error) {
+			api, err := auth0API()
+			if err != nil {
+				return
+			}
+			err = api.EmailTemplate.Update("welcome_email", &management.EmailTemplate{
+				Enabled: auth0.Bool(false),
+			})
+			return
+		},
+	})
+}

--- a/internal/sweep/log_streams.go
+++ b/internal/sweep/log_streams.go
@@ -1,0 +1,43 @@
+package sweep
+
+import (
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// LogStreams will run a test sweeper to remove all Auth0 Log Streams created through tests.
+func LogStreams() {
+	resource.AddTestSweepers("auth0_log_stream", &resource.Sweeper{
+		Name: "auth0_log_stream",
+		F: func(_ string) error {
+			api, err := auth0API()
+			if err != nil {
+				return err
+			}
+
+			logStreams, err := api.LogStream.List()
+			if err != nil {
+				return err
+			}
+
+			var result *multierror.Error
+			for _, logStream := range logStreams {
+				log.Printf("[DEBUG] ➝ %s", logStream.GetName())
+
+				if strings.Contains(logStream.GetName(), "Test") {
+					result = multierror.Append(
+						result,
+						api.LogStream.Delete(logStream.GetID()),
+					)
+
+					log.Printf("[DEBUG] ✗ %v\n", logStream.GetName())
+				}
+			}
+
+			return result.ErrorOrNil()
+		},
+	})
+}

--- a/internal/sweep/organizations.go
+++ b/internal/sweep/organizations.go
@@ -1,0 +1,51 @@
+package sweep
+
+import (
+	"log"
+	"strings"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Organizations will run a test sweeper to remove all Auth0 Organizations created through tests.
+func Organizations() {
+	resource.AddTestSweepers("auth0_organization", &resource.Sweeper{
+		Name: "auth0_organization",
+		F: func(_ string) error {
+			api, err := auth0API()
+			if err != nil {
+				return err
+			}
+
+			var page int
+			var result *multierror.Error
+			for {
+				organizationList, err := api.Organization.List(management.Page(page))
+				if err != nil {
+					return err
+				}
+
+				for _, organization := range organizationList.Organizations {
+					log.Printf("[DEBUG] ➝ %s", organization.GetName())
+
+					if strings.Contains(organization.GetName(), "test") {
+						result = multierror.Append(
+							result,
+							api.Organization.Delete(organization.GetID()),
+						)
+
+						log.Printf("[DEBUG] ✗ %s", organization.GetName())
+					}
+				}
+				if !organizationList.HasNext() {
+					break
+				}
+				page++
+			}
+
+			return result.ErrorOrNil()
+		},
+	})
+}

--- a/internal/sweep/resource_servers.go
+++ b/internal/sweep/resource_servers.go
@@ -1,0 +1,34 @@
+package sweep
+
+import (
+	"log"
+	"strings"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// ResourceServers will run a test sweeper to remove all Auth0 Resource Servers created through tests.
+func ResourceServers() {
+	resource.AddTestSweepers("auth0_resource_server", &resource.Sweeper{
+		Name: "auth0_resource_server",
+		F: func(_ string) error {
+			api, err := auth0API()
+			if err != nil {
+				return err
+			}
+
+			fn := func(rs *management.ResourceServer) {
+				log.Printf("[DEBUG] ➝ %s", rs.GetName())
+				if strings.Contains(rs.GetName(), "Test") {
+					if err := api.ResourceServer.Delete(rs.GetID()); err != nil {
+						log.Printf("[DEBUG] Failed to delete resource server with ID: %s", rs.GetID())
+					}
+					log.Printf("[DEBUG] ✗ %s", rs.GetName())
+				}
+			}
+
+			return api.ResourceServer.Stream(fn, management.IncludeFields("id", "name"))
+		},
+	})
+}

--- a/internal/sweep/roles.go
+++ b/internal/sweep/roles.go
@@ -1,0 +1,49 @@
+package sweep
+
+import (
+	"log"
+	"strings"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Roles will run a test sweeper to remove all Auth0 Roles created through tests.
+func Roles() {
+	resource.AddTestSweepers("auth0_role", &resource.Sweeper{
+		Name: "auth0_role",
+		F: func(_ string) error {
+			api, err := auth0API()
+			if err != nil {
+				return err
+			}
+
+			var page int
+			var result *multierror.Error
+			for {
+				roleList, err := api.Role.List(management.Page(page))
+				if err != nil {
+					return err
+				}
+
+				for _, role := range roleList.Roles {
+					log.Printf("[DEBUG] ➝ %s", role.GetName())
+					if strings.Contains(role.GetName(), "Test") {
+						result = multierror.Append(
+							result,
+							api.Role.Delete(role.GetID()),
+						)
+						log.Printf("[DEBUG] ✗ %s", role.GetName())
+					}
+				}
+				if !roleList.HasNext() {
+					break
+				}
+				page++
+			}
+
+			return result.ErrorOrNil()
+		},
+	})
+}

--- a/internal/sweep/rule_configs.go
+++ b/internal/sweep/rule_configs.go
@@ -1,0 +1,41 @@
+package sweep
+
+import (
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// RuleConfigs will run a test sweeper to remove all Auth0 Rule Configs created through tests.
+func RuleConfigs() {
+	resource.AddTestSweepers("auth0_rule_config", &resource.Sweeper{
+		Name: "auth0_rule_config",
+		F: func(_ string) error {
+			api, err := auth0API()
+			if err != nil {
+				return err
+			}
+
+			configurations, err := api.RuleConfig.List()
+			if err != nil {
+				return err
+			}
+
+			var result *multierror.Error
+			for _, c := range configurations {
+				log.Printf("[DEBUG] ➝ %s", c.GetKey())
+				if strings.Contains(c.GetKey(), "test") {
+					result = multierror.Append(
+						result,
+						api.RuleConfig.Delete(c.GetKey()),
+					)
+					log.Printf("[DEBUG] ✗ %s", c.GetKey())
+				}
+			}
+
+			return result.ErrorOrNil()
+		},
+	})
+}

--- a/internal/sweep/users.go
+++ b/internal/sweep/users.go
@@ -1,0 +1,47 @@
+package sweep
+
+import (
+	"log"
+
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Users will run a test sweeper to remove all Auth0 Users created through tests.
+func Users() {
+	resource.AddTestSweepers("auth0_user", &resource.Sweeper{
+		Name: "auth0_user",
+		F: func(_ string) error {
+			api, err := auth0API()
+			if err != nil {
+				return err
+			}
+
+			var page int
+			var result *multierror.Error
+			for {
+				userList, err := api.User.Search(
+					management.Page(page),
+					management.Query(`email.domain:"acceptance.test.com"`))
+				if err != nil {
+					return err
+				}
+
+				for _, user := range userList.Users {
+					result = multierror.Append(
+						result,
+						api.User.Delete(user.GetID()),
+					)
+					log.Printf("[DEBUG] ✗ %s", user.GetName())
+				}
+				if !userList.HasNext() {
+					break
+				}
+				page++
+			}
+
+			return result.ErrorOrNil()
+		},
+	})
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

As we're preparing to add additional data sources and expand the project, we're taking the liberty of extracting the sweeper logic into a dedicated pkg. This will ultimately help for the goal of ending up with a package structure as follows:

```
.
└── terraform-provider-auth0/
    └── internal/
        ├── mutex
        ├── provider
        ├── auth0/
        │   ├── client/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── resource_global.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   ├── connection/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   ├── organization/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── resource_connection.go
        │   │   ├── resource_member.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   └── ...
        ├── recorder
        ├── sweep
        ├── template
        ├── validation
        └── value
```

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
