### PR TITLE
DXCDT-456: Prevent failure on create if scope already exists in 1:1 resource

### DIFF
--- a/test/data/recordings/TestAccResourceServerScope.yaml
+++ b/test/data/recordings/TestAccResourceServerScope.yaml
@@ -19,7 +19,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: 346
         uncompressed: false
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 124.453791ms
+        duration: 144.413459ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,8 +55,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.010958ms
+        duration: 95.541666ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -91,8 +91,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -102,13 +102,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 136.039875ms
+        duration: 99.007625ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -127,8 +127,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -138,13 +138,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 114.441542ms
+        duration: 125.618875ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -163,7 +163,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -174,13 +174,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.721833ms
+        duration: 103.206208ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -199,7 +199,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: PATCH
       response:
@@ -210,13 +210,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.151708ms
+        duration: 110.09475ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -235,7 +235,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -246,13 +246,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 61.51175ms
+        duration: 112.764584ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -271,7 +271,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -282,13 +282,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 112.525375ms
+        duration: 107.779042ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -307,7 +307,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -318,13 +318,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 130.109542ms
+        duration: 103.797709ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -343,8 +343,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -354,13 +354,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.8505ms
+        duration: 145.857375ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -379,7 +379,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -390,13 +390,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.600792ms
+        duration: 117.139167ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -415,7 +415,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -426,13 +426,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 110.375125ms
+        duration: 162.862875ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -451,7 +451,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -462,13 +462,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 101.29275ms
+        duration: 103.276375ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -487,8 +487,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -498,13 +498,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 103.883958ms
+        duration: 93.496667ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -523,7 +523,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -534,13 +534,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 121.660792ms
+        duration: 106.229125ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -559,7 +559,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -570,13 +570,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 102.259083ms
+        duration: 95.538834ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -595,7 +595,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: PATCH
       response:
@@ -606,13 +606,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.692166ms
+        duration: 104.241167ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -631,7 +631,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -642,13 +642,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 110.959834ms
+        duration: 118.971583ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -667,7 +667,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -678,13 +678,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 100.620667ms
+        duration: 122.476541ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -703,7 +703,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -714,13 +714,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 134.971ms
+        duration: 113.086083ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -739,8 +739,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -750,13 +750,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 102.653875ms
+        duration: 93.701958ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -775,7 +775,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -786,13 +786,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 112.996167ms
+        duration: 92.863375ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -811,7 +811,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -822,13 +822,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 105.354666ms
+        duration: 101.613875ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -847,7 +847,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -858,13 +858,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.21825ms
+        duration: 92.159375ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -883,8 +883,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -894,13 +894,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.492959ms
+        duration: 165.443458ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -919,7 +919,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -930,13 +930,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.677417ms
+        duration: 98.684042ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -955,7 +955,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -966,13 +966,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.707458ms
+        duration: 98.951208ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -991,7 +991,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: PATCH
       response:
@@ -1002,13 +1002,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 121.260625ms
+        duration: 154.404625ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1027,7 +1027,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -1038,13 +1038,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 105.279917ms
+        duration: 87.9975ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1063,7 +1063,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -1074,13 +1074,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.937042ms
+        duration: 83.714375ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1099,7 +1099,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -1110,13 +1110,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 101.030667ms
+        duration: 105.692209ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1135,8 +1135,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1146,13 +1146,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 101.098917ms
+        duration: 80.230417ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1171,7 +1171,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -1182,13 +1182,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 98.525875ms
+        duration: 113.739625ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1207,7 +1207,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -1218,13 +1218,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 101.969292ms
+        duration: 109.218667ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1243,7 +1243,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -1254,13 +1254,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 106.158375ms
+        duration: 97.5975ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1279,7 +1279,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -1290,13 +1290,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.982291ms
+        duration: 101.51625ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1315,8 +1315,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1326,13 +1326,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.101875ms
+        duration: 103.458ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1351,7 +1351,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -1362,13 +1362,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 133.572959ms
+        duration: 108.554541ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1387,7 +1387,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -1398,13 +1398,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.161375ms
+        duration: 94.252125ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1423,7 +1423,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -1434,13 +1434,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 135.92925ms
+        duration: 119.962792ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1459,7 +1459,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -1470,13 +1470,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 131.616709ms
+        duration: 136.324708ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1495,7 +1495,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -1506,13 +1506,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"},{"value":"write:posts","description":""}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 107.400083ms
+        duration: 81.861916ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1531,7 +1531,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: PATCH
       response:
