### PR TITLE
Skip passing through connection options if none in config

### DIFF
--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -91,7 +91,7 @@ func expandConnection(
 	if connectionIsEnterprise(strategy) {
 		connection.ShowAsButton = value.Bool(config.GetAttr("show_as_button"))
 
-		if !data.IsNewResource() {
+		if !data.IsNewResource() && connection.Options != nil {
 			err := passThroughUnconfigurableConnectionOptions(ctx, api, data.Id(), strategy, connection)
 			if err != nil {
 				return nil, diag.FromErr(err)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

If there are no connection options set within the config and thus the options block missing, there's no reason to try passing through unconfigurable connection options as the options field will get omitted in the PATCH. 

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
