### PR TITLE
GH-587: Remove computed property from set_user_root_attributes

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -675,7 +675,7 @@ Optional:
 - `requires_username` (Boolean) Indicates whether the user is required to provide a username in addition to an email address.
 - `scopes` (Set of String) Permissions to grant to the connection. Within the Auth0 dashboard these appear under the "Attributes" and "Extended Attributes" sections. Some examples: `basic_profile`, `ext_profile`, `ext_nested_groups`, etc.
 - `scripts` (Map of String) A map of scripts used for an OAuth connection. Only accepts a `fetchUserProfile` script.
-- `set_user_root_attributes` (String) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using an external IdP. Possible values are 'on_each_login' (default value, it configures the connection to automatically update the root attributes from the external IdP with each user login. When this setting is used, root attributes cannot be independently updated), 'on_first_login' (configures the connection to only set the root attributes on first login, allowing them to be independently updated thereafter).
+- `set_user_root_attributes` (String) Determines whether to sync user profile attributes (`name`, `given_name`, `family_name`, `nickname`, `picture`) at each login or only on the first login. Options include: `on_each_login`, `on_first_login`. Default value: `on_each_login`.
 - `should_trust_email_verified_connection` (String) Choose how Auth0 sets the email_verified field in the user profile.
 - `sign_in_endpoint` (String) SAML single login URL for the connection.
 - `sign_out_endpoint` (String) SAML single logout URL for the connection.

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -584,9 +584,13 @@ func expandConnectionOptionsAzureAD(
 		EnableUsersAPI:      value.Bool(config.GetAttr("api_enable_users")),
 		LogoURL:             value.String(config.GetAttr("icon_url")),
 		IdentityAPI:         value.String(config.GetAttr("identity_api")),
-		SetUserAttributes:   value.String(config.GetAttr("set_user_root_attributes")),
 		NonPersistentAttrs:  value.Strings(config.GetAttr("non_persistent_attrs")),
 		TrustEmailVerified:  value.String(config.GetAttr("should_trust_email_verified_connection")),
+	}
+
+	options.SetUserAttributes = value.String(config.GetAttr("set_user_root_attributes"))
+	if options.GetSetUserAttributes() == "on_each_login" {
+		options.SetUserAttributes = nil // This needs to be omitted to have the toggle enabled in the UI.
 	}
 
 	expandConnectionOptionsScopes(d, options)

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -507,9 +507,13 @@ func flattenConnectionOptionsAzureAD(options *management.ConnectionOptionsAzureA
 		"api_enable_users":                       options.GetEnableUsersAPI(),
 		"max_groups_to_retrieve":                 options.GetMaxGroupsToRetrieve(),
 		"scopes":                                 options.Scopes(),
-		"set_user_root_attributes":               options.GetSetUserAttributes(),
 		"non_persistent_attrs":                   options.GetNonPersistentAttrs(),
 		"should_trust_email_verified_connection": options.GetTrustEmailVerified(),
+	}
+
+	m["set_user_root_attributes"] = options.GetSetUserAttributes()
+	if options.GetSetUserAttributes() == "" {
+		m["set_user_root_attributes"] = "on_each_login"
 	}
 
 	upstreamParams, err := structure.FlattenJsonToString(options.UpstreamParams)

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -236,6 +236,29 @@ func TestAccConnectionAzureAD(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.upstream_params", "{\"screen_name\":{\"alias\":\"login_hint\"}}"),
 				),
 			},
