### PR TITLE
DXCDT-471: Fix creating org members when member list is empty

### DIFF
--- a/internal/auth0/organization/resource_members_test.go
+++ b/internal/auth0/organization/resource_members_test.go
@@ -160,6 +160,9 @@ func TestAccOrganizationMembers(t *testing.T) {
 				ExpectError: regexp.MustCompile("Organization with non empty members"),
 			},
 			{
+				Config: acctest.ParseTestName(testAccOrganizationMembersRemoveAllMembers, testName),
+			},
+			{
 				Config: acctest.ParseTestName(testAccOrganizationMembersWithOneMember, testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_organization_members.my_members", "members.#", "1"),

--- a/test/data/recordings/TestAccOrganizationMembers.yaml
+++ b/test/data/recordings/TestAccOrganizationMembers.yaml
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: 556
         uncompressed: false
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 290.641208ms
+        duration: 225.583458ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -56,7 +56,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -66,13 +66,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.642667ms
+        duration: 114.466416ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -92,7 +92,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -108,7 +108,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 102.742167ms
+        duration: 100.554041ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -128,7 +128,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -144,7 +144,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 116.149792ms
+        duration: 120.568333ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -174,13 +174,13 @@ interactions:
         trailer: {}
         content_length: 556
         uncompressed: false
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 246.037625ms
+        duration: 209.310209ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -200,7 +200,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -210,13 +210,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.922791ms
+        duration: 119.12125ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -236,7 +236,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -252,7 +252,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 102.7495ms
+        duration: 116.413209ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -272,7 +272,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -288,7 +288,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 112.019875ms
+        duration: 156.732167ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -318,13 +318,13 @@ interactions:
         trailer: {}
         content_length: 118
         uncompressed: false
-        body: '{"name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers","id":"org_eYIxxkSmmL9S9PZZ"}'
+        body: '{"name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers","id":"org_rLULwffaQbYevaO0"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 105.580584ms
+        duration: 101.345292ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -344,7 +344,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -354,13 +354,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 120.539333ms
+        duration: 113.904042ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -373,14 +373,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"members":["auth0|6489881ee74ba472099136b6"]}
+            {"members":["auth0|6491a5014a5f17311d569ef6"]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members
         method: POST
       response:
         proto: HTTP/2.0
@@ -396,7 +396,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 123.33975ms
+        duration: 118.161833ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -416,7 +416,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -432,7 +432,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 112.668834ms
+        duration: 128.161917ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -452,7 +452,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -462,13 +462,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":1}'
+        body: '{"members":[{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 116.539167ms
+        duration: 118.75325ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -488,7 +488,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -498,13 +498,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 132.056166ms
+        duration: 87.167791ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -524,7 +524,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -534,13 +534,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 140.070167ms
+        duration: 101.604709ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -560,7 +560,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -576,7 +576,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.269084ms
+        duration: 145.8865ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -596,7 +596,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -612,7 +612,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.4105ms
+        duration: 131.373417ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -632,7 +632,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -642,13 +642,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 93.562083ms
+        duration: 89.788042ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -668,7 +668,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -684,7 +684,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.692459ms
+        duration: 121.137625ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -704,7 +704,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -720,7 +720,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.815667ms
+        duration: 116.819042ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -740,7 +740,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -750,13 +750,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.350291ms
+        duration: 100.112417ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -769,14 +769,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"members":["auth0|6489881ee74ba472099136b6"]}
+            {"members":["auth0|6491a5014a5f17311d569ef6"]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -792,7 +792,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 98.951667ms
+        duration: 127.729541ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -812,7 +812,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -828,43 +828,43 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 110.296542ms
+        duration: 233.267083ms
     - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 47
+        content_length: 5
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"members":["auth0|6489881ee74ba472099136b6"]}
+            null
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members
-        method: POST
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: '{"members":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 118.217166ms
+        status: 200 OK
+        code: 200
+        duration: 131.636625ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -884,7 +884,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -894,13 +894,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":1}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 110.582916ms
+        duration: 109.175208ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -920,7 +920,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -930,13 +930,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.208583ms
+        duration: 106.884959ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -956,7 +956,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -966,13 +966,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 123.108417ms
+        duration: 106.95775ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -992,7 +992,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1002,13 +1002,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":1}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 116.498667ms
+        duration: 88.029833ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1028,7 +1028,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1038,13 +1038,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 127.424875ms
+        duration: 96.8905ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1064,7 +1064,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1074,13 +1074,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 139.6665ms
+        duration: 107.289ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1100,7 +1100,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1110,13 +1110,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":1}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 149.083125ms
+        duration: 94.28525ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1136,7 +1136,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1146,13 +1146,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 101.537209ms
+        duration: 93.591458ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1172,7 +1172,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1182,13 +1182,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 89.022166ms
+        duration: 104.303459ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1208,7 +1208,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -1218,13 +1218,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 103.875583ms
+        duration: 104.050708ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1244,7 +1244,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1254,13 +1254,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 89.676042ms
+        duration: 178.070458ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1280,7 +1280,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1290,13 +1290,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 87.43475ms
+        duration: 121.933208ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1316,7 +1316,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1326,13 +1326,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.543333ms
+        duration: 104.072833ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1352,7 +1352,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1362,13 +1362,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"members":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.579959ms
+        duration: 92.15975ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1388,7 +1388,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1398,13 +1398,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":1}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 148.723875ms
+        duration: 103.6465ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1424,7 +1424,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1434,13 +1434,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 90.862083ms
+        duration: 95.94025ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1460,7 +1460,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1470,13 +1470,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 90.808834ms
+        duration: 112.283667ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1496,7 +1496,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1506,13 +1506,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":1}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.421042ms
+        duration: 129.828125ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1532,7 +1532,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1542,13 +1542,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 87.804875ms
+        duration: 105.854542ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1568,7 +1568,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1578,13 +1578,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 127.980667ms
+        duration: 115.491334ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1604,7 +1604,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -1614,13 +1614,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":1}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 112.6535ms
+        duration: 99.16625ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1640,7 +1640,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1650,13 +1650,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 89.81725ms
+        duration: 145.651292ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1676,7 +1676,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1686,13 +1686,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 95.635459ms
+        duration: 167.477875ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1712,7 +1712,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -1722,13 +1722,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 112.955ms
+        duration: 112.552291ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1748,7 +1748,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1758,13 +1758,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 93.244209ms
+        duration: 142.742667ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1784,7 +1784,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1794,13 +1794,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 90.645ms
+        duration: 109.989ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1820,7 +1820,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1830,13 +1830,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.961459ms
+        duration: 106.606042ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1856,7 +1856,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1866,14 +1866,50 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"members":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 93.669083ms
+        duration: 121.641834ms
     - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 47
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"members":["auth0|6491a5014a5f17311d569ef6"]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 120.459208ms
+    - id: 53
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1892,7 +1928,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1902,49 +1938,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":1}'
+        body: '{"members":[{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.950375ms
-    - id: 53
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 47
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"members":["auth0|6489881e6e808509dc071524"]}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 139.476083ms
+        duration: 106.323917ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1964,7 +1964,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -1974,13 +1974,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.3435ms
+        duration: 91.586708ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -2000,7 +2000,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2010,13 +2010,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.323083ms
+        duration: 112.314166ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2036,7 +2036,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2046,13 +2046,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.432917ms
+        duration: 106.7635ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2072,7 +2072,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2082,13 +2082,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 87.396125ms
+        duration: 93.199333ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2108,7 +2108,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2118,13 +2118,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 89.19525ms
+        duration: 102.689625ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2144,7 +2144,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2154,13 +2154,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 87.600541ms
+        duration: 113.860291ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2180,7 +2180,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -2190,13 +2190,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.57125ms
+        duration: 94.578542ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -2216,7 +2216,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2226,13 +2226,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 86.44575ms
+        duration: 124.269084ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -2252,7 +2252,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2262,13 +2262,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 85.5095ms
+        duration: 105.205209ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -2288,7 +2288,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -2298,13 +2298,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 89.616958ms
+        duration: 95.590292ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -2324,7 +2324,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2334,13 +2334,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 220.11675ms
+        duration: 118.524084ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -2360,7 +2360,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2370,13 +2370,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 98.819083ms
+        duration: 98.487375ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -2396,7 +2396,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2406,13 +2406,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.8455ms
+        duration: 111.96525ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -2432,7 +2432,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2442,13 +2442,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"members":[{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 130.201833ms
+        duration: 105.954458ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -2468,7 +2468,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2478,13 +2478,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.957083ms
+        duration: 85.707459ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -2504,7 +2504,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2514,13 +2514,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 109.48375ms
+        duration: 102.732833ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -2540,7 +2540,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2550,13 +2550,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 88.166792ms
+        duration: 102.403958ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -2576,7 +2576,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2586,13 +2586,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 93.02425ms
+        duration: 100.218917ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -2612,7 +2612,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2622,13 +2622,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.919042ms
+        duration: 103.366375ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -2648,7 +2648,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2658,13 +2658,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.20625ms
+        duration: 145.90175ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -2684,7 +2684,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -2694,13 +2694,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 108.965042ms
+        duration: 98.093458ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -2720,7 +2720,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2730,13 +2730,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 85.07875ms
+        duration: 110.651125ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -2756,7 +2756,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2766,13 +2766,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 89.403375ms
+        duration: 124.28175ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -2792,7 +2792,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -2802,13 +2802,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.757ms
+        duration: 128.99225ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -2828,7 +2828,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2838,13 +2838,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.866625ms
+        duration: 124.584625ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -2864,7 +2864,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2874,13 +2874,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.769834ms
+        duration: 111.098167ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -2900,7 +2900,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -2910,13 +2910,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 209.973333ms
+        duration: 96.890667ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -2936,7 +2936,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2946,14 +2946,50 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"members":[{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.830041ms
+        duration: 110.154791ms
     - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 47
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"members":["auth0|6491a50220e9a839adbf8c88"]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 141.985208ms
+    - id: 83
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2972,7 +3008,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2982,49 +3018,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 98.6695ms
-    - id: 83
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 47
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"members":["auth0|6489881ee74ba472099136b6"]}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 95.184375ms
+        duration: 102.245625ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -3044,7 +3044,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3054,13 +3054,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":50,"total":1}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 212.732542ms
+        duration: 98.563125ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -3080,7 +3080,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3090,13 +3090,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 83.955625ms
+        duration: 104.591041ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -3116,7 +3116,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3126,13 +3126,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 119.441292ms
+        duration: 121.074209ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -3152,7 +3152,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3162,13 +3162,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":100,"total":1}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.870916ms
+        duration: 103.362875ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -3188,7 +3188,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3198,13 +3198,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 88.1345ms
+        duration: 95.754208ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -3224,7 +3224,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3234,13 +3234,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.255084ms
+        duration: 106.4305ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -3260,7 +3260,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -3270,13 +3270,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":100,"total":1}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.77825ms
+        duration: 114.517208ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -3296,7 +3296,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3306,13 +3306,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 80.846709ms
+        duration: 93.385209ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -3332,7 +3332,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3342,13 +3342,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.549ms
+        duration: 101.452875ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -3368,7 +3368,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -3378,13 +3378,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.359791ms
+        duration: 101.96375ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -3404,7 +3404,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3414,13 +3414,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.981041ms
+        duration: 181.081542ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -3440,7 +3440,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3450,13 +3450,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.571125ms
+        duration: 148.071291ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -3476,7 +3476,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3486,13 +3486,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 93.633958ms
+        duration: 94.891416ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -3512,7 +3512,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3522,13 +3522,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.152417ms
+        duration: 109.206583ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -3548,7 +3548,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3558,13 +3558,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":50,"total":1}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.127166ms
+        duration: 98.076083ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -3584,7 +3584,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3594,13 +3594,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 88.49475ms
+        duration: 103.896667ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -3620,7 +3620,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3630,13 +3630,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 90.932625ms
+        duration: 111.050708ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -3656,7 +3656,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3666,13 +3666,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":100,"total":1}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.763334ms
+        duration: 104.261708ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -3692,7 +3692,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3702,13 +3702,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 84.199708ms
+        duration: 123.806041ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -3728,7 +3728,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3738,13 +3738,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 87.062042ms
+        duration: 100.687ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -3764,7 +3764,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -3774,13 +3774,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":100,"total":1}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.146542ms
+        duration: 118.130541ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -3800,7 +3800,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3810,13 +3810,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 101.175875ms
+        duration: 109.17725ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -3836,7 +3836,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3846,13 +3846,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 105.064542ms
+        duration: 110.749417ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -3872,7 +3872,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -3882,13 +3882,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.531ms
+        duration: 100.512083ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -3908,7 +3908,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3918,13 +3918,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 101.470584ms
+        duration: 104.736292ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -3944,7 +3944,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3954,13 +3954,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 89.064875ms
+        duration: 144.846583ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -3980,7 +3980,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -3990,13 +3990,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 112.466958ms
+        duration: 161.964625ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -4016,7 +4016,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4026,14 +4026,50 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 95.026334ms
+        duration: 120.393958ms
     - id: 112
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 47
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"members":["auth0|6491a5014a5f17311d569ef6"]}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 114.809208ms
+    - id: 113
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -4052,7 +4088,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4062,49 +4098,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":50,"total":1}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":50,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 95.76375ms
-    - id: 113
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 47
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"members":["auth0|6489881e6e808509dc071524"]}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 86.220208ms
+        duration: 110.435667ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -4124,7 +4124,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -4134,13 +4134,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 166.533625ms
+        duration: 122.7495ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -4160,7 +4160,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4170,13 +4170,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.961917ms
+        duration: 104.695833ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -4196,7 +4196,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4206,13 +4206,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":100,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 86.786458ms
+        duration: 101.654667ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -4232,7 +4232,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -4242,13 +4242,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":100,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 95.325333ms
+        duration: 100.409042ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -4268,7 +4268,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4278,13 +4278,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 87.762583ms
+        duration: 96.966042ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -4304,7 +4304,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4314,13 +4314,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":100,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.050584ms
+        duration: 108.203167ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -4340,7 +4340,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -4350,13 +4350,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":100,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 87.867084ms
+        duration: 92.186417ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -4376,7 +4376,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4386,13 +4386,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 86.441875ms
+        duration: 130.440417ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -4412,7 +4412,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4422,13 +4422,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 108.443417ms
+        duration: 104.14275ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -4448,7 +4448,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -4458,13 +4458,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 110.802916ms
+        duration: 96.658959ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -4484,7 +4484,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4494,13 +4494,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 75.063708ms
+        duration: 98.141459ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -4520,7 +4520,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4530,13 +4530,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 89.166ms
+        duration: 117.893625ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -4556,7 +4556,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -4566,13 +4566,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 119.786167ms
+        duration: 102.213458ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -4592,7 +4592,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4602,13 +4602,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":50,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 95.100041ms
+        duration: 112.257542ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -4628,7 +4628,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -4638,13 +4638,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 83.817291ms
+        duration: 100.201042ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -4664,7 +4664,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4674,13 +4674,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 103.969958ms
+        duration: 257.912416ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -4700,7 +4700,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4710,13 +4710,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":100,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 105.217042ms
+        duration: 118.404083ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -4736,7 +4736,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -4746,13 +4746,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":100,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 102.465333ms
+        duration: 114.905917ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -4772,7 +4772,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4782,13 +4782,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.424209ms
+        duration: 115.725625ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -4808,7 +4808,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4818,13 +4818,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":100,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.822292ms
+        duration: 123.496291ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -4844,7 +4844,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -4854,13 +4854,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":100,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.897834ms
+        duration: 88.410917ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -4880,7 +4880,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4890,13 +4890,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.301458ms
+        duration: 99.75825ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -4916,7 +4916,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4926,13 +4926,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.019125ms
+        duration: 133.9645ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -4952,7 +4952,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -4962,13 +4962,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 101.403459ms
+        duration: 115.533625ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -4988,7 +4988,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4998,13 +4998,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 100.351541ms
+        duration: 105.997709ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -5024,7 +5024,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5034,13 +5034,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 89.357875ms
+        duration: 106.128208ms
     - id: 140
       request:
         proto: HTTP/1.1
@@ -5060,7 +5060,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -5070,13 +5070,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.004917ms
+        duration: 105.224333ms
     - id: 141
       request:
         proto: HTTP/1.1
@@ -5096,7 +5096,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5106,49 +5106,49 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"}],"start":0,"limit":50,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 111.992375ms
+        duration: 113.439875ms
     - id: 142
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 47
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            null
+            {"members":["auth0|6491a50220e9a839adbf8c88"]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
-        method: GET
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members
+        method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        content_length: 0
+        uncompressed: false
+        body: ""
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 81.301417ms
+        status: 204 No Content
+        code: 204
+        duration: 127.7565ms
     - id: 143
       request:
         proto: HTTP/1.1
@@ -5168,7 +5168,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5178,13 +5178,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"members":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 117.486625ms
+        duration: 106.660708ms
     - id: 144
       request:
         proto: HTTP/1.1
@@ -5204,7 +5204,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -5214,13 +5214,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.313791ms
+        duration: 108.035709ms
     - id: 145
       request:
         proto: HTTP/1.1
@@ -5240,7 +5240,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5250,13 +5250,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":100,"total":0}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.376875ms
+        duration: 100.995708ms
     - id: 146
       request:
         proto: HTTP/1.1
@@ -5276,7 +5276,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5286,13 +5286,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 79.351917ms
+        duration: 117.904709ms
     - id: 147
       request:
         proto: HTTP/1.1
@@ -5312,7 +5312,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -5322,13 +5322,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 95.433125ms
+        duration: 115.850834ms
     - id: 148
       request:
         proto: HTTP/1.1
@@ -5348,7 +5348,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5358,13 +5358,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":100,"total":0}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 83.496292ms
+        duration: 107.301958ms
     - id: 149
       request:
         proto: HTTP/1.1
@@ -5384,7 +5384,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5394,13 +5394,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.264875ms
+        duration: 101.789792ms
     - id: 150
       request:
         proto: HTTP/1.1
@@ -5420,7 +5420,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -5430,13 +5430,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 84.341208ms
+        duration: 97.365958ms
     - id: 151
       request:
         proto: HTTP/1.1
@@ -5456,7 +5456,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5466,13 +5466,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":100,"total":0}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 103.093ms
+        duration: 124.941542ms
     - id: 152
       request:
         proto: HTTP/1.1
@@ -5492,7 +5492,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5502,13 +5502,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 85.858416ms
+        duration: 107.033833ms
     - id: 153
       request:
         proto: HTTP/1.1
@@ -5528,7 +5528,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -5538,13 +5538,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 106.488208ms
+        duration: 109.156416ms
     - id: 154
       request:
         proto: HTTP/1.1
@@ -5564,7 +5564,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5574,13 +5574,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 87.355625ms
+        duration: 102.086834ms
     - id: 155
       request:
         proto: HTTP/1.1
@@ -5600,7 +5600,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5610,13 +5610,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 131.457583ms
+        duration: 220.646166ms
     - id: 156
       request:
         proto: HTTP/1.1
@@ -5636,7 +5636,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -5646,13 +5646,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.775292ms
+        duration: 132.327ms
     - id: 157
       request:
         proto: HTTP/1.1
@@ -5672,7 +5672,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5682,13 +5682,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"members":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 98.140458ms
+        duration: 130.770917ms
     - id: 158
       request:
         proto: HTTP/1.1
@@ -5708,7 +5708,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -5718,13 +5718,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 98.737417ms
+        duration: 98.3585ms
     - id: 159
       request:
         proto: HTTP/1.1
@@ -5744,7 +5744,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5754,13 +5754,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 88.791125ms
+        duration: 110.604667ms
     - id: 160
       request:
         proto: HTTP/1.1
@@ -5780,7 +5780,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5790,13 +5790,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.681625ms
+        duration: 95.259167ms
     - id: 161
       request:
         proto: HTTP/1.1
@@ -5816,7 +5816,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -5826,13 +5826,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":100,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.850875ms
+        duration: 121.507208ms
     - id: 162
       request:
         proto: HTTP/1.1
@@ -5852,7 +5852,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5862,13 +5862,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 90.4695ms
+        duration: 106.865667ms
     - id: 163
       request:
         proto: HTTP/1.1
@@ -5888,7 +5888,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5898,13 +5898,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 93.166541ms
+        duration: 114.821959ms
     - id: 164
       request:
         proto: HTTP/1.1
@@ -5924,7 +5924,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -5934,13 +5934,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[],"start":0,"limit":100,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 100.064583ms
+        duration: 119.164917ms
     - id: 165
       request:
         proto: HTTP/1.1
@@ -5960,7 +5960,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5970,13 +5970,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"members":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.843417ms
+        duration: 147.966542ms
     - id: 166
       request:
         proto: HTTP/1.1
@@ -5996,7 +5996,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6012,7 +6012,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.820667ms
+        duration: 106.765791ms
     - id: 167
       request:
         proto: HTTP/1.1
@@ -6032,7 +6032,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6048,7 +6048,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 90.288125ms
+        duration: 302.895541ms
     - id: 168
       request:
         proto: HTTP/1.1
@@ -6068,7 +6068,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -6078,13 +6078,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 86.689333ms
+        duration: 84.523ms
     - id: 169
       request:
         proto: HTTP/1.1
@@ -6104,7 +6104,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6120,7 +6120,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 86.409791ms
+        duration: 109.523917ms
     - id: 170
       request:
         proto: HTTP/1.1
@@ -6140,7 +6140,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6156,7 +6156,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 100.587875ms
+        duration: 113.833791ms
     - id: 171
       request:
         proto: HTTP/1.1
@@ -6176,7 +6176,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -6186,13 +6186,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 87.411208ms
+        duration: 109.193625ms
     - id: 172
       request:
         proto: HTTP/1.1
@@ -6212,7 +6212,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -6222,13 +6222,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 95.317834ms
+        duration: 105.943833ms
     - id: 173
       request:
         proto: HTTP/1.1
@@ -6248,7 +6248,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6264,7 +6264,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 103.620917ms
+        duration: 105.493042ms
     - id: 174
       request:
         proto: HTTP/1.1
@@ -6284,7 +6284,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6300,7 +6300,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 102.153709ms
+        duration: 110.00475ms
     - id: 175
       request:
         proto: HTTP/1.1
@@ -6320,7 +6320,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -6330,13 +6330,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 83.302959ms
+        duration: 103.953375ms
     - id: 176
       request:
         proto: HTTP/1.1
@@ -6356,7 +6356,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6372,7 +6372,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 88.864ms
+        duration: 99.90475ms
     - id: 177
       request:
         proto: HTTP/1.1
@@ -6392,7 +6392,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6408,7 +6408,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 81.677291ms
+        duration: 105.665125ms
     - id: 178
       request:
         proto: HTTP/1.1
@@ -6428,7 +6428,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -6438,13 +6438,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 81.636875ms
+        duration: 117.8975ms
     - id: 179
       request:
         proto: HTTP/1.1
@@ -6464,7 +6464,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6474,13 +6474,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.953208ms
+        duration: 110.51525ms
     - id: 180
       request:
         proto: HTTP/1.1
@@ -6500,7 +6500,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6510,13 +6510,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 101.688208ms
+        duration: 101.608917ms
     - id: 181
       request:
         proto: HTTP/1.1
@@ -6536,7 +6536,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -6546,13 +6546,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.221375ms
+        duration: 231.360625ms
     - id: 182
       request:
         proto: HTTP/1.1
@@ -6572,7 +6572,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6588,7 +6588,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 116.38825ms
+        duration: 108.1735ms
     - id: 183
       request:
         proto: HTTP/1.1
@@ -6608,7 +6608,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6624,7 +6624,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 100.599833ms
+        duration: 101.966917ms
     - id: 184
       request:
         proto: HTTP/1.1
@@ -6644,7 +6644,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -6654,85 +6654,85 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 173.196166ms
+        duration: 95.257792ms
     - id: 185
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 47
+        content_length: 5
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"members":["auth0|6489881e6e808509dc071524"]}
+            null
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members
-        method: POST
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 109.377ms
+        status: 200 OK
+        code: 200
+        duration: 102.434333ms
     - id: 186
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 47
+        content_length: 5
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"members":["auth0|6489881ee74ba472099136b6"]}
+            null
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members
-        method: POST
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 106.724334ms
+        status: 200 OK
+        code: 200
+        duration: 99.237167ms
     - id: 187
       request:
         proto: HTTP/1.1
