### PR TITLE
DXCDT-360: Move prompt resources to dedicated pkg

### DIFF
--- a/internal/auth0/prompt/resource.go
+++ b/internal/auth0/prompt/resource.go
@@ -1,4 +1,4 @@
-package provider
+package prompt
 
 import (
 	"context"
@@ -14,7 +14,8 @@ import (
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
-func newPrompt() *schema.Resource {
+// NewResource will return a new auth0_prompt resource.
+func NewResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: createPrompt,
 		ReadContext:   readPrompt,

--- a/internal/auth0/prompt/resource_custom_text.go
+++ b/internal/auth0/prompt/resource_custom_text.go
@@ -1,4 +1,4 @@
-package provider
+package prompt
 
 import (
 	"bytes"
@@ -32,7 +32,8 @@ var (
 	errInvalidPromptCustomTextIDFormat = fmt.Errorf("ID must be formated as prompt:language")
 )
 
-func newPromptCustomText() *schema.Resource {
+// NewCustomTextResource will return a new auth0_prompt_custom_text resource.
+func NewCustomTextResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: createPromptCustomText,
 		ReadContext:   readPromptCustomText,

--- a/internal/auth0/prompt/resource_custom_text_test.go
+++ b/internal/auth0/prompt/resource_custom_text_test.go
@@ -1,10 +1,11 @@
-package provider
+package prompt_test
 
 import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
+	"github.com/auth0/terraform-provider-auth0/internal/provider"
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
 )
 
@@ -12,7 +13,7 @@ func TestAccPromptCustomText(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: TestFactories(httpRecorder),
+		ProviderFactories: provider.TestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPromptCustomTextCreate,

--- a/internal/auth0/prompt/resource_test.go
+++ b/internal/auth0/prompt/resource_test.go
@@ -1,10 +1,11 @@
-package provider
+package prompt_test
 
 import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
+	"github.com/auth0/terraform-provider-auth0/internal/provider"
 	"github.com/auth0/terraform-provider-auth0/internal/recorder"
 )
 
@@ -42,7 +43,7 @@ func TestAccPrompt(t *testing.T) {
 	httpRecorder := recorder.New(t)
 
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: TestFactories(httpRecorder),
+		ProviderFactories: provider.TestFactories(httpRecorder),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPromptEmpty,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/connection"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/customdomain"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/organization"
+	"github.com/auth0/terraform-provider-auth0/internal/auth0/prompt"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/resourceserver"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/role"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/tenant"
@@ -97,8 +98,8 @@ func New() *schema.Provider {
 			"auth0_rule":                       newRule(),
 			"auth0_rule_config":                newRuleConfig(),
 			"auth0_hook":                       newHook(),
-			"auth0_prompt":                     newPrompt(),
-			"auth0_prompt_custom_text":         newPromptCustomText(),
+			"auth0_prompt":                     prompt.NewResource(),
+			"auth0_prompt_custom_text":         prompt.NewCustomTextResource(),
 			"auth0_email":                      newEmail(),
 			"auth0_email_template":             newEmailTemplate(),
 			"auth0_user":                       user.NewResource(),


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes



In this PR we are getting closer and closer to our ideal package structure:

```
.
└── terraform-provider-auth0/
    └── internal/
        ├── mutex
        ├── provider
        ├── auth0/
        │   ├── client/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── resource_global.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   ├── connection/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   ├── organization/
        │   │   ├── data_source.go
        │   │   ├── resource.go
        │   │   ├── resource_connection.go
        │   │   ├── resource_member.go
        │   │   ├── flatten.go
        │   │   └── expand.go
        │   └── ...
        ├── recorder
        ├── sweep
        ├── template
        ├── validation
        └── value
```

We migrate all prompt related resources to their own pkg.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
