### PR TITLE
Add `post_login_prompt`to available options for `organization_require_behavior` within client resource

### DIFF
--- a/docs/data-sources/client.md
+++ b/docs/data-sources/client.md
@@ -59,7 +59,7 @@ data "auth0_client" "some-client-by-id" {
 - `native_social_login` (List of Object) Configuration settings to toggle native social login for mobile native applications. Once this is set it must stay set, with both resources set to `false` in order to change the `app_type`. (see [below for nested schema](#nestedatt--native_social_login))
 - `oidc_backchannel_logout_urls` (Set of String) Set of URLs that are valid to call back from Auth0 for OIDC backchannel logout. Currently only one URL is allowed.
 - `oidc_conformant` (Boolean) Indicates whether this client will conform to strict OIDC specifications.
-- `organization_require_behavior` (String) Defines how to proceed during an authentication transaction when `organization_usage = "require"`. Can be `no_prompt` (default) or `pre_login_prompt`.
+- `organization_require_behavior` (String) Defines how to proceed during an authentication transaction when `organization_usage = "require"`. Can be `no_prompt` (default), `pre_login_prompt` or  `post_login_prompt`.
 - `organization_usage` (String) Defines how to proceed during an authentication transaction with regards to an organization. Can be `deny` (default), `allow` or `require`.
 - `refresh_token` (List of Object) Configuration settings for the refresh tokens issued for this client. (see [below for nested schema](#nestedatt--refresh_token))
 - `signing_keys` (List of Map of String) List containing a map of the public cert of the signing key and the public cert of the signing key in PKCS7.

--- a/docs/data-sources/global_client.md
+++ b/docs/data-sources/global_client.md
@@ -48,7 +48,7 @@ data "auth0_global_client" "global" {}
 - `native_social_login` (List of Object) Configuration settings to toggle native social login for mobile native applications. Once this is set it must stay set, with both resources set to `false` in order to change the `app_type`. (see [below for nested schema](#nestedatt--native_social_login))
 - `oidc_backchannel_logout_urls` (Set of String) Set of URLs that are valid to call back from Auth0 for OIDC backchannel logout. Currently only one URL is allowed.
 - `oidc_conformant` (Boolean) Indicates whether this client will conform to strict OIDC specifications.
-- `organization_require_behavior` (String) Defines how to proceed during an authentication transaction when `organization_usage = "require"`. Can be `no_prompt` (default) or `pre_login_prompt`.
+- `organization_require_behavior` (String) Defines how to proceed during an authentication transaction when `organization_usage = "require"`. Can be `no_prompt` (default), `pre_login_prompt` or  `post_login_prompt`.
 - `organization_usage` (String) Defines how to proceed during an authentication transaction with regards to an organization. Can be `deny` (default), `allow` or `require`.
 - `refresh_token` (List of Object) Configuration settings for the refresh tokens issued for this client. (see [below for nested schema](#nestedatt--refresh_token))
 - `signing_keys` (List of Map of String) List containing a map of the public cert of the signing key and the public cert of the signing key in PKCS7.

--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -115,7 +115,7 @@ resource "auth0_client" "my_client" {
 - `native_social_login` (Block List, Max: 1) Configuration settings to toggle native social login for mobile native applications. Once this is set it must stay set, with both resources set to `false` in order to change the `app_type`. (see [below for nested schema](#nestedblock--native_social_login))
 - `oidc_backchannel_logout_urls` (Set of String) Set of URLs that are valid to call back from Auth0 for OIDC backchannel logout. Currently only one URL is allowed.
 - `oidc_conformant` (Boolean) Indicates whether this client will conform to strict OIDC specifications.
-- `organization_require_behavior` (String) Defines how to proceed during an authentication transaction when `organization_usage = "require"`. Can be `no_prompt` (default) or `pre_login_prompt`.
+- `organization_require_behavior` (String) Defines how to proceed during an authentication transaction when `organization_usage = "require"`. Can be `no_prompt` (default), `pre_login_prompt` or  `post_login_prompt`.
 - `organization_usage` (String) Defines how to proceed during an authentication transaction with regards to an organization. Can be `deny` (default), `allow` or `require`.
 - `refresh_token` (Block List, Max: 1) Configuration settings for the refresh tokens issued for this client. (see [below for nested schema](#nestedblock--refresh_token))
 - `sso` (Boolean) Applies only to SSO clients and determines whether Auth0 will handle Single Sign-On (true) or whether the identity provider will (false).

--- a/docs/resources/global_client.md
+++ b/docs/resources/global_client.md
@@ -60,7 +60,7 @@ PAGE
 - `native_social_login` (Block List, Max: 1) Configuration settings to toggle native social login for mobile native applications. Once this is set it must stay set, with both resources set to `false` in order to change the `app_type`. (see [below for nested schema](#nestedblock--native_social_login))
 - `oidc_backchannel_logout_urls` (Set of String) Set of URLs that are valid to call back from Auth0 for OIDC backchannel logout. Currently only one URL is allowed.
 - `oidc_conformant` (Boolean) Indicates whether this client will conform to strict OIDC specifications.
-- `organization_require_behavior` (String) Defines how to proceed during an authentication transaction when `organization_usage = "require"`. Can be `no_prompt` (default) or `pre_login_prompt`.
+- `organization_require_behavior` (String) Defines how to proceed during an authentication transaction when `organization_usage = "require"`. Can be `no_prompt` (default), `pre_login_prompt` or  `post_login_prompt`.
 - `organization_usage` (String) Defines how to proceed during an authentication transaction with regards to an organization. Can be `deny` (default), `allow` or `require`.
 - `refresh_token` (Block List, Max: 1) Configuration settings for the refresh tokens issued for this client. (see [below for nested schema](#nestedblock--refresh_token))
 - `signing_keys` (List of Map of String, Sensitive) List containing a map of the public cert of the signing key and the public cert of the signing key in PKCS7.

--- a/internal/auth0/client/resource.go
+++ b/internal/auth0/client/resource.go
@@ -156,14 +156,14 @@ func NewResource() *schema.Resource {
 				Description: "Defines how to proceed during an authentication transaction with " +
 					"regards to an organization. Can be `deny` (default), `allow` or `require`.",
 			},
-			"organization_require_behavior": {
+				"organization_require_behavior": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"no_prompt", "pre_login_prompt", "post_login_prompt",
 				}, false),
 				Description: "Defines how to proceed during an authentication transaction when " +
-					"`organization_usage = \"require\"`. Can be `no_prompt` (default) or `pre_login_prompt`.",
+					"`organization_usage = \"require\"`. Can be `no_prompt` (default), `pre_login_prompt` or  `post_login_prompt`.",
 			},
 			"allowed_origins": {
 				Type:     schema.TypeList,

--- a/internal/auth0/client/resource.go
+++ b/internal/auth0/client/resource.go
@@ -160,7 +160,7 @@ func NewResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"no_prompt", "pre_login_prompt",
+					"no_prompt", "pre_login_prompt", "post_login_prompt",
 				}, false),
 				Description: "Defines how to proceed during an authentication transaction when " +
 					"`organization_usage = \"require\"`. Can be `no_prompt` (default) or `pre_login_prompt`.",

--- a/internal/auth0/client/resource.go
+++ b/internal/auth0/client/resource.go
@@ -156,7 +156,7 @@ func NewResource() *schema.Resource {
 				Description: "Defines how to proceed during an authentication transaction with " +
 					"regards to an organization. Can be `deny` (default), `allow` or `require`.",
 			},
-				"organization_require_behavior": {
+			"organization_require_behavior": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice([]string{


### PR DESCRIPTION

### 🔧 Changes

Including support for the post_login_promt options for organization_require_behavior in the client resource

### 📚 References

- https://github.com/auth0/terraform-provider-auth0/issues/679
- https://auth0.com/changelog, search for Improved Login Flow for SaaS Users


### 🔬 Testing

Have tested with client and uses the attribute correctly, all unit and acc tests passing

### 📝 Checklist

- [N/A ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ x] I have added documentation for all new/changed functionality (or N/A)

