### PR TITLE
DXCDT-466: Removing `signing_key` from `auth0_client` example

### DIFF
--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -75,11 +75,6 @@ resource "auth0_client" "my_client" {
         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
       ]
       signing_cert = "-----BEGIN PUBLIC KEY-----\nMIGf...bpP/t3\n+JGNGIRMj1hF1rnb6QIDAQAB\n-----END PUBLIC KEY-----\n"
-
-      signing_key {
-        key  = "-----BEGIN PRIVATE KEY-----\nMIGf...bpP/t3\n+JGNGIRMj1hF1rnb6QIDAQAB\n-----END PUBLIC KEY-----\n"
-        cert = "-----BEGIN PUBLIC KEY-----\nMIGf...bpP/t3\n+JGNGIRMj1hF1rnb6QIDAQAB\n-----END PUBLIC KEY-----\n"
-      }
     }
   }
 }

--- a/examples/resources/auth0_client/resource.tf
+++ b/examples/resources/auth0_client/resource.tf
@@ -62,11 +62,6 @@ resource "auth0_client" "my_client" {
         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
       ]
       signing_cert = "-----BEGIN PUBLIC KEY-----\nMIGf...bpP/t3\n+JGNGIRMj1hF1rnb6QIDAQAB\n-----END PUBLIC KEY-----\n"
-
-      signing_key {
-        key  = "-----BEGIN PRIVATE KEY-----\nMIGf...bpP/t3\n+JGNGIRMj1hF1rnb6QIDAQAB\n-----END PUBLIC KEY-----\n"
-        cert = "-----BEGIN PUBLIC KEY-----\nMIGf...bpP/t3\n+JGNGIRMj1hF1rnb6QIDAQAB\n-----END PUBLIC KEY-----\n"
-      }
     }
   }
 }


### PR DESCRIPTION
### 🔧 Changes

The `signing_key` property was erroneously added to the `auth0_client` example in #210 instead of the `auth0_connection`. The property was successfully added to the connection resouce in #265 but has erroneously remained in the client resource documentation since. This PR simply removes this property that doesn't actually exist for clients.

This will fix #606 .

### 📚 References

Related PRs: #210 , #265 
Related Issue: #606 

### 🔬 Testing

N/A.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
