### PR TITLE
DXCDT-360: Move custom domain resources to dedicated pkg

### DIFF
--- a/internal/auth0/customdomain/resource.go
+++ b/internal/auth0/customdomain/resource.go
@@ -1,4 +1,4 @@
-package provider
+package customdomain
 
 import (
 	"context"
@@ -13,7 +13,8 @@ import (
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
-func newCustomDomain() *schema.Resource {
+// NewResource will return a new auth0_custom_domain resource.
+func NewResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: createCustomDomain,
 		ReadContext:   readCustomDomain,

--- a/internal/auth0/customdomain/resource_test.go
+++ b/internal/auth0/customdomain/resource_test.go
@@ -1,4 +1,4 @@
-package provider
+package customdomain_test
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
+	"github.com/auth0/terraform-provider-auth0/internal/provider"
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
 	"github.com/auth0/terraform-provider-auth0/internal/sweep"
 	"github.com/auth0/terraform-provider-auth0/internal/template"
@@ -14,6 +15,12 @@ import (
 
 func init() {
 	sweep.CustomDomains()
+}
+
+// This is needed so that the test
+// sweepers get registered.
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
 }
 
 const testAccCreateSelfManagedCustomDomain = `
@@ -58,7 +65,7 @@ func TestAccCustomDomain(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: TestFactories(httpRecorder),
+		ProviderFactories: provider.TestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: template.ParseTestName(testAccCreateSelfManagedCustomDomain, strings.ToLower(t.Name())),

--- a/internal/auth0/customdomain/resource_verification.go
+++ b/internal/auth0/customdomain/resource_verification.go
@@ -1,4 +1,4 @@
-package provider
+package customdomain
 
 import (
 	"context"
@@ -14,7 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func newCustomDomainVerification() *schema.Resource {
+// NewVerificationResource will return a new auth0_custom_domain_verification resource.
+func NewVerificationResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: createCustomDomainVerification,
 		ReadContext:   readCustomDomainVerification,

--- a/internal/auth0/customdomain/resource_verification_test.go
+++ b/internal/auth0/customdomain/resource_verification_test.go
@@ -1,4 +1,4 @@
-package provider
+package customdomain_test
 
 import (
 	"os"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
+	"github.com/auth0/terraform-provider-auth0/internal/provider"
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
 )
 
@@ -17,7 +18,7 @@ func TestAccCustomDomainVerificationWithAuth0ManagedCerts(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: TestFactories(httpRecorder),
+		ProviderFactories: provider.TestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCustomDomainVerificationWithAuth0ManagedCerts,
@@ -72,7 +73,7 @@ func TestAccCustomDomainVerificationWithSelfManagedCerts(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: TestFactories(httpRecorder),
+		ProviderFactories: provider.TestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCustomDomainVerificationWithSelfManagedCerts,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/client"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/connection"
+	"github.com/auth0/terraform-provider-auth0/internal/auth0/customdomain"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/organization"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/resourceserver"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/role"
@@ -88,8 +89,8 @@ func New() *schema.Provider {
 			"auth0_client_grant":               newClientGrant(),
 			"auth0_connection":                 connection.NewResource(),
 			"auth0_connection_client":          connection.NewClientResource(),
-			"auth0_custom_domain":              newCustomDomain(),
-			"auth0_custom_domain_verification": newCustomDomainVerification(),
+			"auth0_custom_domain":              customdomain.NewResource(),
+			"auth0_custom_domain_verification": customdomain.NewVerificationResource(),
 			"auth0_resource_server":            resourceserver.NewResource(),
 			"auth0_rule":                       newRule(),
 			"auth0_rule_config":                newRuleConfig(),


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

In this PR we are getting closer and closer to our ideal package structure:

```
.
└── terraform-provider-auth0/
    └── internal/
        ├── mutex
        ├── provider
        ├── auth0/
        │   ├── client/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── resource_global.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   ├── connection/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   ├── organization/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── resource_connection.go
        │   │   ├── resource_member.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   └── ...
        ├── recorder
        ├── sweep
        ├── template
        ├── validation
        └── value
```

We migrate all custom domain related resources to their own pkg.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