+			{
+				Config: acctest.ParseTestName(testAccConnectionADConfigUpdateSetUserRootAttributes, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "name", fmt.Sprintf("Acceptance-Test-Azure-AD-%s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "strategy", "waad"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "show_as_button", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.identity_api", "azure-active-directory-v1.0"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.client_id", "123456"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.client_secret", "123456"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.tenant_domain", "example.onmicrosoft.com"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.domain", "example.onmicrosoft.com"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.domain_aliases.#", "2"),
+					resource.TestCheckTypeSetElemAttr("auth0_connection.azure_ad", "options.0.domain_aliases.*", "example.com"),
+					resource.TestCheckTypeSetElemAttr("auth0_connection.azure_ad", "options.0.domain_aliases.*", "api.example.com"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.scopes.#", "3"),
+					resource.TestCheckTypeSetElemAttr("auth0_connection.azure_ad", "options.0.scopes.*", "basic_profile"),
+					resource.TestCheckTypeSetElemAttr("auth0_connection.azure_ad", "options.0.scopes.*", "ext_profile"),
+					resource.TestCheckTypeSetElemAttr("auth0_connection.azure_ad", "options.0.scopes.*", "ext_groups"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.set_user_root_attributes", "on_first_login"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.should_trust_email_verified_connection", "never_set_emails_as_verified"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.upstream_params", "{\"screen_name\":{\"alias\":\"login_hint\"}}"),
+				),
+			},
 		},
 	})
 }
@@ -265,6 +288,41 @@ resource "auth0_connection" "azure_ad" {
 			"ext_profile"
 		]
 		set_user_root_attributes = "on_each_login"
