### PR TITLE
GH-853: Allow deleting branding resource even on free tenants

### DIFF
--- a/internal/auth0/branding/resource.go
+++ b/internal/auth0/branding/resource.go
@@ -166,16 +166,10 @@ func updateBranding(ctx context.Context, data *schema.ResourceData, meta interfa
 func deleteBranding(ctx context.Context, _ *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*config.Config).GetAPI()
 
-	if err := checkForCustomDomains(ctx, api); err != nil {
-		if err == errNoCustomDomain {
-			return nil
+	if err := checkForCustomDomains(ctx, api); err == nil {
+		if err := api.Branding.DeleteUniversalLogin(ctx); err != nil {
+			return diag.FromErr(err)
 		}
-
-		return diag.FromErr(err)
-	}
-
-	if err := api.Branding.DeleteUniversalLogin(ctx); err != nil {
-		return diag.FromErr(err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This PR changes the logic within the delete func of the branding resource to allow free tier tenants to delete the resource as well. Free tier tenants won't have custom domains functionality enabled and at the moment we check if any are set on the tenant to be able to remove the universal login page template.

### 📚 References

- #853 

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
