### PR TITLE
Setting default `idle_session_lifetime` on tenant import

### DIFF
--- a/internal/auth0/tenant/flatten.go
+++ b/internal/auth0/tenant/flatten.go
@@ -17,7 +17,6 @@ func flattenTenant(data *schema.ResourceData, tenant *management.Tenant) error {
 		data.Set("support_url", tenant.GetSupportURL()),
 		data.Set("allowed_logout_urls", tenant.GetAllowedLogoutURLs()),
 		data.Set("session_lifetime", tenant.GetSessionLifetime()),
-		data.Set("idle_session_lifetime", tenant.GetIdleSessionLifetime()),
 		data.Set("sandbox_version", tenant.GetSandboxVersion()),
 		data.Set("enabled_locales", tenant.GetEnabledLocales()),
 		data.Set("flags", flattenTenantFlags(tenant.GetFlags())),
@@ -25,6 +24,13 @@ func flattenTenant(data *schema.ResourceData, tenant *management.Tenant) error {
 		data.Set("sessions", flattenTenantSessions(tenant.GetSessions())),
 		data.Set("allow_organization_name_in_authentication_api", tenant.GetAllowOrgNameInAuthAPI()),
 	)
+
+	if tenant.GetIdleSessionLifetime() == 0 {
+		idleSessionLifetimeDefault := NewResource().Schema["idle_session_lifetime"].Default
+		result = multierror.Append(result, data.Set("idle_session_lifetime", idleSessionLifetimeDefault))
+	} else {
+		result = multierror.Append(result, data.Set("idle_session_lifetime", tenant.GetIdleSessionLifetime()))
+	}
 
 	return result.ErrorOrNil()
 }

