### PR TITLE
DXCDT-451: Align resource import separators

### DIFF
--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -106,10 +106,10 @@ Required:
 Import is supported using the following syntax:
 
 ```shell
-# An action can be imported using the action's ID.
+# This resource can be imported by specifying the action ID.
 #
 # Example:
-terraform import auth0_action.my_action 12f4f21b-017a-319d-92e7-2291c1ca36c4
+terraform import auth0_action.my_action "12f4f21b-017a-319d-92e7-2291c1ca36c4"
 ```
 
 ~> For security reasons importing `secrets` is not allowed. Therefore, it is advised to import

--- a/docs/resources/attack_protection.md
+++ b/docs/resources/attack_protection.md
@@ -133,5 +133,5 @@ Import is supported using the following syntax:
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_attack_protection.my_protection 24940d4b-4bd4-44e7-894e-f92e4de36a40
+terraform import auth0_attack_protection.my_protection "24940d4b-4bd4-44e7-894e-f92e4de36a40"
 ```

--- a/docs/resources/branding.md
+++ b/docs/resources/branding.md
@@ -77,5 +77,5 @@ Import is supported using the following syntax:
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_branding.my_brand 22f4f21b-017a-319d-92e7-2291c1ca36c4
+terraform import auth0_branding.my_brand "22f4f21b-017a-319d-92e7-2291c1ca36c4"
 ```

--- a/docs/resources/branding_theme.md
+++ b/docs/resources/branding_theme.md
@@ -271,8 +271,8 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-# Branding Themes can be imported using their ID.
+# This resource can be imported by specifying the Branding Theme ID.
 #
 # Example:
-terraform import auth0_branding_theme.my_theme XXXXXXXXXXXXXXXXXXXX
+terraform import auth0_branding_theme.my_theme "XXXXXXXXXXXXXXXXXXXX"
 ```

--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -534,8 +534,8 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-# A client can be imported using the client's ID.
+# This resource can be imported by specifying the client ID.
 #
 # Example:
-terraform import auth0_client.my_client AaiyAPdpYdesoKnqjj8HJqRn4T5titww
+terraform import auth0_client.my_client "AaiyAPdpYdesoKnqjj8HJqRn4T5titww"
 ```

--- a/docs/resources/client_credentials.md
+++ b/docs/resources/client_credentials.md
@@ -125,10 +125,10 @@ Read-Only:
 Import is supported using the following syntax:
 
 ```shell
-# A client credentials resource can be imported using the client's ID.
+# This resource can be imported by specifying the client ID.
 #
 # Example:
-terraform import auth0_client_credentials.my_creds AaiyAPdpYdesoKnqjj8HJqRn4T5titww
+terraform import auth0_client_credentials.my_creds "AaiyAPdpYdesoKnqjj8HJqRn4T5titww"
 ```
 
 ~> Importing this resource when the `authentication_method` is set to `private_key_jwt` will force the resource to be recreated.

