### PR TITLE
[1/2] DXCDT-446: Add new config struct to hold api client and global mutex

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X github.com/auth0/terraform-provider-auth0/internal/provider.version={{.Version}}'
+      - '-s -w -X github.com/auth0/terraform-provider-auth0/internal/config.version={{.Version}}'
     goos:
       - freebsd
       - windows

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ build: ## Build the provider binary. Usage: "make build VERSION=0.2.0"
 	then \
 	  echo "Please provide a version. Example: make build VERSION=0.2.0" && exit 1; \
  	fi
-	@go build -v -ldflags "-X github.com/auth0/terraform-provider-auth0/internal/provider.version=${VERSION}" -o "${BUILD_DIR}/${BINARY}_v$(VERSION)"
+	@go build -v -ldflags "-X github.com/auth0/terraform-provider-auth0/internal/config.version=${VERSION}" -o "${BUILD_DIR}/${BINARY}_v$(VERSION)"
 
 install: build ## Install the provider as a terraform plugin. Usage: "make install VERSION=0.2.0"
 	@mkdir -p "${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/$(VERSION)/${GO_OS}_${GO_ARCH}"

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/provider"
 )
 
@@ -55,9 +56,7 @@ func testFactoriesWithHTTPRecordings(httpRecorder *recorder.Recorder) map[string
 	}
 }
 
-func configureTestProviderWithHTTPRecordings(
-	httpRecorder *recorder.Recorder,
-) func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
+func configureTestProviderWithHTTPRecordings(httpRecorder *recorder.Recorder) schema.ConfigureContextFunc {
 	return func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		domain := data.Get("domain").(string)
 		debug := data.Get("debug").(bool)
@@ -90,6 +89,6 @@ func configureTestProviderWithHTTPRecordings(
 			return nil, diag.FromErr(err)
 		}
 
-		return apiClient, nil
+		return config.New(apiClient), nil
 	}
 }

--- a/internal/auth0/action/resource.go
+++ b/internal/auth0/action/resource.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 )
 
 // NewResource will return a new auth0_action resource.