--- a/internal/auth0/tenant/flatten.go
+++ b/internal/auth0/tenant/flatten.go
@@ -16,6 +16,8 @@ func flattenTenant(data *schema.ResourceData, tenant *management.Tenant) error {
 		data.Set("support_email", tenant.GetSupportEmail()),
 		data.Set("support_url", tenant.GetSupportURL()),
 		data.Set("allowed_logout_urls", tenant.GetAllowedLogoutURLs()),
+		data.Set("session_lifetime", tenant.GetSessionLifetime()),
+		data.Set("idle_session_lifetime", tenant.GetIdleSessionLifetime()),
 		data.Set("sandbox_version", tenant.GetSandboxVersion()),
 		data.Set("enabled_locales", tenant.GetEnabledLocales()),
 		data.Set("flags", flattenTenantFlags(tenant.GetFlags())),
@@ -26,14 +28,10 @@ func flattenTenant(data *schema.ResourceData, tenant *management.Tenant) error {
 
 	if tenant.GetIdleSessionLifetime() == 0 {
 		result = multierror.Append(result, data.Set("idle_session_lifetime", idleSessionLifetimeDefault))
-	} else {
-		result = multierror.Append(result, data.Set("idle_session_lifetime", tenant.GetIdleSessionLifetime()))
 	}
 
 	if tenant.GetSessionLifetime() == 0 {
 		result = multierror.Append(result, data.Set("session_lifetime", sessionLifetimeDefault))
-	} else {
-		result = multierror.Append(result, data.Set("session_lifetime", tenant.GetSessionLifetime()))
 	}
 
 	return result.ErrorOrNil()

--- a/internal/auth0/tenant/flatten.go
+++ b/internal/auth0/tenant/flatten.go
@@ -16,7 +16,6 @@ func flattenTenant(data *schema.ResourceData, tenant *management.Tenant) error {
 		data.Set("support_email", tenant.GetSupportEmail()),
 		data.Set("support_url", tenant.GetSupportURL()),
 		data.Set("allowed_logout_urls", tenant.GetAllowedLogoutURLs()),
-		data.Set("session_lifetime", tenant.GetSessionLifetime()),
 		data.Set("sandbox_version", tenant.GetSandboxVersion()),
 		data.Set("enabled_locales", tenant.GetEnabledLocales()),
 		data.Set("flags", flattenTenantFlags(tenant.GetFlags())),
@@ -26,10 +25,15 @@ func flattenTenant(data *schema.ResourceData, tenant *management.Tenant) error {
 	)
 
 	if tenant.GetIdleSessionLifetime() == 0 {
-		idleSessionLifetimeDefault := NewResource().Schema["idle_session_lifetime"].Default
 		result = multierror.Append(result, data.Set("idle_session_lifetime", idleSessionLifetimeDefault))
 	} else {
 		result = multierror.Append(result, data.Set("idle_session_lifetime", tenant.GetIdleSessionLifetime()))
+	}
+
+	if tenant.GetSessionLifetime() == 0 {
+		result = multierror.Append(result, data.Set("session_lifetime", sessionLifetimeDefault))
+	} else {
+		result = multierror.Append(result, data.Set("session_lifetime", tenant.GetSessionLifetime()))
 	}
 
 	return result.ErrorOrNil()

--- a/internal/auth0/tenant/flatten_test.go
+++ b/internal/auth0/tenant/flatten_test.go
@@ -21,8 +21,8 @@ func TestFlattenTenant(t *testing.T) {
 		err := flattenTenant(mockResourceData, &tenant)
 
 		assert.NoError(t, err)
-		assert.Equal(t, mockResourceData.Get("idle_session_lifetime"), idleSessionLifetimeDefault)
-		assert.Equal(t, mockResourceData.Get("session_lifetime"), sessionLifetimeDefault)
+		assert.Equal(t, mockResourceData.Get("idle_session_lifetime"), 72.00)
+		assert.Equal(t, mockResourceData.Get("session_lifetime"), 168.00)
 	})
 
 	t.Run("it does not set default values if remote tenant has values set", func(t *testing.T) {

--- a/internal/auth0/tenant/flatten_test.go
+++ b/internal/auth0/tenant/flatten_test.go
@@ -1,0 +1,40 @@
+package tenant
+
+import (
+	"testing"
+
+	"github.com/auth0/go-auth0"
+	"github.com/auth0/go-auth0/management"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenTenant(t *testing.T) {
+	mockResourceData := schema.TestResourceDataRaw(t, NewResource().Schema, map[string]interface{}{})
+
+	t.Run("it sets default values if remote tenant does not have them set", func(t *testing.T) {
+		tenant := management.Tenant{
+			IdleSessionLifetime: nil,
+			SessionLifetime:     nil,
+		}
+
+		err := flattenTenant(mockResourceData, &tenant)
+
+		assert.NoError(t, err)
+		assert.Equal(t, mockResourceData.Get("idle_session_lifetime"), idleSessionLifetimeDefault)
+		assert.Equal(t, mockResourceData.Get("session_lifetime"), sessionLifetimeDefault)
+	})
+
+	t.Run("it does not set default values if remote tenant has values set", func(t *testing.T) {
+		tenant := management.Tenant{
+			IdleSessionLifetime: auth0.Float64(73.5),
+			SessionLifetime:     auth0.Float64(169.5),
+		}
+
+		err := flattenTenant(mockResourceData, &tenant)
+
+		assert.NoError(t, err)
+		assert.Equal(t, mockResourceData.Get("idle_session_lifetime"), 73.5)
+		assert.Equal(t, mockResourceData.Get("session_lifetime"), 169.5)
+	})
+}

--- a/internal/auth0/tenant/resource.go
+++ b/internal/auth0/tenant/resource.go
@@ -12,6 +12,11 @@ import (
 	internalValidation "github.com/auth0/terraform-provider-auth0/internal/validation"
 )
 
+const (
+	idleSessionLifetimeDefault = 72.00
+	sessionLifetimeDefault     = 168.00
+)
+
 // NewResource will return a new auth0_tenant resource.
 func NewResource() *schema.Resource {
 	return &schema.Resource{
@@ -82,14 +87,14 @@ func NewResource() *schema.Resource {
 			"session_lifetime": {
 				Type:         schema.TypeFloat,
 				Optional:     true,
-				Default:      168,
+				Default:      sessionLifetimeDefault,
 				ValidateFunc: validation.FloatAtLeast(0.01),
 				Description:  "Number of hours during which a session will stay valid.",
 			},
 			"idle_session_lifetime": {
 				Type:         schema.TypeFloat,
 				Optional:     true,
-				Default:      72,
+				Default:      idleSessionLifetimeDefault,
 				ValidateFunc: validation.FloatAtLeast(0.01),
 				Description:  "Number of hours during which a session can be inactive before the user must log in again.",
 			},


### PR DESCRIPTION
### 🔧 Changes

Sometimes when importing a `auth0_tenant` resource, the `idle_session_lifetime` field gets set to zero. Normally this isn't such a problem because subsequent plans or applies will have this value set to the default value of 72. However, the Auth0 CLI's `auth0 tf generate` command will get hung up on the zero value because it violates the schema's validation. This default is necessary because not all tenants will have the `idle_session_lifetime` value set, particularly if it is a new tenant.

### 📚 References

- [TF Generate Command - Auth0 CLI](https://auth0.github.io/auth0-cli/auth0_terraform_generate.html)

### 🔬 Testing

Manual verification on a new tenant. Difficult to add to acceptance tests because our testing tenants will always have this value set; it is important to have it _not_ set for testing.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
