### PR TITLE
Increase schema version for auth0 connection resource

### DIFF
--- a/internal/auth0/connection/resource.go
+++ b/internal/auth0/connection/resource.go
@@ -24,7 +24,8 @@ func NewResource() *schema.Resource {
 			"which may include identity providers (such as Google or LinkedIn), databases, or " +
 			"passwordless authentication methods. This resource allows you to configure " +
 			"and manage connections to be used with your clients and users.",
-		Schema: resourceSchema,
+		Schema:        resourceSchema,
+		SchemaVersion: 3,
 	}
 }
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

The schema version for the connection resource on v0.50.0 is set to 2, if we go back and reset this to 0 we will get the following error for users that will try to upgrade:

```
╷
│ Error: Resource instance managed by newer provider version
│
│ The current state of auth0_connection.this was created by a newer provider version than is currently selected. Upgrade the auth0 provider to work with this state.
```

So we increment the version to 3 after removing the schema upgraders to be able to successfully apply the terraform command and refresh the state. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
