### PR TITLE
issue#530: Fix auth0_resource_server data source to always return the id

### DIFF
--- a/internal/auth0/resourceserver/resource.go
+++ b/internal/auth0/resourceserver/resource.go
@@ -170,6 +170,10 @@ func readResourceServer(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 
+	// Ensuring the ID is the resource server ID and not the identifier,
+	// as both can be used to find a resource server with the Read() func.
+	d.SetId(resourceServer.GetID())
+
 	result := multierror.Append(
 		d.Set("name", resourceServer.GetName()),
 		d.Set("identifier", resourceServer.GetIdentifier()),


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Fixes auth0_resource_server to always expose the ID in the id field instead of the identifier. 

### 📚 References

- #530 

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
