### PR TITLE
fix: updated expected type of logstream.splunk_port

### DIFF
--- a/docs/resources/log_stream.md
+++ b/docs/resources/log_stream.md
@@ -96,7 +96,7 @@ Optional:
 - `mixpanel_service_account_username` (String) The Mixpanel Service Account username. Services Accounts can be created in the Project Settings page.
 - `segment_write_key` (String, Sensitive) The [Segment Write Key](https://segment.com/docs/connections/find-writekey/).
 - `splunk_domain` (String) The Splunk domain name.
-- `splunk_port` (String) The Splunk port.
+- `splunk_port` (Number) The Splunk port.
 - `splunk_secure` (Boolean) This toggle should be turned off when using self-signed certificates.
 - `splunk_token` (String, Sensitive) The Splunk access token.
 - `sumo_source_address` (String) Generated URL for your defined HTTP source in Sumo Logic for collecting streaming data from Auth0.

--- a/internal/auth0/logstream/expand.go
+++ b/internal/auth0/logstream/expand.go
@@ -127,7 +127,7 @@ func expandLogStreamSinkSplunk(config cty.Value) *management.LogStreamSinkSplunk
 	return &management.LogStreamSinkSplunk{
 		Domain: value.String(config.GetAttr("splunk_domain")),
 		Token:  value.String(config.GetAttr("splunk_token")),
-		Port:   value.String(config.GetAttr("splunk_port")),
+		Port:   value.Int(config.GetAttr("splunk_port")),
 		Secure: value.Bool(config.GetAttr("splunk_secure")),
 	}
 }

--- a/internal/auth0/logstream/resource.go
+++ b/internal/auth0/logstream/resource.go
@@ -279,7 +279,7 @@ func NewResource() *schema.Resource {
 							Description:  "The Splunk access token.",
 						},
 						"splunk_port": {
-							Type:         schema.TypeString,
+							Type:         schema.TypeInt,
 							Optional:     true,
 							RequiredWith: []string{"sink.0.splunk_domain", "sink.0.splunk_token", "sink.0.splunk_secure"},
 							Description:  "The Splunk port.",

--- a/internal/auth0/logstream/resource_test.go
+++ b/internal/auth0/logstream/resource_test.go
@@ -405,7 +405,7 @@ func TestAccLogStreamSplunk(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "splunk"),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_domain", "demo.splunk.com"),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_token", "12a34ab5-c6d7-8901-23ef-456b7c89d0c1"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_port", "8088"),
+					// Resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_port", 8088),.
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_secure", "true"),
 				),
 			},
@@ -416,7 +416,7 @@ func TestAccLogStreamSplunk(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "splunk"),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_domain", "prod.splunk.com"),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_token", "12a34ab5-c6d7-8901-23ef-456b7c89d0d1"),
-					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_port", "8088"),
+					// Resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_port", "8088"),.
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_secure", "true"),
 				),
 			},
@@ -431,7 +431,7 @@ resource "auth0_log_stream" "my_log_stream" {
 	sink {
 	  splunk_domain = "demo.splunk.com"
 	  splunk_token = "12a34ab5-c6d7-8901-23ef-456b7c89d0c1"
-	  splunk_port = "8088"
+	  splunk_port = 8088
 	  splunk_secure = "true"
 	}
 }
@@ -443,7 +443,7 @@ resource "auth0_log_stream" "my_log_stream" {
 	sink {
 	  splunk_domain = "prod.splunk.com"
 	  splunk_token = "12a34ab5-c6d7-8901-23ef-456b7c89d0d1"
-	  splunk_port = "8088"
+	  splunk_port = 8088
 	  splunk_secure = "true"
 	}
 }

--- a/internal/auth0/logstream/resource_test.go
+++ b/internal/auth0/logstream/resource_test.go
@@ -405,7 +405,7 @@ func TestAccLogStreamSplunk(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "splunk"),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_domain", "demo.splunk.com"),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_token", "12a34ab5-c6d7-8901-23ef-456b7c89d0c1"),
-					// Resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_port", 8088),.
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_port", "8088"),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_secure", "true"),
 				),
 			},
@@ -416,7 +416,7 @@ func TestAccLogStreamSplunk(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "splunk"),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_domain", "prod.splunk.com"),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_token", "12a34ab5-c6d7-8901-23ef-456b7c89d0d1"),
-					// Resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_port", "8088"),.
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_port", "8088"),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.splunk_secure", "true"),
 				),
 			},


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->
Auth0 changed the returned fields of the json splunk_port from a string `"8088"` to a number `8088`. This caused unmarshalling errors when we were trying to handle it during resource creation or state updates. This completely blocks a few of our deployments that have to interact with splunk log_streams. Please see https://github.com/auth0/terraform-provider-auth0/issues/940 for some more discussion

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

I went ahead and compiled the provider with the branch and ran it through our test suites. No issues reported thus far.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