@@ -6752,7 +6752,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -6762,13 +6762,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 108.96925ms
+        duration: 132.203458ms
     - id: 188
       request:
         proto: HTTP/1.1
@@ -6788,7 +6788,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -6798,13 +6798,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 223.959625ms
+        duration: 212.425417ms
     - id: 189
       request:
         proto: HTTP/1.1
@@ -6824,7 +6824,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6834,13 +6834,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.492583ms
+        duration: 125.069459ms
     - id: 190
       request:
         proto: HTTP/1.1
@@ -6860,7 +6860,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6870,13 +6870,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 98.789334ms
+        duration: 324.775375ms
     - id: 191
       request:
         proto: HTTP/1.1
@@ -6896,7 +6896,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -6906,13 +6906,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 119.044833ms
+        duration: 100.636375ms
     - id: 192
       request:
         proto: HTTP/1.1
@@ -6932,7 +6932,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6942,13 +6942,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 98.618125ms
+        duration: 156.587666ms
     - id: 193
       request:
         proto: HTTP/1.1
@@ -6968,7 +6968,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6978,13 +6978,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 86.069458ms
+        duration: 127.839625ms
     - id: 194
       request:
         proto: HTTP/1.1
@@ -7004,7 +7004,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -7014,13 +7014,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.842ms
+        duration: 105.404333ms
     - id: 195
       request:
         proto: HTTP/1.1
