### PR TITLE
Fix copy-paste error in `connection_clients` docs

### DIFF
--- a/docs/resources/connection_clients.md
+++ b/docs/resources/connection_clients.md
@@ -8,8 +8,8 @@ description: |-
 
 With this resource, you can manage all of the enabled clients on a connection.
 
-!> This resource appends an enabled client to a connection. In contrast, the `auth0_connection_client` resource
-manages all the enabled clients for a connection. To avoid potential issues, it is recommended not to use this
+!> This resource manages all the enabled clients for a connection. In contrast, the `auth0_connection_client` resource
+appends an enabled client to a connection. To avoid potential issues, it is recommended not to use this
 resource in conjunction with the `auth0_connection_client` resource when managing enabled clients for the same
 connection id.
 

--- a/templates/resources/connection_clients.md.tmpl
+++ b/templates/resources/connection_clients.md.tmpl
@@ -8,8 +8,8 @@ description: |-
 
 {{ .Description | trimspace }}
 
-!> This resource appends an enabled client to a connection. In contrast, the `auth0_connection_client` resource
-manages all the enabled clients for a connection. To avoid potential issues, it is recommended not to use this
+!> This resource manages all the enabled clients for a connection. In contrast, the `auth0_connection_client` resource
+appends an enabled client to a connection. To avoid potential issues, it is recommended not to use this
 resource in conjunction with the `auth0_connection_client` resource when managing enabled clients for the same
 connection id.
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

The documentation for `auth0_connection_clients` was slightly incorrect — seems like the notice at the top was copied from `auth0_connection_client`. This fixes that notice to be accurate.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