+		should_trust_email_verified_connection = "never_set_emails_as_verified"
+		upstream_params = jsonencode({
+			"screen_name": {
+				"alias": "login_hint"
+			}
+		})
+	}
+}
+`
+
+const testAccConnectionADConfigUpdateSetUserRootAttributes = `
+resource "auth0_connection" "azure_ad" {
+	name     = "Acceptance-Test-Azure-AD-{{.testName}}"
+	strategy = "waad"
+	show_as_button = true
+	options {
+		identity_api  = "azure-active-directory-v1.0"
+		client_id     = "123456"
+		client_secret = "123456"
+		tenant_domain = "example.onmicrosoft.com"
+		domain        = "example.onmicrosoft.com"
+		domain_aliases = [
+			"example.com",
+			"api.example.com"
+		]
+		use_wsfed            = false
+		waad_protocol        = "openid-connect"
+		waad_common_endpoint = false
+		api_enable_users     = true
+		scopes               = [
+			"basic_profile",
+			"ext_groups",
+			"ext_profile"
+		]
+		set_user_root_attributes = "on_first_login"
 		should_trust_email_verified_connection = "never_set_emails_as_verified"
 		upstream_params = jsonencode({
 			"screen_name": {

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -503,19 +503,12 @@ var resourceSchema = map[string]*schema.Schema{
 				},
 
 				"set_user_root_attributes": {
-					Type:     schema.TypeString,
-					Optional: true,
-					Computed: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"on_each_login", "on_first_login",
-					}, false),
-					Description: "Determines whether the 'name', 'given_name', 'family_name', 'nickname', " +
-						"and 'picture' attributes can be independently updated when using an external IdP. " +
-						"Possible values are 'on_each_login' (default value, it configures the connection to " +
-						"automatically update the root attributes from the external IdP with each user login. " +
-						"When this setting is used, root attributes cannot be independently updated), " +
-						"'on_first_login' (configures the connection to only set the root attributes on " +
-						"first login, allowing them to be independently updated thereafter).",
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice([]string{"on_each_login", "on_first_login"}, false),
+					Description: "Determines whether to sync user profile attributes (`name`, `given_name`, " +
+						"`family_name`, `nickname`, `picture`) at each login or only on the first login. Options " +
+						"include: `on_each_login`, `on_first_login`. Default value: `on_each_login`.",
 				},
 				"non_persistent_attrs": {
 					Type:     schema.TypeSet,

--- a/test/data/recordings/TestAccConnectionAzureAD.yaml
+++ b/test/data/recordings/TestAccConnectionAzureAD.yaml
@@ -1,146 +1,290 @@
 ---
 version: 2
 interactions:
-  - id: 0
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
-      content_length: 663
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        {"name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","strategy":"waad","show_as_button":true,"options":{"client_id":"123456","client_secret":"123456","tenant_domain":"example.onmicrosoft.com","domain":"example.onmicrosoft.com","domain_aliases":["api.example.com","example.com"],"identity_api":"azure-active-directory-v1.0","waad_protocol":"openid-connect","use_wsfed":false,"useCommonEndpoint":false,"api_enable_users":true,"basic_profile":true,"ext_profile":true,"ext_groups":true,"set_user_root_attributes":"on_each_login","should_trust_email_verified_connection":"never_set_emails_as_verified","upstream_params":{"screen_name":{"alias":"login_hint"}}}}
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/0.12.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
-      method: POST
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: false
-      body: '{"id":"con_mPd3qJL3PWbDEuo8","options":{"client_id":"123456","client_secret":"123456","tenant_domain":"example.onmicrosoft.com","domain":"example.onmicrosoft.com","domain_aliases":["api.example.com","example.com"],"identity_api":"azure-active-directory-v1.0","waad_protocol":"openid-connect","use_wsfed":false,"useCommonEndpoint":false,"api_enable_users":true,"basic_profile":true,"ext_profile":true,"ext_groups":true,"set_user_root_attributes":"on_each_login","should_trust_email_verified_connection":"never_set_emails_as_verified","upstream_params":{"screen_name":{"alias":"login_hint"}},"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","thumbprints":["9cea37643ace0d710ad63296857b251d1fca5c48","977b10fb9d1c087e3105564b1d31b09d247bebcd","32be7e01489b7c18a2ecd7758c179b6b16e85d6d","8d2d57a353960e3ff9daf6f018d82f40ed95ccc7","d994292775296e30185d819a5c4265f255744ce2","0ea52ef207fe9c081cca33f7f92ba994d0170277","3b36790db99cb28f50cedd8ca1d1a68a1837d01a"]},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/xtCw5Lda","is_domain_connection":false,"show_as_button":true,"enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 201 Created
-      code: 201
-      duration: 367.955403ms
-  - id: 1
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
-      content_length: 5
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        null
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/0.12.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mPd3qJL3PWbDEuo8
-      method: GET
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: true
-      body: '{"id":"con_mPd3qJL3PWbDEuo8","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["9cea37643ace0d710ad63296857b251d1fca5c48","977b10fb9d1c087e3105564b1d31b09d247bebcd","32be7e01489b7c18a2ecd7758c179b6b16e85d6d","8d2d57a353960e3ff9daf6f018d82f40ed95ccc7","d994292775296e30185d819a5c4265f255744ce2","0ea52ef207fe9c081cca33f7f92ba994d0170277","3b36790db99cb28f50cedd8ca1d1a68a1837d01a"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"useCommonEndpoint":false,"set_user_root_attributes":"on_each_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/xtCw5Lda","is_domain_connection":false,"show_as_button":true,"enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 200 OK
-      code: 200
-      duration: 123.872359ms
-  - id: 2
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
-      content_length: 5
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: |
-        null
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/0.12.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mPd3qJL3PWbDEuo8
-      method: GET
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: -1
-      uncompressed: true
-      body: '{"id":"con_mPd3qJL3PWbDEuo8","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["9cea37643ace0d710ad63296857b251d1fca5c48","977b10fb9d1c087e3105564b1d31b09d247bebcd","32be7e01489b7c18a2ecd7758c179b6b16e85d6d","8d2d57a353960e3ff9daf6f018d82f40ed95ccc7","d994292775296e30185d819a5c4265f255744ce2","0ea52ef207fe9c081cca33f7f92ba994d0170277","3b36790db99cb28f50cedd8ca1d1a68a1837d01a"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"useCommonEndpoint":false,"set_user_root_attributes":"on_each_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/xtCw5Lda","is_domain_connection":false,"show_as_button":true,"enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 200 OK
-      code: 200
-      duration: 114.701971ms
-  - id: 3
-    request:
-      proto: HTTP/1.1
-      proto_major: 1
-      proto_minor: 1
-      content_length: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      host: terraform-provider-auth0-dev.eu.auth0.com
-      remote_addr: ""
-      request_uri: ""
-      body: ""
-      form: { }
-      headers:
-        Content-Type:
-          - application/json
-        User-Agent:
-          - Go-Auth0-SDK/0.12.0
-      url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mPd3qJL3PWbDEuo8
-      method: DELETE
-    response:
-      proto: HTTP/2.0
-      proto_major: 2
-      proto_minor: 0
-      transfer_encoding: [ ]
-      trailer: { }
-      content_length: 41
-      uncompressed: false
-      body: '{"deleted_at":"2022-10-25T16:28:27.291Z"}'
-      headers:
-        Content-Type:
-          - application/json; charset=utf-8
-      status: 202 Accepted
-      code: 202
-      duration: 191.278582ms
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 663
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","strategy":"waad","show_as_button":true,"options":{"client_id":"123456","client_secret":"123456","tenant_domain":"example.onmicrosoft.com","domain":"example.onmicrosoft.com","domain_aliases":["api.example.com","example.com"],"identity_api":"azure-active-directory-v1.0","waad_protocol":"openid-connect","use_wsfed":false,"useCommonEndpoint":false,"api_enable_users":true,"basic_profile":true,"ext_profile":true,"ext_groups":true,"set_user_root_attributes":"on_each_login","should_trust_email_verified_connection":"never_set_emails_as_verified","upstream_params":{"screen_name":{"alias":"login_hint"}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_qHfqVt5tLSvy5stS","options":{"client_id":"123456","client_secret":"123456","tenant_domain":"example.onmicrosoft.com","domain":"example.onmicrosoft.com","domain_aliases":["api.example.com","example.com"],"identity_api":"azure-active-directory-v1.0","waad_protocol":"openid-connect","use_wsfed":false,"useCommonEndpoint":false,"api_enable_users":true,"basic_profile":true,"ext_profile":true,"ext_groups":true,"set_user_root_attributes":"on_each_login","should_trust_email_verified_connection":"never_set_emails_as_verified","upstream_params":{"screen_name":{"alias":"login_hint"}},"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","thumbprints":["9cea37643ace0d710ad63296857b251d1fca5c48","977b10fb9d1c087e3105564b1d31b09d247bebcd","32be7e01489b7c18a2ecd7758c179b6b16e85d6d","8d2d57a353960e3ff9daf6f018d82f40ed95ccc7","d994292775296e30185d819a5c4265f255744ce2","f8a23743d9cd47b6d1a1fc66799a17a9b1d919ec","0ea52ef207fe9c081cca33f7f92ba994d0170277","3b36790db99cb28f50cedd8ca1d1a68a1837d01a"]},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/IGwFbvcA","is_domain_connection":false,"show_as_button":true,"enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 354.452834ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qHfqVt5tLSvy5stS
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_qHfqVt5tLSvy5stS","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["9cea37643ace0d710ad63296857b251d1fca5c48","977b10fb9d1c087e3105564b1d31b09d247bebcd","32be7e01489b7c18a2ecd7758c179b6b16e85d6d","8d2d57a353960e3ff9daf6f018d82f40ed95ccc7","d994292775296e30185d819a5c4265f255744ce2","f8a23743d9cd47b6d1a1fc66799a17a9b1d919ec","0ea52ef207fe9c081cca33f7f92ba994d0170277","3b36790db99cb28f50cedd8ca1d1a68a1837d01a"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"useCommonEndpoint":false,"set_user_root_attributes":"on_each_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/IGwFbvcA","is_domain_connection":false,"show_as_button":true,"enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 123.504584ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qHfqVt5tLSvy5stS
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_qHfqVt5tLSvy5stS","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["9cea37643ace0d710ad63296857b251d1fca5c48","977b10fb9d1c087e3105564b1d31b09d247bebcd","32be7e01489b7c18a2ecd7758c179b6b16e85d6d","8d2d57a353960e3ff9daf6f018d82f40ed95ccc7","d994292775296e30185d819a5c4265f255744ce2","f8a23743d9cd47b6d1a1fc66799a17a9b1d919ec","0ea52ef207fe9c081cca33f7f92ba994d0170277","3b36790db99cb28f50cedd8ca1d1a68a1837d01a"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"useCommonEndpoint":false,"set_user_root_attributes":"on_each_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/IGwFbvcA","is_domain_connection":false,"show_as_button":true,"enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 108.726417ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qHfqVt5tLSvy5stS
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_qHfqVt5tLSvy5stS","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["9cea37643ace0d710ad63296857b251d1fca5c48","977b10fb9d1c087e3105564b1d31b09d247bebcd","32be7e01489b7c18a2ecd7758c179b6b16e85d6d","8d2d57a353960e3ff9daf6f018d82f40ed95ccc7","d994292775296e30185d819a5c4265f255744ce2","f8a23743d9cd47b6d1a1fc66799a17a9b1d919ec","0ea52ef207fe9c081cca33f7f92ba994d0170277","3b36790db99cb28f50cedd8ca1d1a68a1837d01a"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"useCommonEndpoint":false,"set_user_root_attributes":"on_each_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/IGwFbvcA","is_domain_connection":false,"show_as_button":true,"enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 94.147291ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 587
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"show_as_button":true,"options":{"client_id":"123456","client_secret":"123456","tenant_domain":"example.onmicrosoft.com","domain":"example.onmicrosoft.com","domain_aliases":["api.example.com","example.com"],"identity_api":"azure-active-directory-v1.0","waad_protocol":"openid-connect","use_wsfed":false,"useCommonEndpoint":false,"api_enable_users":true,"basic_profile":true,"ext_profile":true,"ext_groups":true,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified","upstream_params":{"screen_name":{"alias":"login_hint"}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qHfqVt5tLSvy5stS
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_qHfqVt5tLSvy5stS","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["9cea37643ace0d710ad63296857b251d1fca5c48","977b10fb9d1c087e3105564b1d31b09d247bebcd","32be7e01489b7c18a2ecd7758c179b6b16e85d6d","8d2d57a353960e3ff9daf6f018d82f40ed95ccc7","d994292775296e30185d819a5c4265f255744ce2","f8a23743d9cd47b6d1a1fc66799a17a9b1d919ec","0ea52ef207fe9c081cca33f7f92ba994d0170277","3b36790db99cb28f50cedd8ca1d1a68a1837d01a"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"useCommonEndpoint":false,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/IGwFbvcA","is_domain_connection":false,"show_as_button":true,"enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 235.3545ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qHfqVt5tLSvy5stS
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_qHfqVt5tLSvy5stS","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["9cea37643ace0d710ad63296857b251d1fca5c48","977b10fb9d1c087e3105564b1d31b09d247bebcd","32be7e01489b7c18a2ecd7758c179b6b16e85d6d","8d2d57a353960e3ff9daf6f018d82f40ed95ccc7","d994292775296e30185d819a5c4265f255744ce2","f8a23743d9cd47b6d1a1fc66799a17a9b1d919ec","0ea52ef207fe9c081cca33f7f92ba994d0170277","3b36790db99cb28f50cedd8ca1d1a68a1837d01a"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"useCommonEndpoint":false,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/IGwFbvcA","is_domain_connection":false,"show_as_button":true,"enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 104.841125ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qHfqVt5tLSvy5stS
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_qHfqVt5tLSvy5stS","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["9cea37643ace0d710ad63296857b251d1fca5c48","977b10fb9d1c087e3105564b1d31b09d247bebcd","32be7e01489b7c18a2ecd7758c179b6b16e85d6d","8d2d57a353960e3ff9daf6f018d82f40ed95ccc7","d994292775296e30185d819a5c4265f255744ce2","f8a23743d9cd47b6d1a1fc66799a17a9b1d919ec","0ea52ef207fe9c081cca33f7f92ba994d0170277","3b36790db99cb28f50cedd8ca1d1a68a1837d01a"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"useCommonEndpoint":false,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/IGwFbvcA","is_domain_connection":false,"show_as_button":true,"enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 104.642167ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qHfqVt5tLSvy5stS
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2023-05-25T15:35:41.628Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 153.281ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

As raised in #587 and #83, the Microsoft Azure AD Connection's `set_user_root_attributes` behavior is different than expected. In order to have the user profile sync on each login, this parameter needs to be omitted from the payload. To do so we need to remove the Computed property from the schema for this value. As well we update our docs to reflect this information. 

### 📚 References

- https://github.com/auth0/terraform-provider-auth0/issues/587
- https://github.com/auth0/terraform-provider-auth0/issues/83

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
