### PR TITLE
GH-273: Increasing number of retries

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -66,7 +66,7 @@ func configureTestProviderWithHTTPRecordings(httpRecorder *recorder.Recorder) sc
 			management.WithStaticToken("insecure"),
 			management.WithClient(httpRecorder.GetDefaultClient()),
 			management.WithDebug(debug),
-			management.WithRetries(3, []int{http.StatusTooManyRequests, http.StatusInternalServerError}),
+			management.WithRetries(12, []int{http.StatusTooManyRequests, http.StatusInternalServerError}),
 		}
 
 		if domain != RecordingsDomain {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,7 +60,7 @@ func ConfigureProvider(terraformVersion *string) schema.ConfigureContextFunc {
 			management.WithDebug(debug),
 			management.WithUserAgent(userAgent(terraformVersion)),
 			management.WithAuth0ClientEnvEntry(providerName, version),
-			management.WithRetries(3, []int{http.StatusTooManyRequests, http.StatusInternalServerError}),
+			management.WithRetries(12, []int{http.StatusTooManyRequests, http.StatusInternalServerError}),
 		)
 		if err != nil {
 			return nil, diag.FromErr(err)


### PR DESCRIPTION
### 🔧 Changes

Version 1 of the Go SDK introduced a new way of expressing retry logic when instantiating the management client. This change is a deviation from v0 which implemented unlimited retries by default. Even with three retries, users are [still experiencing 429 errors in their workflows](https://github.com/auth0/terraform-provider-auth0/issues/273#issuecomment-1668423627) so this PR increases the number of retries to 12. This number was selected arbitrarily but high enough to smooth over most instances without overwhelming our servers in the case of 500s.

### 📚 References

- [Related Github Issue](https://github.com/auth0/terraform-provider-auth0/issues/273)


### 🔬 Testing

Tested on the Go SDK-side. _Should_ make our acceptance tests more reliable too.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