@@ -7040,7 +7040,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7050,13 +7050,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.276667ms
+        duration: 116.832708ms
     - id: 196
       request:
         proto: HTTP/1.1
@@ -7076,7 +7076,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7086,13 +7086,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.711875ms
+        duration: 104.967791ms
     - id: 197
       request:
         proto: HTTP/1.1
@@ -7112,7 +7112,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -7122,13 +7122,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 109.161583ms
+        duration: 94.004708ms
     - id: 198
       request:
         proto: HTTP/1.1
@@ -7148,7 +7148,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7158,13 +7158,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.31275ms
+        duration: 117.619375ms
     - id: 199
       request:
         proto: HTTP/1.1
@@ -7184,7 +7184,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7194,13 +7194,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.872792ms
+        duration: 208.474167ms
     - id: 200
       request:
         proto: HTTP/1.1
@@ -7220,7 +7220,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -7230,13 +7230,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 102.902708ms
+        duration: 198.904417ms
     - id: 201
       request:
         proto: HTTP/1.1
@@ -7256,7 +7256,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -7266,13 +7266,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 151.056ms
+        duration: 104.619292ms
     - id: 202
       request:
         proto: HTTP/1.1
@@ -7292,7 +7292,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7302,13 +7302,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.983292ms
+        duration: 100.743375ms
     - id: 203
       request:
         proto: HTTP/1.1
