### PR TITLE
Documenting limitation of managing action secrets out-of-bound

### DIFF
--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -8,6 +8,8 @@ description: |-
 
 Actions are secure, tenant-specific, versioned functions written in Node.js that execute at certain points during the Auth0 runtime. Actions are used to customize and extend Auth0's capabilities with custom logic.
 
+~> Secrets and dependencies must be managed with Terraform, they cannot be managed out-of-band.
+
 ## Example Usage
 
 ```terraform
@@ -65,10 +67,10 @@ resource "auth0_action" "my_action" {
 
 ### Optional
 
-- `dependencies` (Block Set) List of third party npm modules, and their versions, that this action depends on. (see [below for nested schema](#nestedblock--dependencies))
+- `dependencies` (Block Set) List of third party npm modules, and their versions, that this action depends on. If your action contains dependencies, they must be managed through Terraform; dependencies cannot be managed out-of-band. (see [below for nested schema](#nestedblock--dependencies))
 - `deploy` (Boolean) Deploying an action will create a new immutable version of the action. If the action is currently bound to a trigger, then the system will begin executing the newly deployed version of the action immediately.
 - `runtime` (String) The Node runtime. Defaults to `node18`. Possible values are: `node16` (not recommended), or `node18` (recommended).
-- `secrets` (Block List) List of secrets that are included in an action or a version of an action. Partial management of secrets is not supported. (see [below for nested schema](#nestedblock--secrets))
+- `secrets` (Block List) List of secrets that are included in an action or a version of an action. If your action contains secrets, they **must** be managed through Terraform; Secrets cannot be managed out-of-band. (see [below for nested schema](#nestedblock--secrets))
 
 ### Read-Only
 

--- a/internal/auth0/action/resource.go
+++ b/internal/auth0/action/resource.go
@@ -65,7 +65,7 @@ func NewResource() *schema.Resource {
 			"dependencies": {
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "List of third party npm modules, and their versions, that this action depends on.",
+				Description: "List of third party npm modules, and their versions, that this action depends on. If your action contains dependencies, they must be managed through Terraform; dependencies cannot be managed out-of-band.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -95,7 +95,7 @@ func NewResource() *schema.Resource {
 			"secrets": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "List of secrets that are included in an action or a version of an action. Partial management of secrets is not supported.",
+				Description: "List of secrets that are included in an action or a version of an action. If your action contains secrets, they **must** be managed through Terraform; Secrets cannot be managed out-of-band.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {

--- a/templates/resources/action.md.tmpl
+++ b/templates/resources/action.md.tmpl
@@ -8,6 +8,8 @@ description: |-
 
 {{ .Description | trimspace }}
 
+~> Secrets and dependencies must be managed with Terraform, they cannot be managed out-of-band.
+
 {{ if .HasExample -}}
 
 ## Example Usage


### PR DESCRIPTION
### 🔧 Changes

As noted in #860, users are having issues managing their action secrets out-of-band through the `ignore_changes` block. However, this doesn't result in the expected behavior and secrets can still be deleted in the process. This PR updates the documentation very clear that secrets and dependencies cannot be managed out-of-band. In short, this is because the provider cannot discern between intentionally empty set of secrets and ignoring secrets by omission.

### 📚 References

Related Github Issue: https://github.com/auth0/terraform-provider-auth0/issues/860#issuecomment-1768203036

### 🔬 Testing

N/A.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