@@ -1542,13 +1542,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 155.540209ms
+        duration: 156.985125ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1567,7 +1567,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -1578,13 +1578,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 102.546916ms
+        duration: 94.245667ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1603,8 +1603,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1614,13 +1614,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.542542ms
+        duration: 98.6325ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1639,7 +1639,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -1650,13 +1650,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.858541ms
+        duration: 94.416083ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1675,7 +1675,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -1686,13 +1686,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 109.463208ms
+        duration: 115.841417ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1711,7 +1711,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -1722,13 +1722,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.643083ms
+        duration: 104.602375ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1747,8 +1747,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1758,13 +1758,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.389458ms
+        duration: 101.794125ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1783,7 +1783,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -1794,13 +1794,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 95.357417ms
+        duration: 111.721208ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1819,7 +1819,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -1830,13 +1830,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 103.832583ms
+        duration: 100.972042ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1855,7 +1855,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscope
         method: GET
       response:
@@ -1866,13 +1866,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.246ms
+        duration: 96.537125ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1891,8 +1891,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
         proto: HTTP/2.0
@@ -1902,13 +1902,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.696667ms
+        duration: 90.080625ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1927,8 +1927,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -1938,13 +1938,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.754875ms
+        duration: 94.770875ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1963,7 +1963,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: GET
       response:
@@ -1974,13 +1974,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts from API"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 103.118375ms
+        duration: 125.31975ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1999,7 +1999,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
+                - Go-Auth0-SDK/0.17.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscope
         method: PATCH
       response:
@@ -2010,34 +2010,34 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 112.519292ms
+        duration: 159.092709ms
     - id: 56
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 68
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            null
+            {"name":"Acceptance Test - testaccresourceserverscope","scopes":[]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
-        method: GET
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -2046,13 +2046,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.001708ms
+        duration: 99.986875ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2071,8 +2071,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: GET
       response:
         proto: HTTP/2.0
@@ -2082,14 +2082,86 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"646be36d826801d224b4df2b","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 105.180625ms
+        duration: 94.649333ms
     - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 107.699917ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e21d6ec033e84b61afc","name":"Acceptance Test - testaccresourceserverscope","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscope","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 89.425916ms
+    - id: 60
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2106,8 +2178,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.17.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646be36d826801d224b4df2b
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e21d6ec033e84b61afc
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2123,4 +2195,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 142.590458ms
+        duration: 188.828792ms

--- a/test/data/recordings/TestAccResourceServerScopeWillNotFailOnCreateIfScopeAlreadyExisting.yaml
+++ b/test/data/recordings/TestAccResourceServerScopeWillNotFailOnCreateIfScopeAlreadyExisting.yaml
@@ -1,0 +1,1010 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 237
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","scopes":[]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 428
+        uncompressed: false
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 100.323833ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e466388a85ec04581cf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 188.573ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 98.759917ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 67
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"scopes":[{"value":"read:posts","description":"Can read posts"}]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 230.7425ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 177.620625ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 91.378291ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 83.217708ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e466388a85ec04581cf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 101.418208ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 152.863417ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 110.295167ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 97.017584ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e466388a85ec04581cf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 94.674ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 123.580709ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 95.028917ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 96.01625ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 114.797125ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 97.067958ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 94.673417ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e466388a85ec04581cf
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 160.655209ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 233.06325ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 93.911375ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 115.079167ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%252F%252Fuat.api.terraform-provider-auth0.com%252Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 91.817542ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[{"value":"read:posts","description":"Can read posts"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 308.487917ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 14
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"scopes":[]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 149.49625ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 108.574667ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 14
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"scopes":[]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/https:%2F%2Fuat.api.terraform-provider-auth0.com%2Ftestaccresourceserverscopewillnotfailoncreateifscopealreadyexisting
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"646e1e466388a85ec04581cf","name":"Acceptance Test - testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","identifier":"https://uat.api.terraform-provider-auth0.com/testaccresourceserverscopewillnotfailoncreateifscopealreadyexisting","allow_offline_access":false,"skip_consent_for_verifiable_first_party_clients":false,"token_lifetime":86400,"token_lifetime_for_web":7200,"signing_alg":"RS256","scopes":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 82.216ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/resource-servers/646e1e466388a85ec04581cf
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 203.1905ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

In case the scope already exists on the resource server, currently the 1:1 resource for managing scopes will fail on create. This PR prevents that. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
