### PR TITLE
Mark error_page elements as optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ override.tf.json
 .vscode/*
 !.vscode/tasks.json
 *.code-workspace
+.history

--- a/internal/auth0/tenant/resource.go
+++ b/internal/auth0/tenant/resource.go
@@ -111,19 +111,16 @@ func NewResource() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"html": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type: schema.TypeString,
 							Description: "HTML format with supported Liquid syntax. " +
 								"Customized content of the error page.",
 						},
 						"show_log_link": {
 							Type:        schema.TypeBool,
-							Required:    true,
 							Description: "Indicates whether to show the link to logs as part of the default error page.",
 						},
 						"url": {
 							Type:        schema.TypeString,
-							Required:    true,
 							Description: "URL to redirect to when an error occurs rather than showing the default error page.",
 						},
 					},

--- a/internal/auth0/tenant/resource.go
+++ b/internal/auth0/tenant/resource.go
@@ -111,16 +111,19 @@ func NewResource() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"html": {
-							Type: schema.TypeString,
+							Type:     schema.TypeString,
+							Optional: true,
 							Description: "HTML format with supported Liquid syntax. " +
 								"Customized content of the error page.",
 						},
 						"show_log_link": {
 							Type:        schema.TypeBool,
+							Optional:    true,
 							Description: "Indicates whether to show the link to logs as part of the default error page.",
 						},
 						"url": {
 							Type:        schema.TypeString,
+							Optional:    true,
 							Description: "URL to redirect to when an error occurs rather than showing the default error page.",
 						},
 					},


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

As Per discussion on slack [here](https://okta.slack.com/archives/C02SE6ZBGVC/p1691990805452079), currently all `error_page` elements are marked as `required=true` whereas in Management API [ref](https://auth0.com/docs/api/management/v2/tenants/patch-settings) these elements are `optional`. 

In this pull request, `error_page` elements are marked as `false` and it is aligned with Management [API](https://auth0.com/docs/api/management/v2/tenants/patch-settings).

### 🔬 Testing



### 📝 Checklist

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
