### PR TITLE
Remove connection metadata key validation

### DIFF
--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -36,7 +36,7 @@ data "auth0_connection" "some-connection-by-id" {
 - `enabled_clients` (Set of String) IDs of the clients for which the connection is enabled.
 - `id` (String) The ID of this resource.
 - `is_domain_connection` (Boolean) Indicates whether the connection is domain level.
-- `metadata` (Map of String) Metadata associated with the connection, in the form of a map of string values (max 255 chars). Maximum of 10 metadata properties allowed.
+- `metadata` (Map of String) Metadata associated with the connection, in the form of a map of string values (max 255 chars).
 - `options` (List of Object) Configuration settings for connection options. (see [below for nested schema](#nestedatt--options))
 - `realms` (List of String) Defines the realms for which the connection will be used (e.g., email domains). If not specified, the connection name is added as the realm.
 - `show_as_button` (Boolean) Display connection as a button. Only available on enterprise connections.

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -602,7 +602,7 @@ resource "auth0_connection" "okta" {
 
 - `display_name` (String) Name used in login screen.
 - `is_domain_connection` (Boolean) Indicates whether the connection is domain level.
-- `metadata` (Map of String) Metadata associated with the connection, in the form of a map of string values (max 255 chars). Maximum of 10 metadata properties allowed.
+- `metadata` (Map of String) Metadata associated with the connection, in the form of a map of string values (max 255 chars).
 - `options` (Block List, Max: 1) Configuration settings for connection options. (see [below for nested schema](#nestedblock--options))
 - `realms` (List of String) Defines the realms for which the connection will be used (e.g., email domains). If not specified, the connection name is added as the realm.
 - `show_as_button` (Boolean) Display connection as a button. Only available on enterprise connections.

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -55,9 +55,9 @@ var resourceSchemaV0 = map[string]*schema.Schema{
 		Type:             schema.TypeMap,
 		Elem:             &schema.Schema{Type: schema.TypeString},
 		Optional:         true,
-		ValidateDiagFunc: validation.MapKeyLenBetween(0, 10),
+		ValidateDiagFunc: validation.MapValueLenBetween(0, 255),
 		Description: "Metadata associated with the connection, in the form of a map of string values " +
-			"(max 255 chars). Maximum of 10 metadata properties allowed.",
+			"(max 255 chars).",
 	},
 	"options": {
 		Type:        schema.TypeList,


### PR DESCRIPTION
### 🔧 Changes

Validation on the `metadata` attribute of the `auth0_connection` resource now allows only keys with length 0-10 and the description shows a max of 10 metadata values. 

I have tested this with the API and you are allowed to:
* Add key lenghts longer then 255
* More then 10 metadata items 
* Values cannot be longer then 255 

I am not sure about the real limits, but it seems that the validation on the attribute does not match the validation on the API.

### 📚 References

-

### 🔬 Testing

Add connection with following metadata:

```
resource "auth0_connection" "my-connection" {
  name           = "my-connection"
  display_name   = "My Connection"

  metadata = {
    longer_then_10_chars = "value"
  }
}
```

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