--- a/docs/resources/client_grant.md
+++ b/docs/resources/client_grant.md
@@ -57,10 +57,9 @@ resource "auth0_client_grant" "my_client_grant" {
 Import is supported using the following syntax:
 
 ```shell
-# Client grants can be imported using the grant ID.
-#
-# Application -> APIs -> Expand the required API
+# This resource can be imported by specifying the client grant ID.
+# You can find this within the Management Dashboard in Application -> APIs -> Expand the required API.
 #
 # Example:
-terraform import auth0_client_grant.my_client_grant cgr_XXXXXXXXXXXXXXXX
+terraform import auth0_client_grant.my_client_grant "cgr_XXXXXXXXXXXXXXXX"
 ```

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -807,8 +807,8 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-# Connections can be imported using their ID.
+# This resource can be imported by specifying the connection ID.
 #
 # Example:
-terraform import auth0_connection.google con_a17f21fdb24d48a0
+terraform import auth0_connection.google "con_a17f21fdb24d48a0"
 ```

--- a/docs/resources/connection_client.md
+++ b/docs/resources/connection_client.md
@@ -53,8 +53,9 @@ Import is supported using the following syntax:
 
 ```shell
 # This resource can be imported by specifying the
-# connection ID and client ID separated by ":".
+# connection ID and client ID separated by "::" (note the double colon)
+# <connectionID>::<clientID>
 #
 # Example:
-terraform import auth0_connection_client.my_conn_client_assoc con_XXXXX:XXXXXXXX
+terraform import auth0_connection_client.my_conn_client_assoc "con_XXXXX::XXXXXXXX"
 ```

--- a/docs/resources/connection_clients.md
+++ b/docs/resources/connection_clients.md
@@ -62,5 +62,5 @@ Import is supported using the following syntax:
 # This resource can be imported by specifying the Connection ID.
 #
 # Example:
-terraform import auth0_connection_clients.my_conn_clients_assoc con_XXXXX:
+terraform import auth0_connection_clients.my_conn_clients_assoc "con_XXXXX"
 ```

--- a/docs/resources/custom_domain.md
+++ b/docs/resources/custom_domain.md
@@ -56,5 +56,5 @@ Import is supported using the following syntax:
 # https://auth0.com/docs/api/management/v2#!/Custom_Domains/get_custom_domains
 #
 # Example:
-terraform import auth0_custom_domain.my_custom_domain cd_XXXXXXXXXXXXXXXX
+terraform import auth0_custom_domain.my_custom_domain "cd_XXXXXXXXXXXXXXXX"
 ```

--- a/docs/resources/custom_domain_verification.md
+++ b/docs/resources/custom_domain_verification.md
@@ -72,5 +72,5 @@ Import is supported using the following syntax:
 # You can import this resource using the custom domain ID.
 #
 # Example:
-terraform import auth0_custom_domain_verification.my_custom_domain_verification cd_XXXXXXXXXXXXXXXX
+terraform import auth0_custom_domain_verification.my_custom_domain_verification "cd_XXXXXXXXXXXXXXXX"
 ```

--- a/docs/resources/email.md
+++ b/docs/resources/email.md
@@ -121,5 +121,5 @@ Import is supported using the following syntax:
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_email.my_email_provider b4213dc2-2eed-42c3-9516-c6131a9ce0b0
+terraform import auth0_email.my_email_provider "b4213dc2-2eed-42c3-9516-c6131a9ce0b0"
 ```

--- a/docs/resources/email_template.md
+++ b/docs/resources/email_template.md
@@ -74,5 +74,5 @@ Import is supported using the following syntax:
 # for legacy scenarios.
 #
 # Example:
-terraform import auth0_email_template.my_email_template welcome_email
+terraform import auth0_email_template.my_email_template "welcome_email"
 ```

--- a/docs/resources/guardian.md
+++ b/docs/resources/guardian.md
@@ -225,5 +225,5 @@ Import is supported using the following syntax:
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_guardian.my_guardian 24940d4b-4bd4-44e7-894e-f92e4de36a40
+terraform import auth0_guardian.my_guardian "24940d4b-4bd4-44e7-894e-f92e4de36a40"
 ```

--- a/docs/resources/hook.md
+++ b/docs/resources/hook.md
@@ -59,8 +59,8 @@ resource "auth0_hook" "my_hook" {
 Import is supported using the following syntax:
 
 ```shell
-# A hook can be imported using the hook's ID.
+# This resource can be imported by specifying the hook ID.
 #
 # Example:
-terraform import auth0_hook.my_hook 00001
+terraform import auth0_hook.my_hook "00001"
 ```

--- a/docs/resources/log_stream.md
+++ b/docs/resources/log_stream.md
@@ -106,8 +106,8 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-# An existing log stream can be imported using its ID.
+# This resource can be imported by specifying the log stream ID.
 #
 # Example:
-terraform import auth0_log_stream.example lst_XXXXXXXXXXXXXXXX
+terraform import auth0_log_stream.example "lst_XXXXXXXXXXXXXXXX"
 ```

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -64,8 +64,8 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-# Existing organizations can be imported using the organization ID.
+# This resource can be imported by specifying the organization ID.
 #
 # Example:
-terraform import auth0_organization.my_organization org_XXXXXXXXXXXXXX
+terraform import auth0_organization.my_organization "org_XXXXXXXXXXXXXX"
 ```

--- a/docs/resources/organization_connection.md
+++ b/docs/resources/organization_connection.md
@@ -57,8 +57,9 @@ Import is supported using the following syntax:
 
 ```shell
 # This resource can be imported by specifying the
-# organization ID and connection ID separated by ":".
+# organization ID and connection ID separated by "::" (note the double colon)
+# <organizationID>::<connectionID>
 #
 # Example:
-terraform import auth0_organization_connection.my_org_conn org_XXXXX:con_XXXXX
+terraform import auth0_organization_connection.my_org_conn "org_XXXXX::con_XXXXX"
 ```

--- a/docs/resources/organization_connections.md
+++ b/docs/resources/organization_connections.md
@@ -77,5 +77,5 @@ Import is supported using the following syntax:
 # This resource can be imported by specifying the organization ID.
 #
 # Example:
-terraform import auth0_organization_connections.my_org_conns org_XXXXX
+terraform import auth0_organization_connections.my_org_conns "org_XXXXX"
 ```

--- a/docs/resources/organization_member.md
+++ b/docs/resources/organization_member.md
@@ -51,8 +51,9 @@ Import is supported using the following syntax:
 
 ```shell
 # This resource can be imported by specifying the
-# organization ID and user ID separated by ":".
+# organization ID and user ID separated by "::" (note the double colon)
+# <organizationID>::<userID>
 #
 # Example:
-terraform import auth0_organization_member.my_org_member "org_XXXXX:auth0|XXXXX"
+terraform import auth0_organization_member.my_org_member "org_XXXXX::auth0|XXXXX"
 ```

--- a/docs/resources/organization_member_role.md
+++ b/docs/resources/organization_member_role.md
@@ -69,7 +69,8 @@ Import is supported using the following syntax:
 
 ```shell
 # This resource can be imported by specifying the
-# organization ID, user ID and role ID separated by "::".
+# organization ID, user ID and role ID separated by "::" (note the double colon)
+# <organizationID>::<userID>::<roleID>
 #
 # Example:
 terraform import auth0_organization_member_role.my_org_member_role "org_XXXXX::auth0|XXXXX::role_XXXX"

--- a/docs/resources/organization_member_roles.md
+++ b/docs/resources/organization_member_roles.md
@@ -61,8 +61,9 @@ Import is supported using the following syntax:
 
 ```shell
 # This resource can be imported by specifying the
-# organization ID and user ID separated by ":".
+# organization ID and user ID separated by "::" (note the double colon)
+# <organizationID>::<userID>
 #
 # Example:
-terraform import auth0_organization_member_roles.my_org_member_roles "org_XXXXX:auth0|XXXXX"
+terraform import auth0_organization_member_roles.my_org_member_roles "org_XXXXX::auth0|XXXXX"
 ```

--- a/docs/resources/pages.md
+++ b/docs/resources/pages.md
@@ -99,5 +99,5 @@ Import is supported using the following syntax:
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_pages.my_pages 22f4f21b-017a-319d-92e7-2291c1ca36c4
+terraform import auth0_pages.my_pages "22f4f21b-017a-319d-92e7-2291c1ca36c4"
 ```

--- a/docs/resources/prompt.md
+++ b/docs/resources/prompt.md
@@ -42,5 +42,5 @@ Import is supported using the following syntax:
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_prompt.my_prompt 22f4f21b-017a-319d-92e7-2291c1ca36c4
+terraform import auth0_prompt.my_prompt "22f4f21b-017a-319d-92e7-2291c1ca36c4"
 ```

--- a/docs/resources/prompt_custom_text.md
+++ b/docs/resources/prompt_custom_text.md
@@ -60,8 +60,10 @@ resource "auth0_prompt_custom_text" "example" {
 Import is supported using the following syntax:
 
 ```shell
-# This resource can be imported by specifying the prompt and language separated by ":".
+# This resource can be imported by specifying the
+# prompt and language separated by "::" (note the double colon)
+# <prompt>::<language>
 #
 # Example
-terraform import auth0_prompt_custom_text.example login:en
+terraform import auth0_prompt_custom_text.example "login::en"
 ```

--- a/docs/resources/resource_server.md
+++ b/docs/resources/resource_server.md
@@ -54,5 +54,5 @@ Import is supported using the following syntax:
 # Existing resource servers can be imported using their ID.
 #
 # Example:
-terraform import auth0_resource_server.my_resource_server XXXXXXXXXXXXXXXXXXXXXXX
+terraform import auth0_resource_server.my_resource_server "XXXXXXXXXXXXXXXXXXXXXXX"
 ```

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -40,5 +40,5 @@ Import is supported using the following syntax:
 # Existing roles can be imported using their ID.
 #
 # Example:
-terraform import auth0_role.my_role XXXXXXXXXXXXXXXXXXXXXXX
+terraform import auth0_role.my_role "XXXXXXXXXXXXXXXXXXXXXXX"
 ```

--- a/docs/resources/rule.md
+++ b/docs/resources/rule.md
@@ -53,5 +53,5 @@ Import is supported using the following syntax:
 # Existing rules can be imported using their ID.
 #
 # Example:
-terraform import auth0_rule.my_rule rul_XXXXXXXXXXXXX
+terraform import auth0_rule.my_rule "rul_XXXXXXXXXXXXX"
 ```

--- a/docs/resources/rule_config.md
+++ b/docs/resources/rule_config.md
@@ -47,5 +47,5 @@ Import is supported using the following syntax:
 # Existing rule configs can be imported using their key name.
 #
 # Example:
-terraform import auth0_rule_config.my_rule_config foo
+terraform import auth0_rule_config.my_rule_config "foo"
 ```

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -110,5 +110,5 @@ Import is supported using the following syntax:
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_tenant.my_tenant 82f4f21b-017a-319d-92e7-2291c1ca36c4
+terraform import auth0_tenant.my_tenant "82f4f21b-017a-319d-92e7-2291c1ca36c4"
 ```

--- a/docs/resources/trigger_action.md
+++ b/docs/resources/trigger_action.md
@@ -61,8 +61,9 @@ Import is supported using the following syntax:
 
 ```shell
 # This resource can be imported by specifying the
-# trigger and action ID separated by "::".
+# trigger and action ID separated by "::" (note the double colon)
+# <trigger>::<actionID>
 #
 # Example:
-terraform import auth0_trigger_action.post_login_action post-login::28b5c8fa-d371-5734-acf6-d0cf80ead918
+terraform import auth0_trigger_action.post_login_action "post-login::28b5c8fa-d371-5734-acf6-d0cf80ead918"
 ```

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -62,5 +62,5 @@ Import is supported using the following syntax:
 # This resource can be imported using the user ID.
 #
 # Example:
-terraform import auth0_user.user auth0|111111111111111111111111
+terraform import auth0_user.user "auth0|111111111111111111111111"
 ```

--- a/examples/resources/auth0_action/import.sh
+++ b/examples/resources/auth0_action/import.sh
@@ -1,4 +1,4 @@
-# An action can be imported using the action's ID.
+# This resource can be imported by specifying the action ID.
 #
 # Example:
-terraform import auth0_action.my_action 12f4f21b-017a-319d-92e7-2291c1ca36c4
+terraform import auth0_action.my_action "12f4f21b-017a-319d-92e7-2291c1ca36c4"

--- a/examples/resources/auth0_attack_protection/import.sh
+++ b/examples/resources/auth0_attack_protection/import.sh
@@ -4,4 +4,4 @@
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_attack_protection.my_protection 24940d4b-4bd4-44e7-894e-f92e4de36a40
+terraform import auth0_attack_protection.my_protection "24940d4b-4bd4-44e7-894e-f92e4de36a40"

--- a/examples/resources/auth0_branding/import.sh
+++ b/examples/resources/auth0_branding/import.sh
@@ -4,4 +4,4 @@
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_branding.my_brand 22f4f21b-017a-319d-92e7-2291c1ca36c4
+terraform import auth0_branding.my_brand "22f4f21b-017a-319d-92e7-2291c1ca36c4"

--- a/examples/resources/auth0_branding_theme/import.sh
+++ b/examples/resources/auth0_branding_theme/import.sh
@@ -1,4 +1,4 @@
-# Branding Themes can be imported using their ID.
+# This resource can be imported by specifying the Branding Theme ID.
 #
 # Example:
-terraform import auth0_branding_theme.my_theme XXXXXXXXXXXXXXXXXXXX
+terraform import auth0_branding_theme.my_theme "XXXXXXXXXXXXXXXXXXXX"

--- a/examples/resources/auth0_client/import.sh
+++ b/examples/resources/auth0_client/import.sh
@@ -1,4 +1,4 @@
-# A client can be imported using the client's ID.
+# This resource can be imported by specifying the client ID.
 #
 # Example:
-terraform import auth0_client.my_client AaiyAPdpYdesoKnqjj8HJqRn4T5titww
+terraform import auth0_client.my_client "AaiyAPdpYdesoKnqjj8HJqRn4T5titww"

--- a/examples/resources/auth0_client_credentials/import.sh
+++ b/examples/resources/auth0_client_credentials/import.sh
@@ -1,4 +1,4 @@
-# A client credentials resource can be imported using the client's ID.
+# This resource can be imported by specifying the client ID.
 #
 # Example:
-terraform import auth0_client_credentials.my_creds AaiyAPdpYdesoKnqjj8HJqRn4T5titww
+terraform import auth0_client_credentials.my_creds "AaiyAPdpYdesoKnqjj8HJqRn4T5titww"

--- a/examples/resources/auth0_client_grant/import.sh
+++ b/examples/resources/auth0_client_grant/import.sh
@@ -1,6 +1,5 @@
-# Client grants can be imported using the grant ID.
-#
-# Application -> APIs -> Expand the required API
+# This resource can be imported by specifying the client grant ID.
+# You can find this within the Management Dashboard in Application -> APIs -> Expand the required API.
 #
 # Example:
-terraform import auth0_client_grant.my_client_grant cgr_XXXXXXXXXXXXXXXX
+terraform import auth0_client_grant.my_client_grant "cgr_XXXXXXXXXXXXXXXX"

--- a/examples/resources/auth0_connection/import.sh
+++ b/examples/resources/auth0_connection/import.sh
@@ -1,4 +1,4 @@
-# Connections can be imported using their ID.
+# This resource can be imported by specifying the connection ID.
 #
 # Example:
-terraform import auth0_connection.google con_a17f21fdb24d48a0
+terraform import auth0_connection.google "con_a17f21fdb24d48a0"

--- a/examples/resources/auth0_connection_client/import.sh
+++ b/examples/resources/auth0_connection_client/import.sh
@@ -1,5 +1,6 @@
 # This resource can be imported by specifying the
-# connection ID and client ID separated by ":".
+# connection ID and client ID separated by "::" (note the double colon)
+# <connectionID>::<clientID>
 #
 # Example:
-terraform import auth0_connection_client.my_conn_client_assoc con_XXXXX:XXXXXXXX
+terraform import auth0_connection_client.my_conn_client_assoc "con_XXXXX::XXXXXXXX"

--- a/examples/resources/auth0_connection_clients/import.sh
+++ b/examples/resources/auth0_connection_clients/import.sh
@@ -1,4 +1,4 @@
 # This resource can be imported by specifying the Connection ID.
 #
 # Example:
-terraform import auth0_connection_clients.my_conn_clients_assoc con_XXXXX:
+terraform import auth0_connection_clients.my_conn_clients_assoc "con_XXXXX"

--- a/examples/resources/auth0_custom_domain/import.sh
+++ b/examples/resources/auth0_custom_domain/import.sh
@@ -4,4 +4,4 @@
 # https://auth0.com/docs/api/management/v2#!/Custom_Domains/get_custom_domains
 #
 # Example:
-terraform import auth0_custom_domain.my_custom_domain cd_XXXXXXXXXXXXXXXX
+terraform import auth0_custom_domain.my_custom_domain "cd_XXXXXXXXXXXXXXXX"

--- a/examples/resources/auth0_custom_domain_verification/import.sh
+++ b/examples/resources/auth0_custom_domain_verification/import.sh
@@ -1,4 +1,4 @@
 # You can import this resource using the custom domain ID.
 #
 # Example:
-terraform import auth0_custom_domain_verification.my_custom_domain_verification cd_XXXXXXXXXXXXXXXX
+terraform import auth0_custom_domain_verification.my_custom_domain_verification "cd_XXXXXXXXXXXXXXXX"

--- a/examples/resources/auth0_email/import.sh
+++ b/examples/resources/auth0_email/import.sh
@@ -4,4 +4,4 @@
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_email.my_email_provider b4213dc2-2eed-42c3-9516-c6131a9ce0b0
+terraform import auth0_email.my_email_provider "b4213dc2-2eed-42c3-9516-c6131a9ce0b0"

--- a/examples/resources/auth0_email_template/import.sh
+++ b/examples/resources/auth0_email_template/import.sh
@@ -8,4 +8,4 @@
 # for legacy scenarios.
 #
 # Example:
-terraform import auth0_email_template.my_email_template welcome_email
+terraform import auth0_email_template.my_email_template "welcome_email"

--- a/examples/resources/auth0_guardian/import.sh
+++ b/examples/resources/auth0_guardian/import.sh
@@ -4,4 +4,4 @@
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_guardian.my_guardian 24940d4b-4bd4-44e7-894e-f92e4de36a40
+terraform import auth0_guardian.my_guardian "24940d4b-4bd4-44e7-894e-f92e4de36a40"

--- a/examples/resources/auth0_hook/import.sh
+++ b/examples/resources/auth0_hook/import.sh
@@ -1,4 +1,4 @@
-# A hook can be imported using the hook's ID.
+# This resource can be imported by specifying the hook ID.
 #
 # Example:
-terraform import auth0_hook.my_hook 00001
+terraform import auth0_hook.my_hook "00001"

--- a/examples/resources/auth0_log_stream/import.sh
+++ b/examples/resources/auth0_log_stream/import.sh
@@ -1,4 +1,4 @@
-# An existing log stream can be imported using its ID.
+# This resource can be imported by specifying the log stream ID.
 #
 # Example:
-terraform import auth0_log_stream.example lst_XXXXXXXXXXXXXXXX
+terraform import auth0_log_stream.example "lst_XXXXXXXXXXXXXXXX"

--- a/examples/resources/auth0_organization/import.sh
+++ b/examples/resources/auth0_organization/import.sh
@@ -1,4 +1,4 @@
-# Existing organizations can be imported using the organization ID.
+# This resource can be imported by specifying the organization ID.
 #
 # Example:
-terraform import auth0_organization.my_organization org_XXXXXXXXXXXXXX
+terraform import auth0_organization.my_organization "org_XXXXXXXXXXXXXX"

--- a/examples/resources/auth0_organization_connection/import.sh
+++ b/examples/resources/auth0_organization_connection/import.sh
@@ -1,5 +1,6 @@
 # This resource can be imported by specifying the
-# organization ID and connection ID separated by ":".
+# organization ID and connection ID separated by "::" (note the double colon)
+# <organizationID>::<connectionID>
 #
 # Example:
-terraform import auth0_organization_connection.my_org_conn org_XXXXX:con_XXXXX
+terraform import auth0_organization_connection.my_org_conn "org_XXXXX::con_XXXXX"

--- a/examples/resources/auth0_organization_connections/import.sh
+++ b/examples/resources/auth0_organization_connections/import.sh
@@ -1,4 +1,4 @@
 # This resource can be imported by specifying the organization ID.
 #
 # Example:
-terraform import auth0_organization_connections.my_org_conns org_XXXXX
+terraform import auth0_organization_connections.my_org_conns "org_XXXXX"

--- a/examples/resources/auth0_organization_member/import.sh
+++ b/examples/resources/auth0_organization_member/import.sh
@@ -1,5 +1,6 @@
 # This resource can be imported by specifying the
-# organization ID and user ID separated by ":".
+# organization ID and user ID separated by "::" (note the double colon)
+# <organizationID>::<userID>
 #
 # Example:
-terraform import auth0_organization_member.my_org_member "org_XXXXX:auth0|XXXXX"
+terraform import auth0_organization_member.my_org_member "org_XXXXX::auth0|XXXXX"

--- a/examples/resources/auth0_organization_member_role/import.sh
+++ b/examples/resources/auth0_organization_member_role/import.sh
@@ -1,5 +1,6 @@
 # This resource can be imported by specifying the
-# organization ID, user ID and role ID separated by "::".
+# organization ID, user ID and role ID separated by "::" (note the double colon)
+# <organizationID>::<userID>::<roleID>
 #
 # Example:
 terraform import auth0_organization_member_role.my_org_member_role "org_XXXXX::auth0|XXXXX::role_XXXX"

--- a/examples/resources/auth0_organization_member_roles/import.sh
+++ b/examples/resources/auth0_organization_member_roles/import.sh
@@ -1,5 +1,6 @@
 # This resource can be imported by specifying the
-# organization ID and user ID separated by ":".
+# organization ID and user ID separated by "::" (note the double colon)
+# <organizationID>::<userID>
 #
 # Example:
-terraform import auth0_organization_member_roles.my_org_member_roles "org_XXXXX:auth0|XXXXX"
+terraform import auth0_organization_member_roles.my_org_member_roles "org_XXXXX::auth0|XXXXX"

--- a/examples/resources/auth0_pages/import.sh
+++ b/examples/resources/auth0_pages/import.sh
@@ -4,4 +4,4 @@
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_pages.my_pages 22f4f21b-017a-319d-92e7-2291c1ca36c4
+terraform import auth0_pages.my_pages "22f4f21b-017a-319d-92e7-2291c1ca36c4"

--- a/examples/resources/auth0_prompt/import.sh
+++ b/examples/resources/auth0_prompt/import.sh
@@ -4,4 +4,4 @@
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_prompt.my_prompt 22f4f21b-017a-319d-92e7-2291c1ca36c4
+terraform import auth0_prompt.my_prompt "22f4f21b-017a-319d-92e7-2291c1ca36c4"

--- a/examples/resources/auth0_prompt_custom_text/import.sh
+++ b/examples/resources/auth0_prompt_custom_text/import.sh
@@ -1,4 +1,6 @@
-# This resource can be imported by specifying the prompt and language separated by ":".
+# This resource can be imported by specifying the
+# prompt and language separated by "::" (note the double colon)
+# <prompt>::<language>
 #
 # Example
-terraform import auth0_prompt_custom_text.example login:en
+terraform import auth0_prompt_custom_text.example "login::en"

--- a/examples/resources/auth0_resource_server/import.sh
+++ b/examples/resources/auth0_resource_server/import.sh
@@ -1,4 +1,4 @@
 # Existing resource servers can be imported using their ID.
 #
 # Example:
-terraform import auth0_resource_server.my_resource_server XXXXXXXXXXXXXXXXXXXXXXX
+terraform import auth0_resource_server.my_resource_server "XXXXXXXXXXXXXXXXXXXXXXX"

--- a/examples/resources/auth0_role/import.sh
+++ b/examples/resources/auth0_role/import.sh
@@ -1,4 +1,4 @@
 # Existing roles can be imported using their ID.
 #
 # Example:
-terraform import auth0_role.my_role XXXXXXXXXXXXXXXXXXXXXXX
+terraform import auth0_role.my_role "XXXXXXXXXXXXXXXXXXXXXXX"

--- a/examples/resources/auth0_rule/import.sh
+++ b/examples/resources/auth0_rule/import.sh
@@ -1,4 +1,4 @@
 # Existing rules can be imported using their ID.
 #
 # Example:
-terraform import auth0_rule.my_rule rul_XXXXXXXXXXXXX
+terraform import auth0_rule.my_rule "rul_XXXXXXXXXXXXX"

--- a/examples/resources/auth0_rule_config/import.sh
+++ b/examples/resources/auth0_rule_config/import.sh
@@ -1,4 +1,4 @@
 # Existing rule configs can be imported using their key name.
 #
 # Example:
-terraform import auth0_rule_config.my_rule_config foo
+terraform import auth0_rule_config.my_rule_config "foo"

--- a/examples/resources/auth0_tenant/import.sh
+++ b/examples/resources/auth0_tenant/import.sh
@@ -4,4 +4,4 @@
 # We recommend [Version 4 UUID](https://www.uuidgenerator.net/version4)
 #
 # Example:
-terraform import auth0_tenant.my_tenant 82f4f21b-017a-319d-92e7-2291c1ca36c4
+terraform import auth0_tenant.my_tenant "82f4f21b-017a-319d-92e7-2291c1ca36c4"

--- a/examples/resources/auth0_trigger_action/import.sh
+++ b/examples/resources/auth0_trigger_action/import.sh
@@ -1,5 +1,6 @@
 # This resource can be imported by specifying the
-# trigger and action ID separated by "::".
+# trigger and action ID separated by "::" (note the double colon)
+# <trigger>::<actionID>
 #
 # Example:
-terraform import auth0_trigger_action.post_login_action post-login::28b5c8fa-d371-5734-acf6-d0cf80ead918
+terraform import auth0_trigger_action.post_login_action "post-login::28b5c8fa-d371-5734-acf6-d0cf80ead918"

--- a/examples/resources/auth0_user/import.sh
+++ b/examples/resources/auth0_user/import.sh
@@ -1,4 +1,4 @@
 # This resource can be imported using the user ID.
 #
 # Example:
-terraform import auth0_user.user auth0|111111111111111111111111
+terraform import auth0_user.user "auth0|111111111111111111111111"

--- a/internal/auth0/connection/resource_client.go
+++ b/internal/auth0/connection/resource_client.go
@@ -44,7 +44,7 @@ func NewClientResource() *schema.Resource {
 		ReadContext:   readConnectionClient,
 		DeleteContext: deleteConnectionClient,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorColon, "connection_id", "client_id"),
+			StateContext: internalSchema.ImportResourceGroupID("connection_id", "client_id"),
 		},
 		Description: "With this resource, you can enable a single client on a connection.",
 	}
@@ -75,7 +75,7 @@ func createConnectionClient(ctx context.Context, data *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	data.SetId(connectionID + ":" + clientID)
+	internalSchema.SetResourceGroupID(data, connectionID, clientID)
 
 	return readConnectionClient(ctx, data, meta)
 }

--- a/internal/auth0/organization/resource_connection.go
+++ b/internal/auth0/organization/resource_connection.go
@@ -22,7 +22,7 @@ func NewConnectionResource() *schema.Resource {
 		UpdateContext: updateOrganizationConnection,
 		DeleteContext: deleteOrganizationConnection,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorColon, "organization_id", "connection_id"),
+			StateContext: internalSchema.ImportResourceGroupID("organization_id", "connection_id"),
 		},
 		Schema: map[string]*schema.Schema{
 			"organization_id": {
@@ -74,7 +74,7 @@ func createOrganizationConnection(ctx context.Context, data *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	data.SetId(organizationID + ":" + connectionID)
+	internalSchema.SetResourceGroupID(data, organizationID, connectionID)
 
 	return readOrganizationConnection(ctx, data, meta)
 }

--- a/internal/auth0/organization/resource_connection_test.go
+++ b/internal/auth0/organization/resource_connection_test.go
@@ -166,7 +166,7 @@ func TestAccOrganizationConnection(t *testing.T) {
 					connID, err := acctest.ExtractResourceAttributeFromState(state, "auth0_connection.my_connection_1", "id")
 					assert.NoError(t, err)
 
-					return orgID + ":" + connID, nil
+					return orgID + "::" + connID, nil
 				},
 				ImportStatePersist: true,
 			},
@@ -181,7 +181,7 @@ func TestAccOrganizationConnection(t *testing.T) {
 					connID, err := acctest.ExtractResourceAttributeFromState(state, "auth0_connection.my_connection_2", "id")
 					assert.NoError(t, err)
 
-					return orgID + ":" + connID, nil
+					return orgID + "::" + connID, nil
 				},
 				ImportStatePersist: true,
 			},

--- a/internal/auth0/organization/resource_member.go
+++ b/internal/auth0/organization/resource_member.go
@@ -20,7 +20,7 @@ func NewMemberResource() *schema.Resource {
 		ReadContext:   readOrganizationMember,
 		DeleteContext: deleteOrganizationMember,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorColon, "organization_id", "user_id"),
+			StateContext: internalSchema.ImportResourceGroupID("organization_id", "user_id"),
 		},
 		Schema: map[string]*schema.Schema{
 			"organization_id": {
@@ -49,7 +49,7 @@ func createOrganizationMember(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	d.SetId(organizationID + ":" + userID)
+	internalSchema.SetResourceGroupID(d, organizationID, userID)
 
 	return readOrganizationMember(ctx, d, m)
 }

--- a/internal/auth0/organization/resource_member_role.go
+++ b/internal/auth0/organization/resource_member_role.go
@@ -21,7 +21,7 @@ func NewMemberRoleResource() *schema.Resource {
 		ReadContext:   readOrganizationMemberRole,
 		DeleteContext: deleteOrganizationMemberRole,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorDoubleColon, "organization_id", "user_id", "role_id"),
+			StateContext: internalSchema.ImportResourceGroupID("organization_id", "user_id", "role_id"),
 		},
 		Schema: map[string]*schema.Schema{
 			"organization_id": {
@@ -71,7 +71,7 @@ func createOrganizationMemberRole(ctx context.Context, data *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	data.SetId(organizationID + internalSchema.SeparatorDoubleColon + userID + internalSchema.SeparatorDoubleColon + roleID)
+	internalSchema.SetResourceGroupID(data, organizationID, userID, roleID)
 
 	return readOrganizationMemberRole(ctx, data, meta)
 }

--- a/internal/auth0/organization/resource_member_role_test.go
+++ b/internal/auth0/organization/resource_member_role_test.go
@@ -125,7 +125,7 @@ func TestAccOrganizationMemberRole(t *testing.T) {
 						return "", err
 					}
 
-					return organizationID + ":" + userID, nil
+					return organizationID + "::" + userID, nil
 				},
 				ImportStatePersist: true,
 			},

--- a/internal/auth0/organization/resource_member_roles.go
+++ b/internal/auth0/organization/resource_member_roles.go
@@ -22,7 +22,7 @@ func NewMemberRolesResource() *schema.Resource {
 		UpdateContext: updateOrganizationMemberRoles,
 		DeleteContext: deleteOrganizationMemberRoles,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorColon, "organization_id", "user_id"),
+			StateContext: internalSchema.ImportResourceGroupID("organization_id", "user_id"),
 		},
 		Schema: map[string]*schema.Schema{
 			"organization_id": {
@@ -62,7 +62,7 @@ func createOrganizationMemberRoles(ctx context.Context, data *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	data.SetId(organizationID + ":" + userID)
+	internalSchema.SetResourceGroupID(data, organizationID, userID)
 
 	return readOrganizationMemberRoles(ctx, data, meta)
 }

--- a/internal/auth0/organization/resource_member_roles_test.go
+++ b/internal/auth0/organization/resource_member_roles_test.go
@@ -167,7 +167,7 @@ func TestAccOrganizationMemberRoles(t *testing.T) {
 						return "", err
 					}
 
-					return organizationID + ":" + userID, nil
+					return organizationID + "::" + userID, nil
 				},
 				ImportStatePersist: true,
 			},

--- a/internal/auth0/organization/resource_member_test.go
+++ b/internal/auth0/organization/resource_member_test.go
@@ -126,7 +126,7 @@ func TestAccOrganizationMember(t *testing.T) {
 					userID, err := acctest.ExtractResourceAttributeFromState(state, "auth0_user.user_1", "id")
 					assert.NoError(t, err)
 
-					return orgID + ":" + userID, nil
+					return orgID + "::" + userID, nil
 				},
 				ImportStatePersist: true,
 			},
@@ -141,7 +141,7 @@ func TestAccOrganizationMember(t *testing.T) {
 					userID, err := acctest.ExtractResourceAttributeFromState(state, "auth0_user.user_2", "id")
 					assert.NoError(t, err)
 
-					return orgID + ":" + userID, nil
+					return orgID + "::" + userID, nil
 				},
 				ImportStatePersist: true,
 			},

--- a/internal/auth0/prompt/resource_custom_text.go
+++ b/internal/auth0/prompt/resource_custom_text.go
@@ -40,7 +40,7 @@ func NewCustomTextResource() *schema.Resource {
 		UpdateContext: updatePromptCustomText,
 		DeleteContext: deletePromptCustomText,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorColon, "prompt", "language"),
+			StateContext: internalSchema.ImportResourceGroupID("prompt", "language"),
 		},
 		Description: "With this resource, you can manage custom text on your Auth0 prompts. You can read more about " +
 			"custom texts [here](https://auth0.com/docs/customize/universal-login-pages/customize-login-text-prompts).",
@@ -72,7 +72,11 @@ func NewCustomTextResource() *schema.Resource {
 }
 
 func createPromptCustomText(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	d.SetId(d.Get("prompt").(string) + ":" + d.Get("language").(string))
+	prompt := d.Get("prompt").(string)
+	language := d.Get("language").(string)
+
+	internalSchema.SetResourceGroupID(d, prompt, language)
+
 	return updatePromptCustomText(ctx, d, m)
 }
 

--- a/internal/auth0/resourceserver/resource_scope.go
+++ b/internal/auth0/resourceserver/resource_scope.go
@@ -40,7 +40,7 @@ func NewScopeResource() *schema.Resource {
 		ReadContext:   readResourceServerScope,
 		DeleteContext: deleteResourceServerScope,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorDoubleColon, "resource_server_identifier", "scope"),
+			StateContext: internalSchema.ImportResourceGroupID("resource_server_identifier", "scope"),
 		},
 		Description: "With this resource, you can manage scopes (permissions) associated with a resource server (API).",
 	}
@@ -67,7 +67,7 @@ func createResourceServerScope(ctx context.Context, data *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	data.SetId(fmt.Sprintf(`%s::%s`, resourceServerIdentifier, scope))
+	internalSchema.SetResourceGroupID(data, resourceServerIdentifier, scope)
 
 	for _, apiScope := range existingAPI.GetScopes() {
 		if apiScope.GetValue() == scope {

--- a/internal/auth0/role/resource_permission.go
+++ b/internal/auth0/role/resource_permission.go
@@ -50,7 +50,7 @@ func NewPermissionResource() *schema.Resource {
 		ReadContext:   readRolePermission,
 		DeleteContext: deleteRolePermission,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorDoubleColon, "role_id", "resource_server_identifier", "permission"),
+			StateContext: internalSchema.ImportResourceGroupID("role_id", "resource_server_identifier", "permission"),
 		},
 		Description: "With this resource, you can manage role permissions (1-1).",
 	}
@@ -76,7 +76,7 @@ func createRolePermission(ctx context.Context, data *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	data.SetId(roleID + internalSchema.SeparatorDoubleColon + resourceServerID + internalSchema.SeparatorDoubleColon + permissionName)
+	internalSchema.SetResourceGroupID(data, roleID, resourceServerID, permissionName)
 
 	return readRolePermission(ctx, data, meta)
 }

--- a/internal/auth0/user/resource_permission.go
+++ b/internal/auth0/user/resource_permission.go
@@ -50,7 +50,7 @@ func NewPermissionResource() *schema.Resource {
 		ReadContext:   readUserPermission,
 		DeleteContext: deleteUserPermission,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorDoubleColon, "user_id", "resource_server_identifier", "permission"),
+			StateContext: internalSchema.ImportResourceGroupID("user_id", "resource_server_identifier", "permission"),
 		},
 		Description: "With this resource, you can manage user permissions.",
 	}
@@ -76,7 +76,7 @@ func createUserPermission(ctx context.Context, data *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	data.SetId(userID + internalSchema.SeparatorDoubleColon + resourceServerID + internalSchema.SeparatorDoubleColon + permissionName)
+	internalSchema.SetResourceGroupID(data, userID, resourceServerID, permissionName)
 
 	return readUserPermission(ctx, data, meta)
 }

--- a/internal/auth0/user/resource_role.go
+++ b/internal/auth0/user/resource_role.go
@@ -47,7 +47,7 @@ func NewRoleResource() *schema.Resource {
 		ReadContext:   readUserRole,
 		DeleteContext: deleteUserRole,
 		Importer: &schema.ResourceImporter{
-			StateContext: internalSchema.ImportResourceGroupID(internalSchema.SeparatorDoubleColon, "user_id", "role_id"),
+			StateContext: internalSchema.ImportResourceGroupID("user_id", "role_id"),
 		},
 		Description: "With this resource, you can manage assigned roles for a user.",
 	}
@@ -67,7 +67,7 @@ func createUserRole(ctx context.Context, data *schema.ResourceData, meta interfa
 		return diag.FromErr(err)
 	}
 
-	data.SetId(userID + internalSchema.SeparatorDoubleColon + roleID)
+	internalSchema.SetResourceGroupID(data, userID, roleID)
 
 	return readUserRole(ctx, data, meta)
 }

--- a/internal/schema/importer_test.go
+++ b/internal/schema/importer_test.go
@@ -13,41 +13,36 @@ func TestImportResourceGroupID(t *testing.T) {
 	var testCases = []struct {
 		testName           string
 		givenID            string
-		givenSeparator     string
 		expectedAttributes map[int]map[string]string
 		expectedError      error
 	}{
 		{
-			testName:       "it correctly parses the resource ID (org:conn)",
-			givenID:        "org_1234:conn_5678",
-			givenSeparator: ":",
+			testName: "it correctly parses the resource ID (org::conn)",
+			givenID:  "org_1234::conn_5678",
 			expectedAttributes: map[int]map[string]string{
 				1: {"organization_id": "org_1234"},
 				2: {"connection_id": "conn_5678"},
 			},
 		},
 		{
-			testName:       "it correctly parses the resource ID (org:user)",
-			givenID:        "org_1234:auth0|62d82",
-			givenSeparator: ":",
+			testName: "it correctly parses the resource ID (org::user)",
+			givenID:  "org_1234::auth0|62d82",
 			expectedAttributes: map[int]map[string]string{
 				1: {"organization_id": "org_1234"},
 				2: {"user_id": "auth0|62d82"},
 			},
 		},
 		{
-			testName:       "it correctly parses the resource ID (conn:client)",
-			givenID:        "conn_5678::client_1234",
-			givenSeparator: "::",
+			testName: "it correctly parses the resource ID (conn::client)",
+			givenID:  "conn_5678::client_1234",
 			expectedAttributes: map[int]map[string]string{
 				1: {"connection_id": "conn_5678"},
 				2: {"client_id": "client_1234"},
 			},
 		},
 		{
-			testName:       "it correctly parses the resource ID (org:member:role)",
-			givenID:        "org_5678:user_1234:role_5341",
-			givenSeparator: ":",
+			testName: "it correctly parses the resource ID (org::member::role)",
+			givenID:  "org_5678::user_1234::role_5341",
 			expectedAttributes: map[int]map[string]string{
 				1: {"organization_id": "org_5678"},
 				2: {"user_id": "user_1234"},
@@ -55,9 +50,8 @@ func TestImportResourceGroupID(t *testing.T) {
 			},
 		},
 		{
-			testName:       "it correctly parses the resource ID (user:api:permission)",
-			givenID:        "user_5678::https://api::read:books",
-			givenSeparator: "::",
+			testName: "it correctly parses the resource ID (user::api::permission)",
+			givenID:  "user_5678::https://api::read:books",
 			expectedAttributes: map[int]map[string]string{
 				1: {"user_id": "user_5678"},
 				2: {"resource_server_identifier": "https://api"},
@@ -70,24 +64,22 @@ func TestImportResourceGroupID(t *testing.T) {
 			expectedError: fmt.Errorf("ID cannot be empty"),
 		},
 		{
-			testName:       "it fails when the given ID does not have \":\" as a separator",
-			givenID:        "org_1234conn_5678",
-			givenSeparator: ":",
+			testName: "it fails when the given ID does not have \"::\" as a separator",
+			givenID:  "org_1234conn_5678",
 			expectedAttributes: map[int]map[string]string{
 				1: {"organization_id": ""},
 				2: {"connection_id": ""},
 			},
-			expectedError: fmt.Errorf("ID must be formatted as <organization_id>:<connection_id>"),
+			expectedError: fmt.Errorf("ID must be formatted as <organization_id>::<connection_id>"),
 		},
 		{
-			testName:       "it fails when the given ID has too many separators",
-			givenID:        "org_1234:conn_5678:",
-			givenSeparator: ":",
+			testName: "it fails when the given ID has too many separators",
+			givenID:  "org_1234::conn_5678::",
 			expectedAttributes: map[int]map[string]string{
 				1: {"organization_id": ""},
 				2: {"connection_id": ""},
 			},
-			expectedError: fmt.Errorf("ID must be formatted as <organization_id>:<connection_id>"),
+			expectedError: fmt.Errorf("ID must be formatted as <organization_id>::<connection_id>"),
 		},
 	}
 
@@ -109,7 +101,7 @@ func TestImportResourceGroupID(t *testing.T) {
 			data := schema.TestResourceDataRaw(t, testSchema, nil)
 			data.SetId(testCase.givenID)
 
-			importFunc := ImportResourceGroupID(testCase.givenSeparator, resourceKeys...)
+			importFunc := ImportResourceGroupID(resourceKeys...)
 			actualData, err := importFunc(context.Background(), data, nil)
 
 			if testCase.expectedError != nil {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR aligns the resource import separator so everything uses "::" consistently, making it easier to remember which separator to use when importing resource groups.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