@@ -131,7 +133,7 @@ func NewResource() *schema.Resource {
 }
 
 func createAction(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	action := expandAction(d.GetRawConfig())
 	if err := api.Action.Create(action); err != nil {
@@ -148,7 +150,7 @@ func createAction(ctx context.Context, d *schema.ResourceData, m interface{}) di
 }
 
 func readAction(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	action, err := api.Action.Read(d.Id())
 	if err != nil {
@@ -177,7 +179,7 @@ func readAction(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 }
 
 func updateAction(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	diagnostics := preventErasingUnmanagedSecrets(d, api)
 	if diagnostics.HasError() {
@@ -197,7 +199,7 @@ func updateAction(ctx context.Context, d *schema.ResourceData, m interface{}) di
 }
 
 func deleteAction(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if err := api.Action.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {
@@ -217,7 +219,7 @@ func deployAction(ctx context.Context, d *schema.ResourceData, m interface{}) di
 		return nil
 	}
 
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		action, err := api.Action.Read(d.Id())

--- a/internal/auth0/action/resource_trigger_binding.go
+++ b/internal/auth0/action/resource_trigger_binding.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 )
 
 // NewTriggerBindingResource will return a new auth0_trigger_binding resource.
@@ -68,7 +70,7 @@ func NewTriggerBindingResource() *schema.Resource {
 }
 
 func createTriggerBinding(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	id := d.Get("trigger").(string)
 	triggerBindings := expandTriggerBindings(d.GetRawConfig().GetAttr("actions"))
@@ -83,7 +85,7 @@ func createTriggerBinding(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func readTriggerBinding(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	triggerBindings, err := api.Action.Bindings(d.Id())
 	if err != nil {
@@ -104,7 +106,7 @@ func readTriggerBinding(ctx context.Context, d *schema.ResourceData, m interface
 
 func updateTriggerBinding(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	triggerBindings := expandTriggerBindings(d.GetRawConfig().GetAttr("actions"))
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.Action.UpdateBindings(d.Id(), triggerBindings); err != nil {
 		return diag.FromErr(err)
 	}
@@ -113,7 +115,7 @@ func updateTriggerBinding(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func deleteTriggerBinding(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.Action.UpdateBindings(d.Id(), []*management.ActionBinding{}); err != nil {
 		if mErr, ok := err.(management.Error); ok {
 			if mErr.Status() == http.StatusNotFound {

--- a/internal/auth0/attackprotection/resource.go
+++ b/internal/auth0/attackprotection/resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -277,7 +278,7 @@ func createAttackProtection(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func readAttackProtection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	breachedPasswords, err := api.AttackProtection.GetBreachedPasswordDetection()
 	if err != nil {
@@ -304,7 +305,7 @@ func readAttackProtection(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func updateAttackProtection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if ipt := expandSuspiciousIPThrottling(d); ipt != nil {
 		if err := api.AttackProtection.UpdateSuspiciousIPThrottling(ipt); err != nil {
@@ -328,7 +329,7 @@ func updateAttackProtection(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func deleteAttackProtection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	enabled := false
 

--- a/internal/auth0/branding/data_source.go
+++ b/internal/auth0/branding/data_source.go
@@ -3,12 +3,12 @@ package branding
 import (
 	"context"
 
-	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalSchema "github.com/auth0/terraform-provider-auth0/internal/schema"
 )
 
@@ -29,7 +29,7 @@ func readBrandingForDataSource(ctx context.Context, data *schema.ResourceData, m
 	// This resource is not identified by an id in the Auth0 management API.
 	data.SetId(id.UniqueId())
 
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 
 	branding, err := api.Branding.Read()
 	if err != nil {

--- a/internal/auth0/branding/resource.go
+++ b/internal/auth0/branding/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -104,7 +105,7 @@ func createBranding(ctx context.Context, d *schema.ResourceData, m interface{}) 
 }
 
 func readBranding(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	branding, err := api.Branding.Read()
 	if err != nil {
@@ -138,7 +139,7 @@ func readBranding(ctx context.Context, d *schema.ResourceData, m interface{}) di
 }
 
 func updateBranding(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if branding := expandBranding(d.GetRawConfig()); branding.String() != "{}" {
 		if err := api.Branding.Update(branding); err != nil {
@@ -160,7 +161,7 @@ func updateBranding(ctx context.Context, d *schema.ResourceData, m interface{}) 
 }
 
 func deleteBranding(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if _, ok := d.GetOk("universal_login"); !ok {
 		d.SetId("")

--- a/internal/auth0/branding/resource_theme.go
+++ b/internal/auth0/branding/resource_theme.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -462,7 +463,7 @@ func NewThemeResource() *schema.Resource {
 }
 
 func createBrandingTheme(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 
 	if existingBrandingTheme, err := api.BrandingTheme.Default(); err == nil {
 		data.SetId(existingBrandingTheme.GetID())
@@ -480,7 +481,7 @@ func createBrandingTheme(ctx context.Context, data *schema.ResourceData, meta in
 }
 
 func readBrandingTheme(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 
 	brandingTheme, err := api.BrandingTheme.Default()
 	if err != nil {
@@ -507,7 +508,7 @@ func readBrandingTheme(ctx context.Context, data *schema.ResourceData, meta inte
 }
 
 func updateBrandingTheme(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 
 	brandingTheme := expandBrandingTheme(data)
 	if err := api.BrandingTheme.Update(data.Id(), &brandingTheme); err != nil {
@@ -518,7 +519,7 @@ func updateBrandingTheme(ctx context.Context, data *schema.ResourceData, meta in
 }
 
 func deleteBrandingTheme(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 
 	if err := api.BrandingTheme.Delete(data.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok {

--- a/internal/auth0/client/data_source.go
+++ b/internal/auth0/client/data_source.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalSchema "github.com/auth0/terraform-provider-auth0/internal/schema"
 )
 
@@ -44,7 +45,7 @@ func readClientForDataSource(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.Errorf("One of 'client_id' or 'name' is required.")
 	}
 
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	var page int
 	for {

--- a/internal/auth0/client/global_resource.go
+++ b/internal/auth0/client/global_resource.go
@@ -6,6 +6,8 @@ import (
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 )
 
 // NewGlobalResource will return a new auth0_global_client resource.
@@ -52,7 +54,7 @@ func createGlobalClient(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func readGlobalClientID(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	clients, err := api.Client.List(
 		management.Parameter("is_global", "true"),

--- a/internal/auth0/client/resource.go
+++ b/internal/auth0/client/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalValidation "github.com/auth0/terraform-provider-auth0/internal/validation"
 )
 
@@ -734,7 +735,7 @@ func NewResource() *schema.Resource {
 }
 
 func createClient(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	client := expandClient(d)
 	if err := api.Client.Create(client); err != nil {
@@ -747,7 +748,7 @@ func createClient(ctx context.Context, d *schema.ResourceData, m interface{}) di
 }
 
 func readClient(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	client, err := api.Client.Read(d.Id())
 	if err != nil {
@@ -800,7 +801,7 @@ func readClient(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 }
 
 func updateClient(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	client := expandClient(d)
 	if clientHasChange(client) {
@@ -819,7 +820,7 @@ func updateClient(ctx context.Context, d *schema.ResourceData, m interface{}) di
 }
 
 func deleteClient(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if err := api.Client.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {
@@ -837,7 +838,7 @@ func rotateClientSecret(d *schema.ResourceData, m interface{}) error {
 		return nil
 	}
 
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	client, err := api.Client.RotateSecret(d.Id())
 	if err != nil {

--- a/internal/auth0/client/resource_grant.go
+++ b/internal/auth0/client/resource_grant.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -50,7 +51,7 @@ func NewGrantResource() *schema.Resource {
 }
 
 func createClientGrant(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	grantList, err := api.ClientGrant.List(
 		management.Parameter("audience", d.Get("audience").(string)),
@@ -76,7 +77,7 @@ func createClientGrant(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 func readClientGrant(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	clientGrant, err := api.ClientGrant.Read(d.Id())
 	if err != nil {
@@ -97,7 +98,7 @@ func readClientGrant(ctx context.Context, d *schema.ResourceData, m interface{})
 }
 
 func updateClientGrant(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	clientGrant := expandClientGrant(d)
 	if clientGrantHasChange(clientGrant) {
@@ -110,7 +111,7 @@ func updateClientGrant(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 func deleteClientGrant(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if err := api.ClientGrant.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {

--- a/internal/auth0/connection/data_source.go
+++ b/internal/auth0/connection/data_source.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalSchema "github.com/auth0/terraform-provider-auth0/internal/schema"
 )
 
@@ -42,7 +43,7 @@ func readConnectionForDataSource(ctx context.Context, data *schema.ResourceData,
 		return readConnection(ctx, data, meta)
 	}
 
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 	name := data.Get("name").(string)
 	page := 0
 	for {

--- a/internal/auth0/connection/resource.go
+++ b/internal/auth0/connection/resource.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 )
 
 // NewResource will return a new auth0_connection resource.
@@ -42,7 +44,7 @@ func NewResource() *schema.Resource {
 }
 
 func createConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	connection, diagnostics := expandConnection(d, api)
 	if diagnostics.HasError() {
@@ -61,7 +63,7 @@ func createConnection(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func readConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	connection, err := api.Connection.Read(d.Id())
 	if err != nil {
@@ -103,7 +105,7 @@ func readConnection(ctx context.Context, d *schema.ResourceData, m interface{}) 
 }
 
 func updateConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	connection, diagnostics := expandConnection(d, api)
 	if diagnostics.HasError() {
@@ -120,7 +122,7 @@ func updateConnection(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func deleteConnection(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if err := api.Connection.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {

--- a/internal/auth0/connection/resource_client.go
+++ b/internal/auth0/connection/resource_client.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/auth0/terraform-provider-auth0/internal/mutex"
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalSchema "github.com/auth0/terraform-provider-auth0/internal/schema"
 )
 
@@ -51,12 +51,13 @@ func NewClientResource() *schema.Resource {
 }
 
 func createConnectionClient(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
+	mutex := meta.(*config.Config).GetMutex()
 
 	connectionID := data.Get("connection_id").(string)
 
-	mutex.Global.Lock(connectionID)
-	defer mutex.Global.Unlock(connectionID)
+	mutex.Lock(connectionID)
+	defer mutex.Unlock(connectionID)
 
 	connection, err := api.Connection.Read(connectionID)
 	if err != nil {
@@ -79,7 +80,7 @@ func createConnectionClient(ctx context.Context, data *schema.ResourceData, meta
 }
 
 func readConnectionClient(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 
 	connectionID := data.Get("connection_id").(string)
 	clientID := data.Get("client_id").(string)
@@ -113,12 +114,13 @@ func readConnectionClient(_ context.Context, data *schema.ResourceData, meta int
 }
 
 func deleteConnectionClient(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
+	mutex := meta.(*config.Config).GetMutex()
 
 	connectionID := data.Get("connection_id").(string)
 
-	mutex.Global.Lock(connectionID)
-	defer mutex.Global.Unlock(connectionID)
+	mutex.Lock(connectionID)
+	defer mutex.Unlock(connectionID)
 
 	connection, err := api.Connection.Read(connectionID)
 	if err != nil {

--- a/internal/auth0/connection/resource_clients.go
+++ b/internal/auth0/connection/resource_clients.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/auth0/terraform-provider-auth0/internal/mutex"
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -54,12 +54,13 @@ func NewClientsResource() *schema.Resource {
 }
 
 func createConnectionClients(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
+	mutex := meta.(*config.Config).GetMutex()
 
 	connectionID := data.Get("connection_id").(string)
 
-	mutex.Global.Lock(connectionID)
-	defer mutex.Global.Unlock(connectionID)
+	mutex.Lock(connectionID)
+	defer mutex.Unlock(connectionID)
 
 	connection, err := api.Connection.Read(
 		connectionID,
@@ -99,7 +100,7 @@ func createConnectionClients(ctx context.Context, data *schema.ResourceData, met
 }
 
 func readConnectionClients(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 
 	connection, err := api.Connection.Read(
 		data.Id(),
@@ -124,10 +125,11 @@ func readConnectionClients(ctx context.Context, data *schema.ResourceData, meta 
 }
 
 func updateConnectionClients(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
+	mutex := meta.(*config.Config).GetMutex()
 
-	mutex.Global.Lock(data.Id())
-	defer mutex.Global.Unlock(data.Id())
+	mutex.Lock(data.Id())
+	defer mutex.Unlock(data.Id())
 
 	if err := api.Connection.Update(
 		data.Id(),
@@ -145,10 +147,11 @@ func updateConnectionClients(ctx context.Context, data *schema.ResourceData, met
 }
 
 func deleteConnectionClients(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
+	mutex := meta.(*config.Config).GetMutex()
 
-	mutex.Global.Lock(data.Id())
-	defer mutex.Global.Unlock(data.Id())
+	mutex.Lock(data.Id())
+	defer mutex.Unlock(data.Id())
 
 	enabledClients := make([]string, 0)
 

--- a/internal/auth0/customdomain/data_source.go
+++ b/internal/auth0/customdomain/data_source.go
@@ -3,11 +3,11 @@ package customdomain
 import (
 	"context"
 
-	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalSchema "github.com/auth0/terraform-provider-auth0/internal/schema"
 )
 
@@ -25,7 +25,7 @@ func dataSourceSchema() map[string]*schema.Schema {
 }
 
 func readCustomDomainForDataSource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 
 	customDomains, err := api.CustomDomain.List()
 	if err != nil {

--- a/internal/auth0/customdomain/resource.go
+++ b/internal/auth0/customdomain/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -100,7 +101,7 @@ func NewResource() *schema.Resource {
 }
 
 func createCustomDomain(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	customDomain := expandCustomDomain(d)
 	if err := api.CustomDomain.Create(customDomain); err != nil {
@@ -113,7 +114,7 @@ func createCustomDomain(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func readCustomDomain(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	customDomain, err := api.CustomDomain.Read(d.Id())
 	if err != nil {
@@ -144,7 +145,7 @@ func readCustomDomain(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func updateCustomDomain(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	customDomain := expandCustomDomain(d)
 	if err := api.CustomDomain.Update(d.Id(), customDomain); err != nil {
@@ -159,7 +160,7 @@ func updateCustomDomain(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func deleteCustomDomain(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if err := api.CustomDomain.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {

--- a/internal/auth0/customdomain/resource_verification.go
+++ b/internal/auth0/customdomain/resource_verification.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 )
 
 // NewVerificationResource will return a new auth0_custom_domain_verification resource.
@@ -55,7 +57,7 @@ func NewVerificationResource() *schema.Resource {
 }
 
 func createCustomDomainVerification(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		customDomainVerification, err := api.CustomDomain.Verify(d.Get("custom_domain_id").(string))
@@ -90,7 +92,7 @@ func createCustomDomainVerification(ctx context.Context, d *schema.ResourceData,
 }
 
 func readCustomDomainVerification(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	customDomain, err := api.CustomDomain.Read(d.Id())
 	if err != nil {

--- a/internal/auth0/email/resource.go
+++ b/internal/auth0/email/resource.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 )
 
 // NewResource will return a new auth0_email resource.
@@ -187,7 +189,7 @@ func NewResource() *schema.Resource {
 func createEmail(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	d.SetId(id.UniqueId())
 
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if emailProviderIsConfigured(api) {
 		return updateEmail(ctx, d, m)
 	}
@@ -201,7 +203,7 @@ func createEmail(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 }
 
 func readEmail(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	email, err := api.EmailProvider.Read()
 	if err != nil {
@@ -225,7 +227,7 @@ func readEmail(ctx context.Context, d *schema.ResourceData, m interface{}) diag.
 }
 
 func updateEmail(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	email := expandEmailProvider(d.GetRawConfig())
 	if err := api.EmailProvider.Update(email); err != nil {
@@ -236,7 +238,7 @@ func updateEmail(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 }
 
 func deleteEmail(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if err := api.EmailProvider.Delete(); err != nil {
 		return diag.FromErr(err)

--- a/internal/auth0/email/resource_template.go
+++ b/internal/auth0/email/resource_template.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 )
 
 // NewTemplateResource will return a new auth0_email_template resource.
@@ -99,7 +101,7 @@ func NewTemplateResource() *schema.Resource {
 }
 
 func createEmailTemplate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	email := expandEmailTemplate(d.GetRawConfig())
 
@@ -129,7 +131,7 @@ func createEmailTemplate(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func readEmailTemplate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	email, err := api.EmailTemplate.Read(d.Id())
 	if err != nil {
@@ -158,7 +160,7 @@ func readEmailTemplate(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 func updateEmailTemplate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	email := expandEmailTemplate(d.GetRawConfig())
 	if err := api.EmailTemplate.Update(d.Id(), email); err != nil {
@@ -169,7 +171,7 @@ func updateEmailTemplate(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func deleteEmailTemplate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	emailTemplate := &management.EmailTemplate{
 		Template: auth0.String(d.Id()),
 		Enabled:  auth0.Bool(false),

--- a/internal/auth0/guardian/resource.go
+++ b/internal/auth0/guardian/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalValidation "github.com/auth0/terraform-provider-auth0/internal/validation"
 )
 
@@ -416,7 +417,7 @@ func createGuardian(ctx context.Context, d *schema.ResourceData, m interface{}) 
 }
 
 func readGuardian(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	flattenedPolicy, err := flattenMultiFactorPolicy(api)
 	if err != nil {
@@ -480,7 +481,7 @@ func readGuardian(ctx context.Context, d *schema.ResourceData, m interface{}) di
 }
 
 func updateGuardian(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	result := multierror.Append(
 		updatePolicy(d, api),
@@ -501,7 +502,7 @@ func updateGuardian(ctx context.Context, d *schema.ResourceData, m interface{}) 
 }
 
 func deleteGuardian(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	result := multierror.Append(
 		api.Guardian.MultiFactor.UpdatePolicy(&management.MultiFactorPolicies{}),

--- a/internal/auth0/hook/expand.go
+++ b/internal/auth0/hook/expand.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -34,7 +35,7 @@ func expandHook(d *schema.ResourceData) *management.Hook {
 func checkForUntrackedHookSecrets(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	secretsFromConfig := d.Get("secrets").(map[string]interface{})
 
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	secretsFromAPI, err := api.Hook.Secrets(d.Id())
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/auth0/hook/resource.go
+++ b/internal/auth0/hook/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -79,7 +80,7 @@ func NewResource() *schema.Resource {
 }
 
 func createHook(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	hook := expandHook(d)
 	if err := api.Hook.Create(hook); err != nil {
@@ -96,7 +97,7 @@ func createHook(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 }
 
 func readHook(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	hook, err := api.Hook.Read(d.Id())
 	if err != nil {
 		if mErr, ok := err.(management.Error); ok {
@@ -127,7 +128,7 @@ func readHook(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 
 func updateHook(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	hook := expandHook(d)
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.Hook.Update(d.Id(), hook); err != nil {
 		return diag.FromErr(err)
 	}
@@ -140,7 +141,7 @@ func updateHook(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 }
 
 func deleteHook(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.Hook.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok {
 			if mErr.Status() == http.StatusNotFound {
@@ -156,7 +157,7 @@ func deleteHook(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 
 func upsertHookSecrets(ctx context.Context, d *schema.ResourceData, m interface{}) error {
 	if d.IsNewResource() || d.HasChange("secrets") {
-		api := m.(*management.Management)
+		api := m.(*config.Config).GetAPI()
 
 		hookSecrets := value.MapOfStrings(d.GetRawConfig().GetAttr("secrets"))
 		if hookSecrets == nil {

--- a/internal/auth0/logstream/resource.go
+++ b/internal/auth0/logstream/resource.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 )
 
 var validLogStreamTypes = []string{
@@ -261,7 +263,7 @@ func NewResource() *schema.Resource {
 }
 
 func createLogStream(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	logStream := expandLogStream(d)
 	if err := api.LogStream.Create(logStream); err != nil {
@@ -284,7 +286,7 @@ func createLogStream(ctx context.Context, d *schema.ResourceData, m interface{})
 }
 
 func readLogStream(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	logStream, err := api.LogStream.Read(d.Id())
 	if err != nil {
@@ -307,7 +309,7 @@ func readLogStream(ctx context.Context, d *schema.ResourceData, m interface{}) d
 }
 
 func updateLogStream(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	logStream := expandLogStream(d)
 	if err := api.LogStream.Update(d.Id(), logStream); err != nil {
@@ -318,7 +320,7 @@ func updateLogStream(ctx context.Context, d *schema.ResourceData, m interface{})
 }
 
 func deleteLogStream(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if err := api.LogStream.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {

--- a/internal/auth0/organization/data_source.go
+++ b/internal/auth0/organization/data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalSchema "github.com/auth0/terraform-provider-auth0/internal/schema"
 )
 
@@ -61,7 +62,7 @@ func dataSourceSchema() map[string]*schema.Schema {
 }
 
 func readOrganizationForDataSource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 	var foundOrganization *management.Organization
 	var err error
 

--- a/internal/auth0/organization/resource.go
+++ b/internal/auth0/organization/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -74,7 +75,7 @@ func NewResource() *schema.Resource {
 }
 
 func createOrganization(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	organization := expandOrganization(d)
 	if err := api.Organization.Create(organization); err != nil {
@@ -87,7 +88,7 @@ func createOrganization(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func readOrganization(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	organization, err := api.Organization.Read(d.Id())
 	if err != nil {
@@ -109,7 +110,7 @@ func readOrganization(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func updateOrganization(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	organization := expandOrganization(d)
 	if err := api.Organization.Update(d.Id(), organization); err != nil {
@@ -120,7 +121,7 @@ func updateOrganization(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func deleteOrganization(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if err := api.Organization.Delete(d.Id()); err != nil {
 		if err, ok := err.(management.Error); ok && err.Status() == http.StatusNotFound {

--- a/internal/auth0/organization/resource_connection.go
+++ b/internal/auth0/organization/resource_connection.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/auth0/terraform-provider-auth0/internal/mutex"
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalSchema "github.com/auth0/terraform-provider-auth0/internal/schema"
 )
 
@@ -58,12 +58,13 @@ func NewConnectionResource() *schema.Resource {
 }
 
 func createOrganizationConnection(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
+	mutex := meta.(*config.Config).GetMutex()
 
 	organizationID := data.Get("organization_id").(string)
 
-	mutex.Global.Lock(organizationID)
-	defer mutex.Global.Unlock(organizationID)
+	mutex.Lock(organizationID)
+	defer mutex.Unlock(organizationID)
 
 	connectionID := data.Get("connection_id").(string)
 	assignMembershipOnLogin := data.Get("assign_membership_on_login").(bool)
@@ -83,7 +84,7 @@ func createOrganizationConnection(ctx context.Context, data *schema.ResourceData
 }
 
 func readOrganizationConnection(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 
 	organizationID := data.Get("organization_id").(string)
 	connectionID := data.Get("connection_id").(string)
@@ -107,12 +108,13 @@ func readOrganizationConnection(ctx context.Context, data *schema.ResourceData, 
 }
 
 func updateOrganizationConnection(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
+	mutex := meta.(*config.Config).GetMutex()
 
 	organizationID := data.Get("organization_id").(string)
 
-	mutex.Global.Lock(organizationID)
-	defer mutex.Global.Unlock(organizationID)
+	mutex.Lock(organizationID)
+	defer mutex.Unlock(organizationID)
 
 	connectionID := data.Get("connection_id").(string)
 	assignMembershipOnLogin := data.Get("assign_membership_on_login").(bool)
@@ -129,12 +131,13 @@ func updateOrganizationConnection(ctx context.Context, data *schema.ResourceData
 }
 
 func deleteOrganizationConnection(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
+	mutex := meta.(*config.Config).GetMutex()
 
 	organizationID := data.Get("organization_id").(string)
 
-	mutex.Global.Lock(organizationID)
-	defer mutex.Global.Unlock(organizationID)
+	mutex.Lock(organizationID)
+	defer mutex.Unlock(organizationID)
 
 	connectionID := data.Get("connection_id").(string)
 

--- a/internal/auth0/prompt/resource.go
+++ b/internal/auth0/prompt/resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -58,7 +59,7 @@ func createPrompt(ctx context.Context, d *schema.ResourceData, m interface{}) di
 }
 
 func readPrompt(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	prompt, err := api.Prompt.Read()
 	if err != nil {
@@ -75,7 +76,7 @@ func readPrompt(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 }
 
 func updatePrompt(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	prompt := expandPrompt(d.GetRawConfig())
 	if err := api.Prompt.Update(prompt); err != nil {

--- a/internal/auth0/prompt/resource_custom_text.go
+++ b/internal/auth0/prompt/resource_custom_text.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalSchema "github.com/auth0/terraform-provider-auth0/internal/schema"
 )
 
@@ -76,7 +77,7 @@ func createPromptCustomText(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func readPromptCustomText(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	customText, err := api.Prompt.CustomText(d.Get("prompt").(string), d.Get("language").(string))
 	if err != nil {
 		if mErr, ok := err.(management.Error); ok {
@@ -97,7 +98,7 @@ func readPromptCustomText(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func updatePromptCustomText(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	prompt := d.Get("prompt").(string)
 	language := d.Get("language").(string)

--- a/internal/auth0/resourceserver/data_source.go
+++ b/internal/auth0/resourceserver/data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalSchema "github.com/auth0/terraform-provider-auth0/internal/schema"
 )
 
@@ -45,7 +46,7 @@ func readResourceServerForDataSource(ctx context.Context, data *schema.ResourceD
 		resourceServerID = url.PathEscape(data.Get("identifier").(string))
 	}
 
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 	resourceServer, err := api.ResourceServer.Read(resourceServerID)
 	if err != nil {
 		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {

--- a/internal/auth0/resourceserver/resource.go
+++ b/internal/auth0/resourceserver/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -140,7 +141,7 @@ func NewResource() *schema.Resource {
 }
 
 func createResourceServer(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	resourceServer := expandResourceServer(d)
 	if err := api.ResourceServer.Create(resourceServer); err != nil {
@@ -153,7 +154,7 @@ func createResourceServer(ctx context.Context, d *schema.ResourceData, m interfa
 }
 
 func readResourceServer(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	resourceServer, err := api.ResourceServer.Read(d.Id())
 	if err != nil {
@@ -196,7 +197,7 @@ func readResourceServer(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func updateResourceServer(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	resourceServer := expandResourceServer(d)
 	if err := api.ResourceServer.Update(d.Id(), resourceServer); err != nil {
@@ -212,7 +213,7 @@ func deleteResourceServer(ctx context.Context, d *schema.ResourceData, m interfa
 		return nil
 	}
 
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if err := api.ResourceServer.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {

--- a/internal/auth0/role/data_source.go
+++ b/internal/auth0/role/data_source.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalSchema "github.com/auth0/terraform-provider-auth0/internal/schema"
 )
 
@@ -42,7 +43,7 @@ func readRoleForDataSource(ctx context.Context, data *schema.ResourceData, meta 
 		return readRole(ctx, data, meta)
 	}
 
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 	name := data.Get("name").(string)
 	page := 0
 	for {

--- a/internal/auth0/role/resource.go
+++ b/internal/auth0/role/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -64,7 +65,7 @@ func NewResource() *schema.Resource {
 }
 
 func createRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	role := expandRole(d)
 	if err := api.Role.Create(role); err != nil {
@@ -83,7 +84,7 @@ func createRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 }
 
 func readRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	role, err := api.Role.Read(d.Id())
 	if err != nil {
@@ -125,7 +126,7 @@ func readRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 }
 
 func updateRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	role := expandRole(d)
 	if err := api.Role.Update(d.Id(), role); err != nil {
@@ -142,7 +143,7 @@ func updateRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 }
 
 func deleteRole(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if err := api.Role.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok && mErr.Status() == http.StatusNotFound {
@@ -186,7 +187,7 @@ func assignRolePermissions(d *schema.ResourceData, m interface{}) error {
 		})
 	}
 
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	if len(rmPermissions) > 0 {
 		if err := api.Role.RemovePermissions(d.Id(), rmPermissions); err != nil {

--- a/internal/auth0/rule/resource.go
+++ b/internal/auth0/rule/resource.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 )
 
 var ruleNameRegexp = regexp.MustCompile(`^[^\s-][\w -]+[^\s-]$`)
@@ -65,7 +67,7 @@ func NewResource() *schema.Resource {
 
 func createRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	rule := expandRule(d.GetRawConfig())
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.Rule.Create(rule); err != nil {
 		return diag.FromErr(err)
 	}
@@ -76,7 +78,7 @@ func createRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 }
 
 func readRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	rule, err := api.Rule.Read(d.Id())
 	if err != nil {
 		if mErr, ok := err.(management.Error); ok {
@@ -100,7 +102,7 @@ func readRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 
 func updateRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	rule := expandRule(d.GetRawConfig())
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.Rule.Update(d.Id(), rule); err != nil {
 		return diag.FromErr(err)
 	}
@@ -109,7 +111,7 @@ func updateRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 }
 
 func deleteRule(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.Rule.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok {
 			if mErr.Status() == http.StatusNotFound {

--- a/internal/auth0/rule/resource_config.go
+++ b/internal/auth0/rule/resource_config.go
@@ -8,6 +8,8 @@ import (
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 )
 
 // NewConfigResource will return a new auth0_rule_config resource.
@@ -45,7 +47,7 @@ func createRuleConfig(ctx context.Context, d *schema.ResourceData, m interface{}
 	ruleConfig := expandRuleConfig(d.GetRawConfig())
 	key := auth0.StringValue(ruleConfig.Key)
 	ruleConfig.Key = nil
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.RuleConfig.Upsert(key, ruleConfig); err != nil {
 		return diag.FromErr(err)
 	}
@@ -56,7 +58,7 @@ func createRuleConfig(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func readRuleConfig(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	ruleConfig, err := api.RuleConfig.Read(d.Id())
 	if err != nil {
 		if mErr, ok := err.(management.Error); ok {
@@ -74,7 +76,7 @@ func readRuleConfig(ctx context.Context, d *schema.ResourceData, m interface{}) 
 func updateRuleConfig(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	ruleConfig := expandRuleConfig(d.GetRawConfig())
 	ruleConfig.Key = nil
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.RuleConfig.Upsert(d.Id(), ruleConfig); err != nil {
 		return diag.FromErr(err)
 	}
@@ -83,7 +85,7 @@ func updateRuleConfig(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func deleteRuleConfig(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.RuleConfig.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok {
 			if mErr.Status() == http.StatusNotFound {

--- a/internal/auth0/tenant/data_source.go
+++ b/internal/auth0/tenant/data_source.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalSchema "github.com/auth0/terraform-provider-auth0/internal/schema"
 )
 
@@ -41,7 +41,7 @@ func dataSourceSchema() map[string]*schema.Schema {
 }
 
 func readTenantForDataSource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	api := meta.(*management.Management)
+	api := meta.(*config.Config).GetAPI()
 
 	u, err := url.Parse(api.URI())
 	if err != nil {

--- a/internal/auth0/tenant/resource.go
+++ b/internal/auth0/tenant/resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalValidation "github.com/auth0/terraform-provider-auth0/internal/validation"
 )
 
@@ -395,7 +396,7 @@ func createTenant(ctx context.Context, d *schema.ResourceData, m interface{}) di
 }
 
 func readTenant(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	tenant, err := api.Tenant.Read()
 	if err != nil {
 		if mErr, ok := err.(management.Error); ok {
@@ -433,7 +434,7 @@ func readTenant(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 
 func updateTenant(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	tenant := expandTenant(d)
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.Tenant.Update(tenant); err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/auth0/user/resource.go
+++ b/internal/auth0/user/resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
 
@@ -158,7 +159,7 @@ func NewResource() *schema.Resource {
 }
 
 func readUser(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	user, err := api.User.Read(d.Id())
 	if err != nil {
@@ -213,7 +214,7 @@ func readUser(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 }
 
 func createUser(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 
 	user, err := expandUser(d)
 	if err != nil {
@@ -243,7 +244,7 @@ func updateUser(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 		return diag.FromErr(err)
 	}
 
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if userHasChange(user) {
 		if err := api.User.Update(d.Id(), user); err != nil {
 			return diag.FromErr(err)
@@ -258,7 +259,7 @@ func updateUser(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 }
 
 func deleteUser(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	api := m.(*management.Management)
+	api := m.(*config.Config).GetAPI()
 	if err := api.User.Delete(d.Id()); err != nil {
 		if mErr, ok := err.(management.Error); ok {
 			if mErr.Status() == http.StatusNotFound {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/auth0/go-auth0"
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
+
+	"github.com/auth0/terraform-provider-auth0/internal/mutex"
+)
+
+const providerName = "Terraform-Provider-Auth0"
+
+var version = "dev"
+
+// Config is the type used for the
+// *schema.Provider meta parameter.
+type Config struct {
+	api   *management.Management
+	mutex *mutex.KeyValue
+}
+
+// New instantiates a new Config.
+func New(apiClient *management.Management) *Config {
+	return &Config{
+		api:   apiClient,
+		mutex: mutex.New(),
+	}
+}
+
+// GetAPI fetches an instance of the *management.Management client.
+func (c *Config) GetAPI() *management.Management {
+	return c.api
+}
+
+// GetMutex fetches an instance of the *mutex.KeyValue.
+func (c *Config) GetMutex() *mutex.KeyValue {
+	return c.mutex
+}
+
+// ConfigureProvider will configure the *schema.Provider so that
+// *management.Management client and *mutex.KeyValue is stored
+// and passed into the subsequent resources as the meta parameter.
+func ConfigureProvider(terraformVersion *string) schema.ConfigureContextFunc {
+	return func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
+		domain := data.Get("domain").(string)
+		clientID := data.Get("client_id").(string)
+		clientSecret := data.Get("client_secret").(string)
+		apiToken := data.Get("api_token").(string)
+		audience := data.Get("audience").(string)
+		debug := data.Get("debug").(bool)
+
+		apiClient, err := management.New(domain,
+			authenticationOption(clientID, clientSecret, apiToken, audience),
+			management.WithDebug(debug),
+			management.WithUserAgent(userAgent(terraformVersion)),
+			management.WithAuth0ClientEnvEntry(providerName, version),
+		)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+
+		return New(apiClient), nil
+	}
+}
+
+// userAgent computes the desired User-Agent header for the *management.Management client.
+func userAgent(terraformVersion *string) string {
+	sdkVersion := auth0.Version
+	terraformSDKVersion := meta.SDKVersionString()
+
+	userAgent := fmt.Sprintf(
+		"%s/%s (Go-Auth0-SDK/%s; Terraform-SDK/%s; Terraform/%s)",
+		providerName,
+		version,
+		sdkVersion,
+		terraformSDKVersion,
+		*terraformVersion,
+	)
+
+	return userAgent
+}
+
+// authenticationOption computes the desired authentication option for the *management.Management client.
+func authenticationOption(clientID, clientSecret, apiToken, audience string) management.Option {
+	if apiToken != "" {
+		return management.WithStaticToken(apiToken)
+	}
+
+	if audience != "" {
+		return management.WithClientCredentialsAndAudience(
+			clientID,
+			clientSecret,
+			audience,
+		)
+	}
+
+	return management.WithClientCredentials(clientID, clientSecret)
+}

--- a/internal/mutex/mutex.go
+++ b/internal/mutex/mutex.go
@@ -5,10 +5,6 @@ import (
 	"sync"
 )
 
-// Global is instantiated just once and
-// reused across different resources.
-var Global = New()
-
 // KeyValue is a simple key/value
 // store for arbitrary mutexes.
 type KeyValue struct {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,15 +1,9 @@
 package provider
 
 import (
-	"context"
-	"fmt"
 	"os"
 
-	"github.com/auth0/go-auth0"
-	"github.com/auth0/go-auth0/management"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
 
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/action"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/attackprotection"
@@ -28,9 +22,8 @@ import (
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/rule"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/tenant"
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/user"
+	"github.com/auth0/terraform-provider-auth0/internal/config"
 )
-
-var version = "dev"
 
 // New returns a *schema.Provider.
 func New() *schema.Provider {
@@ -139,59 +132,7 @@ func New() *schema.Provider {
 		},
 	}
 
-	provider.ConfigureContextFunc = configureProvider(&provider.TerraformVersion)
+	provider.ConfigureContextFunc = config.ConfigureProvider(&provider.TerraformVersion)
 
 	return provider
-}
-
-// ConfigureProvider will configure the *schema.Provider so that *management.Management
-// client is stored and passed into the subsequent resources as the meta parameter.
-func configureProvider(
-	terraformVersion *string,
-) func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
-	return func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
-		sdkVersion := auth0.Version
-		terraformSDKVersion := meta.SDKVersionString()
-
-		userAgent := fmt.Sprintf(
-			"Terraform-Provider-Auth0/%s (Go-Auth0-SDK/%s; Terraform-SDK/%s; Terraform/%s)",
-			version,
-			sdkVersion,
-			terraformSDKVersion,
-			*terraformVersion,
-		)
-
-		domain := data.Get("domain").(string)
-		audience := data.Get("audience").(string)
-		debug := data.Get("debug").(bool)
-		clientID := data.Get("client_id").(string)
-		clientSecret := data.Get("client_secret").(string)
-		apiToken := data.Get("api_token").(string)
-
-		authenticationOption := management.WithStaticToken(apiToken)
-		// If api_token is not specified, authenticate with client ID and client secret.
-		if apiToken == "" {
-			authenticationOption = management.WithClientCredentials(clientID, clientSecret)
-
-			if audience != "" {
-				authenticationOption = management.WithClientCredentialsAndAudience(
-					clientID,
-					clientSecret,
-					audience,
-				)
-			}
-		}
-
-		apiClient, err := management.New(domain,
-			authenticationOption,
-			management.WithDebug(debug),
-			management.WithUserAgent(userAgent),
-			management.WithAuth0ClientEnvEntry("Terraform-Provider-Auth0", version),
-		)
-		if err != nil {
-			return nil, diag.FromErr(err)
-		}
-
-		return apiClient, nil
-	}
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR consolidates the api client and the global mutex into one Config struct that gets passed as the meta property for the provider.

Doing so will enable us to inject into this Config struct another mechanism to potentially detect if mutually exclusive resources for the same resource ID are used and trigger a warning/error. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