@@ -7328,7 +7328,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7338,13 +7338,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 93.589625ms
+        duration: 106.045709ms
     - id: 204
       request:
         proto: HTTP/1.1
@@ -7364,7 +7364,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -7374,13 +7374,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.968875ms
+        duration: 109.199375ms
     - id: 205
       request:
         proto: HTTP/1.1
@@ -7400,7 +7400,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7410,13 +7410,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 91.301167ms
+        duration: 114.394083ms
     - id: 206
       request:
         proto: HTTP/1.1
@@ -7436,7 +7436,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7446,13 +7446,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"members":[],"start":0,"limit":100,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 109.65425ms
+        duration: 105.513208ms
     - id: 207
       request:
         proto: HTTP/1.1
@@ -7472,7 +7472,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -7482,13 +7482,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.537083ms
+        duration: 106.8415ms
     - id: 208
       request:
         proto: HTTP/1.1
@@ -7508,7 +7508,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7518,13 +7518,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.851875ms
+        duration: 105.898958ms
     - id: 209
       request:
         proto: HTTP/1.1
@@ -7544,7 +7544,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7554,13 +7554,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 101.660583ms
+        duration: 97.157ms
     - id: 210
       request:
         proto: HTTP/1.1
@@ -7580,7 +7580,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -7590,13 +7590,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 109.275292ms
+        duration: 104.771375ms
     - id: 211
       request:
         proto: HTTP/1.1
