### PR TITLE
DXCDT-540: Prevent null string literal when importing custom text prompts

### DIFF
--- a/internal/auth0/prompt/flatten.go
+++ b/internal/auth0/prompt/flatten.go
@@ -26,14 +26,14 @@ func flattenPromptCustomText(data *schema.ResourceData, customText map[string]in
 		return err
 	}
 
-	if body == "null" {
-		return data.Set("body", nil)
-	}
-
 	return data.Set("body", body)
 }
 
 func marshalCustomTextBody(b map[string]interface{}) (string, error) {
+	if b == nil {
+		return "{}", nil
+	}
+
 	bodyBytes, err := json.Marshal(b)
 	if err != nil {
 		return "", fmt.Errorf("failed to serialize the custom texts to JSON: %w", err)

--- a/internal/auth0/prompt/flatten.go
+++ b/internal/auth0/prompt/flatten.go
@@ -26,6 +26,10 @@ func flattenPromptCustomText(data *schema.ResourceData, customText map[string]in
 		return err
 	}
 
+	if body == "null" {
+		return data.Set("body", nil)
+	}
+
 	return data.Set("body", body)
 }
 

--- a/internal/auth0/prompt/resource_custom_text_test.go
+++ b/internal/auth0/prompt/resource_custom_text_test.go
@@ -12,6 +12,14 @@ func TestAccPromptCustomText(t *testing.T) {
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
+				Config: testAccPromptCustomTextEmptyBody,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "prompt", "login"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "language", "en"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "body", "{}"),
+				),
+			},
+			{
 				Config: testAccPromptCustomTextCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "prompt", "login"),
@@ -35,9 +43,25 @@ func TestAccPromptCustomText(t *testing.T) {
 					),
 				),
 			},
+			{
+				Config: testAccPromptCustomTextEmptyBody,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "prompt", "login"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "language", "en"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "body", "{}"),
+				),
+			},
 		},
 	})
 }
+
+const testAccPromptCustomTextEmptyBody = `
+resource "auth0_prompt_custom_text" "prompt_custom_text" {
+  prompt = "login"
+  language = "en"
+  body = "{}"
+}
+`
 
 const testAccPromptCustomTextCreate = `
 resource "auth0_prompt_custom_text" "prompt_custom_text" {

--- a/test/data/recordings/TestAccPromptCustomText.yaml
+++ b/test/data/recordings/TestAccPromptCustomText.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 133
+        content_length: 3
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"login":{"alertListTitle":"Alerts","buttonText":"Continue","emailPlaceholder":"Email address","title":"Welcome to ${companyName}"}}
+            {}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.11.0
+                - Go-Auth0/1.0.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
         method: PUT
       response:
@@ -28,15 +28,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Continue","emailPlaceholder":"Email address","title":"Welcome to ${companyName}"}}'
+        content_length: 2
+        uncompressed: false
+        body: '{}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1ms
+        duration: 154.318375ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,7 +55,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.11.0
+                - Go-Auth0/1.0.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
         method: GET
       response:
@@ -64,15 +64,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Continue","emailPlaceholder":"Email address","title":"Welcome to ${companyName}"}}'
+        content_length: 2
+        uncompressed: false
+        body: '{}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1ms
+        duration: 68.087542ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -91,7 +91,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.11.0
+                - Go-Auth0/1.0.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
         method: GET
       response:
@@ -100,15 +100,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Continue","emailPlaceholder":"Email address","title":"Welcome to ${companyName}"}}'
+        content_length: 2
+        uncompressed: false
+        body: '{}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1ms
+        duration: 178.246334ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -127,9 +127,45 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.11.0
+                - Go-Auth0/1.0.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
         method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '{}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 157.751125ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 133
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"login":{"alertListTitle":"Alerts","buttonText":"Continue","emailPlaceholder":"Email address","title":"Welcome to ${companyName}"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.0.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
+        method: PUT
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -144,43 +180,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 132
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"login":{"alertListTitle":"Alerts","buttonText":"Proceed","emailPlaceholder":"Email Address","title":"Welcome to ${companyName}"}}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0-SDK/0.11.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Proceed","emailPlaceholder":"Email Address","title":"Welcome to ${companyName}"}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 1ms
+        duration: 170.454667ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -199,7 +199,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.11.0
+                - Go-Auth0/1.0.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
         method: GET
       response:
@@ -210,13 +210,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Proceed","emailPlaceholder":"Email Address","title":"Welcome to ${companyName}"}}'
+        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Continue","emailPlaceholder":"Email address","title":"Welcome to ${companyName}"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1ms
+        duration: 151.822042ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -235,7 +235,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.11.0
+                - Go-Auth0/1.0.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
         method: GET
       response:
@@ -246,50 +246,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Proceed","emailPlaceholder":"Email Address","title":"Welcome to ${companyName}"}}'
+        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Continue","emailPlaceholder":"Email address","title":"Welcome to ${companyName}"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1ms
+        duration: 152.117917ms
     - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 3
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0-SDK/0.11.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
-        method: PUT
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2
-        uncompressed: false
-        body: '{}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 1ms
-    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -307,7 +271,223 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0-SDK/0.11.0
+                - Go-Auth0/1.0.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Continue","emailPlaceholder":"Email address","title":"Welcome to ${companyName}"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 63.871834ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 132
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"login":{"alertListTitle":"Alerts","buttonText":"Proceed","emailPlaceholder":"Email Address","title":"Welcome to ${companyName}"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.0.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Proceed","emailPlaceholder":"Email Address","title":"Welcome to ${companyName}"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 74.097333ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.0.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Proceed","emailPlaceholder":"Email Address","title":"Welcome to ${companyName}"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 89.6465ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.0.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Proceed","emailPlaceholder":"Email Address","title":"Welcome to ${companyName}"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 151.20125ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.0.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"login":{"alertListTitle":"Alerts","buttonText":"Proceed","emailPlaceholder":"Email Address","title":"Welcome to ${companyName}"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 144.794875ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 3
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.0.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '{}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 83.862042ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.0.2
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
         method: GET
       response:
@@ -324,4 +504,112 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1ms
+        duration: 174.305792ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.0.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '{}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 144.166875ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 3
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.0.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
+        method: PUT
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '{}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 163.848917ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 5
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            null
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.0.2
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/prompts/login/custom-text/en
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '{}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 68.379458ms


### PR DESCRIPTION
### 🔧 Changes

When using Terraform config-driven imports with the `auth0_prompt_custom_text` resource, there can be cases where the `body` property gets generated literally as `"null"`. This occurred because the Management API returns an empty object string literal `"{}"` for unconfigured custom text prompts and would get interpreted somewhere in the Terraform SDK as `nil` which would cause a bit of havoc when marshalling back to a string.

With this PR, the generated custom text prompt looks like this:
```
resource "auth0_prompt_custom_text" "fr_signup" {
  body     = "{}"
  language = "fr"
  prompt   = "signup"
}
```

This is preferred because it matches the output of the Management API.

### 🔬 Testing

Added unit tests to enable empty object as body property. Manually verified that config-driven import works as expected.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
