### PR TITLE
Removing `token_endpoint_auth_method` from `auth0_client` example

### DIFF
--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -18,7 +18,6 @@ resource "auth0_client" "my_client" {
   custom_login_page_on                = true
   is_first_party                      = true
   is_token_endpoint_ip_header_trusted = true
-  token_endpoint_auth_method          = "client_secret_post"
   oidc_conformant                     = false
   callbacks                           = ["https://example.com/callback"]
   allowed_origins                     = ["https://example.com"]

--- a/examples/resources/auth0_client/resource.tf
+++ b/examples/resources/auth0_client/resource.tf
@@ -5,7 +5,6 @@ resource "auth0_client" "my_client" {
   custom_login_page_on                = true
   is_first_party                      = true
   is_token_endpoint_ip_header_trusted = true
-  token_endpoint_auth_method          = "client_secret_post"
   oidc_conformant                     = false
   callbacks                           = ["https://example.com/callback"]
   allowed_origins                     = ["https://example.com"]


### PR DESCRIPTION
### 🔧 Changes

As noted in #813, the `token_endpoint_auth_method` was incorrectly left in an `auth0_client` example when it had been removed from the resource in v1.0.0-beta.1. This removal is also mentioned in the [migration guide](https://github.com/auth0/terraform-provider-auth0/blob/v1/MIGRATION_GUIDE.md#client-authentication-method).

This PR simply removes this property from the example and thus the docs.

### 📚 References

- [Related migration guide section](https://github.com/auth0/terraform-provider-auth0/blob/v1/MIGRATION_GUIDE.md#client-authentication-method)

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
