### PR TITLE
DXCDT-360: Move user resources to dedicated pkg

### DIFF
--- a/internal/auth0/user/resource.go
+++ b/internal/auth0/user/resource.go
@@ -1,4 +1,4 @@
-package provider
+package user
 
 import (
 	"context"
@@ -18,7 +18,8 @@ import (
 
 type validateUserFunc func(*management.User) error
 
-func newUser() *schema.Resource {
+// NewResource will return a new auth0_user resource.
+func NewResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: createUser,
 		ReadContext:   readUser,

--- a/internal/auth0/user/resource_test.go
+++ b/internal/auth0/user/resource_test.go
@@ -1,4 +1,4 @@
-package provider
+package user_test
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
+	"github.com/auth0/terraform-provider-auth0/internal/provider"
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
 	"github.com/auth0/terraform-provider-auth0/internal/sweep"
 	"github.com/auth0/terraform-provider-auth0/internal/template"
@@ -17,9 +18,15 @@ func init() {
 	sweep.Users()
 }
 
+// This is needed so that the test
+// sweepers get registered.
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
 func TestAccUserMissingRequiredParams(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: TestFactories(nil),
+		ProviderFactories: provider.TestFactories(nil),
 		Steps: []resource.TestStep{
 			{
 				Config:      "resource auth0_user user {}",
@@ -156,7 +163,7 @@ func TestAccUser(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: TestFactories(httpRecorder),
+		ProviderFactories: provider.TestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccUserEmpty, strings.ToLower(t.Name())),
@@ -255,7 +262,7 @@ func TestAccUserChangeUsername(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: TestFactories(httpRecorder),
+		ProviderFactories: provider.TestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccUserChangeUsernameCreate, "terra"),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/organization"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/resourceserver"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/tenant"
+	"github.com/auth0/terraform-provider-auth0/internal/auth0/user"
 )
 
 var version = "dev"
@@ -96,7 +97,7 @@ func New() *schema.Provider {
 			"auth0_prompt_custom_text":         newPromptCustomText(),
 			"auth0_email":                      newEmail(),
 			"auth0_email_template":             newEmailTemplate(),
-			"auth0_user":                       newUser(),
+			"auth0_user":                       user.NewResource(),
 			"auth0_tenant":                     tenant.NewResource(),
 			"auth0_role":                       newRole(),
 			"auth0_log_stream":                 newLogStream(),


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes


In this PR we are getting closer and closer to our ideal package structure:

```
.
└── terraform-provider-auth0/
    └── internal/
        ├── mutex
        ├── provider
        ├── auth0/
        │   ├── client/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── resource_global.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   ├── connection/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   ├── organization/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── resource_connection.go
        │   │   ├── resource_member.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   └── ...
        ├── recorder
        ├── sweep
        ├── template
        ├── validation
        └── value
```

We migrate all user related resources to their own user pkg. 


### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
