### PR TITLE
ci: Add `.semgrepignore` exclusion manifest

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,4 +1,5 @@
 docs/
 examples/
 test/
-*.md
+\_.md
+internal/\*\_test.go

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,4 @@
+docs/
+examples/
+test/
+*.md


### PR DESCRIPTION
This PR adds a `.semgrepignore` manifest file to exclude certain directories and documentation files from being incorrectly flagged by Semgrep. This will help avoid false positive warnings being triggered.