### PR TITLE
Refactor import resource group ids logic

### DIFF
--- a/internal/auth0/connection/resource_client.go
+++ b/internal/auth0/connection/resource_client.go
@@ -44,7 +44,7 @@ func NewClientResource() *schema.Resource {
 		ReadContext:   readConnectionClient,
 		DeleteContext: deleteConnectionClient,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourcePairID("connection_id", "client_id"),
+			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorColon, "connection_id", "client_id"),
 		},
 		Description: "With this resource, you can enable a single client on a connection.",
 	}

--- a/internal/auth0/organization/resource_connection.go
+++ b/internal/auth0/organization/resource_connection.go
@@ -22,7 +22,7 @@ func NewConnectionResource() *schema.Resource {
 		UpdateContext: updateOrganizationConnection,
 		DeleteContext: deleteOrganizationConnection,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourcePairID("organization_id", "connection_id"),
+			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorColon, "organization_id", "connection_id"),
 		},
 		Schema: map[string]*schema.Schema{
 			"organization_id": {

--- a/internal/auth0/organization/resource_member.go
+++ b/internal/auth0/organization/resource_member.go
@@ -22,7 +22,7 @@ func NewMemberResource() *schema.Resource {
 		UpdateContext: updateOrganizationMember,
 		DeleteContext: deleteOrganizationMember,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourcePairID("organization_id", "user_id"),
+			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorColon, "organization_id", "user_id"),
 		},
 		Schema: map[string]*schema.Schema{
 			"organization_id": {

--- a/internal/auth0/organization/resource_member_roles.go
+++ b/internal/auth0/organization/resource_member_roles.go
@@ -21,7 +21,7 @@ func NewMemberRolesResource() *schema.Resource {
 		UpdateContext: updateOrganizationMemberRoles,
 		DeleteContext: deleteOrganizationMemberRoles,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourcePairID("organization_id", "user_id"),
+			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorColon, "organization_id", "user_id"),
 		},
 		Schema: map[string]*schema.Schema{
 			"organization_id": {

--- a/internal/auth0/prompt/resource_custom_text.go
+++ b/internal/auth0/prompt/resource_custom_text.go
@@ -40,7 +40,7 @@ func NewCustomTextResource() *schema.Resource {
 		UpdateContext: updatePromptCustomText,
 		DeleteContext: deletePromptCustomText,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourcePairID("prompt", "language"),
+			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorColon, "prompt", "language"),
 		},
 		Description: "With this resource, you can manage custom text on your Auth0 prompts. You can read more about " +
 			"custom texts [here](https://auth0.com/docs/customize/universal-login-pages/customize-login-text-prompts).",


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR renames the old `ImportResourcePairID` func to `ImportResourceGroupID` and it extends its capabilities to be able to accept an aleatory number of attribute names using a variadic string variable and a given separator string so we can also clean up the codebase from redundant import funcs. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