@@ -7616,7 +7616,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7626,13 +7626,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 96.200916ms
+        duration: 116.61425ms
     - id: 212
       request:
         proto: HTTP/1.1
@@ -7652,7 +7652,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7662,13 +7662,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 86.284458ms
+        duration: 103.118542ms
     - id: 213
       request:
         proto: HTTP/1.1
@@ -7688,7 +7688,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -7698,85 +7698,85 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 107.639167ms
+        duration: 121.488042ms
     - id: 214
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 47
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            null
+            {"members":["auth0|6491a5014a5f17311d569ef6"]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
-        method: GET
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        content_length: 0
+        uncompressed: false
+        body: ""
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 96.257042ms
+        status: 204 No Content
+        code: 204
+        duration: 128.694959ms
     - id: 215
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 47
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            null
+            {"members":["auth0|6491a50220e9a839adbf8c88"]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
-        method: GET
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        content_length: 0
+        uncompressed: false
+        body: ""
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 93.480375ms
+        status: 204 No Content
+        code: 204
+        duration: 129.901125ms
     - id: 216
       request:
         proto: HTTP/1.1
@@ -7796,7 +7796,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7806,13 +7806,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 95.714417ms
+        duration: 111.296792ms
     - id: 217
       request:
         proto: HTTP/1.1
@@ -7832,7 +7832,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7842,13 +7842,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 115.950666ms
+        duration: 123.953417ms
     - id: 218
       request:
         proto: HTTP/1.1
@@ -7868,7 +7868,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -7878,13 +7878,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.119667ms
+        duration: 121.271459ms
     - id: 219
       request:
         proto: HTTP/1.1
@@ -7904,7 +7904,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7914,13 +7914,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 125.034334ms
+        duration: 97.258667ms
     - id: 220
       request:
         proto: HTTP/1.1
@@ -7940,7 +7940,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7950,13 +7950,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 92.597166ms
+        duration: 123.828958ms
     - id: 221
       request:
         proto: HTTP/1.1
@@ -7976,7 +7976,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -7986,13 +7986,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.150Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881ee74ba472099136b6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.150Z","user_id":"auth0|6489881ee74ba472099136b6"}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 123.839625ms
+        duration: 96.6655ms
     - id: 222
       request:
         proto: HTTP/1.1
@@ -8012,7 +8012,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8028,7 +8028,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.415958ms
+        duration: 112.262208ms
     - id: 223
       request:
         proto: HTTP/1.1
@@ -8048,7 +8048,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8064,7 +8064,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 105.767083ms
+        duration: 106.465792ms
     - id: 224
       request:
         proto: HTTP/1.1
@@ -8084,7 +8084,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -8094,13 +8094,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"created_at":"2023-06-14T09:27:58.727Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6489881e6e808509dc071524","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-14T09:27:58.727Z","user_id":"auth0|6489881e6e808509dc071524"}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 88.012167ms
+        duration: 94.028542ms
     - id: 225
       request:
         proto: HTTP/1.1
@@ -8120,7 +8120,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8136,7 +8136,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 83.2725ms
+        duration: 103.615792ms
     - id: 226
       request:
         proto: HTTP/1.1
@@ -8156,7 +8156,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524/permissions?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8166,13 +8166,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.810583ms
+        duration: 118.882958ms
     - id: 227
       request:
         proto: HTTP/1.1
@@ -8192,7 +8192,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8202,13 +8202,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 94.46625ms
+        duration: 111.95175ms
     - id: 228
       request:
         proto: HTTP/1.1
@@ -8228,7 +8228,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members/auth0%7C6489881e6e808509dc071524/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: GET
       response:
         proto: HTTP/2.0
@@ -8238,13 +8238,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 88.759916ms
+        duration: 94.322375ms
     - id: 229
       request:
         proto: HTTP/1.1
@@ -8264,7 +8264,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members/auth0%7C6489881ee74ba472099136b6/roles?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8274,13 +8274,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 109.745708ms
+        duration: 110.578083ms
     - id: 230
       request:
         proto: HTTP/1.1
@@ -8300,7 +8300,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&per_page=50
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8310,13 +8310,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 101.641542ms
+        duration: 137.8445ms
     - id: 231
       request:
         proto: HTTP/1.1
@@ -8336,7 +8336,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: GET
       response:
         proto: HTTP/2.0
@@ -8346,13 +8346,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 90.521041ms
+        duration: 92.306958ms
     - id: 232
       request:
         proto: HTTP/1.1
@@ -8372,7 +8372,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8382,13 +8382,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 99.565916ms
+        duration: 101.437791ms
     - id: 233
       request:
         proto: HTTP/1.1
@@ -8408,7 +8408,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8418,13 +8418,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.692ms
+        duration: 117.005208ms
     - id: 234
       request:
         proto: HTTP/1.1
@@ -8444,7 +8444,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: GET
       response:
         proto: HTTP/2.0
@@ -8454,13 +8454,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_eYIxxkSmmL9S9PZZ","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 88.214709ms
+        duration: 91.56275ms
     - id: 235
       request:
         proto: HTTP/1.1
@@ -8480,7 +8480,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/enabled_connections?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8490,13 +8490,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 100.449708ms
+        duration: 101.539542ms
     - id: 236
       request:
         proto: HTTP/1.1
@@ -8516,7 +8516,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members?include_totals=true&page=0&per_page=100
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8526,14 +8526,1058 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"members":[{"user_id":"auth0|6489881e6e808509dc071524","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6489881ee74ba472099136b6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 93.668791ms
+        duration: 113.65375ms
     - id: 237
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 113.168917ms
+    - id: 238
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 130.0695ms
+    - id: 239
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 131.3345ms
+    - id: 240
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 113.637833ms
+    - id: 241
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 102.865792ms
+    - id: 242
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 105.9395ms
+    - id: 243
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 104.9895ms
+    - id: 244
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 125.064042ms
+    - id: 245
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 123.2605ms
+    - id: 246
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 113.963167ms
+    - id: 247
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 96.026042ms
+    - id: 248
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 113.090292ms
+    - id: 249
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 109.110333ms
+    - id: 250
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"created_at":"2023-06-20T13:09:21.833Z","email":"testaccorganizationmembers1@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a5014a5f17311d569ef6","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers1@auth0.com","nickname":"testaccorganizationmembers1","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:21.833Z","user_id":"auth0|6491a5014a5f17311d569ef6"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 93.91775ms
+    - id: 251
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 99.851542ms
+    - id: 252
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6/permissions?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 102.820959ms
+    - id: 253
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"created_at":"2023-06-20T13:09:22.403Z","email":"testaccorganizationmembers2@auth0.com","email_verified":false,"identities":[{"connection":"Username-Password-Authentication","user_id":"6491a50220e9a839adbf8c88","provider":"auth0","isSocial":false}],"name":"testaccorganizationmembers2@auth0.com","nickname":"testaccorganizationmembers2","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","updated_at":"2023-06-20T13:09:22.403Z","user_id":"auth0|6491a50220e9a839adbf8c88"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 101.915083ms
+    - id: 254
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 135.913125ms
+    - id: 255
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88/permissions?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"permissions":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 102.367292ms
+    - id: 256
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 99.5285ms
+    - id: 257
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members/auth0%7C6491a50220e9a839adbf8c88/roles?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 101.550667ms
+    - id: 258
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members/auth0%7C6491a5014a5f17311d569ef6/roles?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"roles":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 118.888791ms
+    - id: 259
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":50,"total":2}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 105.353792ms
+    - id: 260
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 97.272958ms
+    - id: 261
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 98.912042ms
+    - id: 262
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 114.983042ms
+    - id: 263
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_rLULwffaQbYevaO0","name":"some-org-testaccorganizationmembers","display_name":"testaccorganizationmembers"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 103.558166ms
+    - id: 264
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/enabled_connections?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 106.150625ms
+    - id: 265
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0-SDK/0.17.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"members":[{"user_id":"auth0|6491a50220e9a839adbf8c88","email":"testaccorganizationmembers2@auth0.com","picture":"https://s.gravatar.com/avatar/89bb41f83b53cf422764a9d5a9bad2f1?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers2@auth0.com"},{"user_id":"auth0|6491a5014a5f17311d569ef6","email":"testaccorganizationmembers1@auth0.com","picture":"https://s.gravatar.com/avatar/4f34aa9f8f57ca4c76491ba399a9d6c2?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fte.png","name":"testaccorganizationmembers1@auth0.com"}],"start":0,"limit":100,"total":2}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 104.268416ms
+    - id: 266
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8545,14 +9589,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"members":["auth0|6489881e6e808509dc071524","auth0|6489881ee74ba472099136b6"]}
+            {"members":["auth0|6491a5014a5f17311d569ef6","auth0|6491a50220e9a839adbf8c88"]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8568,8 +9612,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 90.5415ms
-    - id: 238
+        duration: 116.082625ms
+    - id: 267
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8581,14 +9625,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"members":["auth0|6489881ee74ba472099136b6"]}
+            {"members":["auth0|6491a5014a5f17311d569ef6"]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8604,8 +9648,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 94.703625ms
-    - id: 239
+        duration: 118.364208ms
+    - id: 268
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8617,14 +9661,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"members":["auth0|6489881e6e808509dc071524"]}
+            {"members":["auth0|6491a50220e9a839adbf8c88"]}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ/members
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0/members
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8640,8 +9684,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 87.758083ms
-    - id: 240
+        duration: 92.396125ms
+    - id: 269
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8659,7 +9703,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_eYIxxkSmmL9S9PZZ
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_rLULwffaQbYevaO0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8675,8 +9719,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 88.6475ms
-    - id: 241
+        duration: 161.367167ms
+    - id: 270
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8694,7 +9738,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881e6e808509dc071524
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a50220e9a839adbf8c88
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8710,8 +9754,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 159.723625ms
-    - id: 242
+        duration: 306.877584ms
+    - id: 271
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -8729,7 +9773,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0-SDK/0.17.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6489881ee74ba472099136b6
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/users/auth0%7C6491a5014a5f17311d569ef6
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8745,4 +9789,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 115.214625ms
+        duration: 299.819667ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

While ensuring we can reliably run our tests e2e on a real test tenant, we encountered a bug where the organization members resource triggered an error when trying to create the resource with an empty members list. This PR fixes this issue by skipping the API call if the list is empty. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
