### PR TITLE
Make "scopes" required for Okta Workforce Connections

### DIFF
--- a/internal/auth0/connection/data_source_scim_test.go
+++ b/internal/auth0/connection/data_source_scim_test.go
@@ -24,6 +24,7 @@ resource "auth0_connection" "my_connection" {
 		client_id                = "1234567"
 		client_secret            = "1234567"
 		issuer                   = "https://example.okta.com"
+		scopes 					 = ["openid", "profile", "email"]
 		jwks_uri                 = "https://example.okta.com/oauth2/v1/keys"
 		token_endpoint           = "https://example.okta.com/oauth2/v1/token"
 		authorization_endpoint   = "https://example.okta.com/oauth2/v1/authorize"

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -910,6 +910,10 @@ func expandConnectionOptionsOkta(data *schema.ResourceData, config cty.Value) (i
 		return nil, diag.FromErr(err)
 	}
 
+	if len(data.Get("options.0.scopes").(*schema.Set).List()) < 1 {
+		return nil, diag.FromErr(fmt.Errorf("the scopes option is required for connection strategy %s", management.ConnectionStrategyOkta))
+	}
+
 	expandConnectionOptionsScopes(data, options)
 
 	options.UpstreamParams, err = value.MapFromJSON(config.GetAttr("upstream_params"))

--- a/internal/auth0/connection/resource_scim_test.go
+++ b/internal/auth0/connection/resource_scim_test.go
@@ -35,6 +35,7 @@ resource "auth0_connection" "my_connection" {
 	options {
 		client_id                = "1234567"
 		client_secret            = "1234567"
+		scopes 					 = ["openid", "profile", "email"]
 		issuer                   = "https://example.okta.com"
 		jwks_uri                 = "https://example.okta.com/oauth2/v1/keys"
 		token_endpoint           = "https://example.okta.com/oauth2/v1/token"
@@ -124,7 +125,7 @@ func TestAccSCIMConfiguration(t *testing.T) {
 			},
 			{
 				Config:      acctest.ParseTestName(testAccSCIMConfigurationGivenAnUnsupportedConnection, t.Name()),
-				ExpectError: regexp.MustCompile("404 Not Found: scim strategy not enabled"),
+				ExpectError: regexp.MustCompile("404 Not Found: This connection type does not support SCIM."),
 			},
 			{
 				Config: acctest.ParseTestName(testAccSCIMConfigurationWithDefaults, t.Name()),

--- a/internal/auth0/organization/resource_connections_test.go
+++ b/internal/auth0/organization/resource_connections_test.go
@@ -27,6 +27,7 @@ resource "auth0_connection" "my_enterprise_connection" {
 	options {
 		client_id                = "1234567"
 		client_secret            = "1234567"
+		scopes  				 = ["openid", "profile", "email"]
 		issuer                   = "https://example.okta.com"
 		jwks_uri                 = "https://example.okta.com/oauth2/v1/keys"
 		token_endpoint           = "https://example.okta.com/oauth2/v1/token"

--- a/test/data/recordings/TestAccDataSCIMConfiguration.yaml
+++ b/test/data/recordings/TestAccDataSCIMConfiguration.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
+                - Go-Auth0/1.20.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_xxxxxxxxxxxxxxxx/scim-configuration
         method: GET
       response:
@@ -35,26 +35,26 @@ interactions:
                 - application/json; charset=utf-8
         status: 404 Not Found
         code: 404
-        duration: 236.873625ms
+        duration: 327.525792ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 463
+        content_length: 494
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","strategy":"okta","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token"}}
+            {"name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","strategy":"okta","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","scope":"email openid profile"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
+                - Go-Auth0/1.20.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -63,15 +63,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 773
+        content_length: 804
         uncompressed: false
-        body: '{"id":"con_3tTzkzidQ1kgu9ov","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
+        body: '{"id":"con_Ha5VHHBFF9Wi1Dqz","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","scope":"email openid profile","schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 289.071125ms
+        duration: 384.479959ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -89,8 +89,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz
         method: GET
       response:
         proto: HTTP/2.0
@@ -100,13 +100,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_3tTzkzidQ1kgu9ov","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
+        body: '{"id":"con_Ha5VHHBFF9Wi1Dqz","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 222.525959ms
+        duration: 340.288375ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -124,8 +124,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -141,7 +141,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 404 Not Found
         code: 404
-        duration: 232.655417ms
+        duration: 405.746708ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -159,8 +159,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz
         method: GET
       response:
         proto: HTTP/2.0
@@ -170,13 +170,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_3tTzkzidQ1kgu9ov","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
+        body: '{"id":"con_Ha5VHHBFF9Wi1Dqz","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 217.06775ms
+        duration: 345.43075ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -194,8 +194,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration
         method: POST
       response:
         proto: HTTP/2.0
@@ -205,13 +205,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_3tTzkzidQ1kgu9ov","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:21.789Z","created_at":"2024-07-17T18:27:21.789Z","user_id_attribute":"externalId"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_Ha5VHHBFF9Wi1Dqz","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:05:37.380Z","created_at":"2025-05-06T04:05:37.380Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 264.317667ms
+        duration: 358.424125ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -229,8 +229,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -240,13 +240,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_3tTzkzidQ1kgu9ov","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:21.789Z","created_at":"2024-07-17T18:27:21.789Z","user_id_attribute":"externalId"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_Ha5VHHBFF9Wi1Dqz","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:05:37.380Z","created_at":"2025-05-06T04:05:37.380Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 254.797625ms
+        duration: 357.925416ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -264,8 +264,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -275,13 +275,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_3tTzkzidQ1kgu9ov","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:21.789Z","created_at":"2024-07-17T18:27:21.789Z","user_id_attribute":"externalId"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_Ha5VHHBFF9Wi1Dqz","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:05:37.380Z","created_at":"2025-05-06T04:05:37.380Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 253.444292ms
+        duration: 344.199917ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -299,8 +299,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration/default-mapping
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration/default-mapping
         method: GET
       response:
         proto: HTTP/2.0
@@ -316,7 +316,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 212.562167ms
+        duration: 345.89875ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -334,8 +334,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -345,13 +345,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_3tTzkzidQ1kgu9ov","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:21.789Z","created_at":"2024-07-17T18:27:21.789Z","user_id_attribute":"externalId"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_Ha5VHHBFF9Wi1Dqz","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:05:37.380Z","created_at":"2025-05-06T04:05:37.380Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 223.851375ms
+        duration: 359.93925ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -369,8 +369,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration/default-mapping
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration/default-mapping
         method: GET
       response:
         proto: HTTP/2.0
@@ -386,7 +386,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 208.848041ms
+        duration: 375.412083ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -404,8 +404,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz
         method: GET
       response:
         proto: HTTP/2.0
@@ -415,13 +415,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_3tTzkzidQ1kgu9ov","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
+        body: '{"id":"con_Ha5VHHBFF9Wi1Dqz","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 230.018042ms
+        duration: 336.002ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -439,8 +439,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -450,13 +450,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_3tTzkzidQ1kgu9ov","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:21.789Z","created_at":"2024-07-17T18:27:21.789Z","user_id_attribute":"externalId"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_Ha5VHHBFF9Wi1Dqz","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:05:37.380Z","created_at":"2025-05-06T04:05:37.380Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 221.938042ms
+        duration: 349.275125ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -474,8 +474,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -485,13 +485,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_3tTzkzidQ1kgu9ov","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:21.789Z","created_at":"2024-07-17T18:27:21.789Z","user_id_attribute":"externalId"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_Ha5VHHBFF9Wi1Dqz","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:05:37.380Z","created_at":"2025-05-06T04:05:37.380Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 233.737792ms
+        duration: 350.595375ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -509,8 +509,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration/default-mapping
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration/default-mapping
         method: GET
       response:
         proto: HTTP/2.0
@@ -526,7 +526,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 235.760291ms
+        duration: 351.049459ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -544,8 +544,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz
         method: GET
       response:
         proto: HTTP/2.0
@@ -555,13 +555,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_3tTzkzidQ1kgu9ov","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
+        body: '{"id":"con_Ha5VHHBFF9Wi1Dqz","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 243.019459ms
+        duration: 338.772542ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -579,8 +579,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -590,13 +590,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_3tTzkzidQ1kgu9ov","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:21.789Z","created_at":"2024-07-17T18:27:21.789Z","user_id_attribute":"externalId"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_Ha5VHHBFF9Wi1Dqz","connection_name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:05:37.380Z","created_at":"2025-05-06T04:05:37.380Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 251.327125ms
+        duration: 361.411875ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -614,8 +614,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz/scim-configuration
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -626,12 +626,10 @@ interactions:
         content_length: 0
         uncompressed: false
         body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
+        headers: {}
         status: 204 No Content
         code: 204
-        duration: 232.1575ms
+        duration: 929.601042ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -649,8 +647,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz
         method: GET
       response:
         proto: HTTP/2.0
@@ -660,13 +658,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_3tTzkzidQ1kgu9ov","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
+        body: '{"id":"con_Ha5VHHBFF9Wi1Dqz","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccDataSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccDataSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 235.590666ms
+        duration: 385.017375ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -684,8 +682,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_3tTzkzidQ1kgu9ov
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Ha5VHHBFF9Wi1Dqz
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -695,10 +693,10 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2024-07-17T18:27:27.354Z"}'
+        body: '{"deleted_at":"2025-05-06T04:05:45.727Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 249.347292ms
+        duration: 342.107083ms

--- a/test/data/recordings/TestAccOrganizationConnection.yaml
+++ b/test/data/recordings/TestAccOrganizationConnection.yaml
@@ -19,7 +19,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
+                - Go-Auth0/1.19.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: 574
         uncompressed: false
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 496.504875ms
+        duration: 373.066584ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -54,8 +54,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,32 +65,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.157791ms
+        duration: 400.105042ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 450
+        content_length: 481
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","display_name":"testaccorganizationconnection","strategy":"okta","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token"}}
+            {"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","display_name":"testaccorganizationconnection","strategy":"okta","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","scope":"email openid profile"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
+                - Go-Auth0/1.19.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -99,15 +99,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 767
+        content_length: 798
         uncompressed: false
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","scope":"email openid profile","schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 604.8535ms
+        duration: 436.693959ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -125,8 +125,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -136,13 +136,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.203834ms
+        duration: 357.951417ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -161,7 +161,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
+                - Go-Auth0/1.19.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations
         method: POST
       response:
@@ -172,13 +172,13 @@ interactions:
         trailer: {}
         content_length: 124
         uncompressed: false
-        body: '{"id":"org_5WBes4tPvZU22pKC","display_name":"testaccorganizationconnection","name":"some-org-testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","display_name":"testaccorganizationconnection","name":"some-org-testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 383.075166ms
+        duration: 372.761542ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -196,8 +196,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -207,13 +207,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 370.197958ms
+        duration: 354.224375ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -226,14 +226,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_FN85UGAI9ZKnZMcb"}
+            {"connection_id":"con_EBx4mMAQOb3A26jy"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -243,13 +243,13 @@ interactions:
         trailer: {}
         content_length: 226
         uncompressed: false
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 389.464708ms
+        duration: 357.80875ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -267,8 +267,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -278,13 +278,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.160959ms
+        duration: 377.221334ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -302,8 +302,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -313,13 +313,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.41ms
+        duration: 351.2645ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -337,8 +337,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -348,13 +348,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 369.166125ms
+        duration: 336.877167ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -372,8 +372,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -389,7 +389,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.431417ms
+        duration: 370.204209ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -407,8 +407,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -418,13 +418,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 373.444084ms
+        status: 403 Forbidden
+        code: 403
+        duration: 348.578917ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -442,8 +442,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -453,13 +453,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 435.46875ms
+        duration: 516.853ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -477,8 +477,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -488,13 +488,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 372.328125ms
+        duration: 340.63625ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -512,8 +512,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -529,7 +529,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 546.21425ms
+        duration: 371.652583ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -547,8 +547,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -558,13 +558,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 360.844334ms
+        status: 403 Forbidden
+        code: 403
+        duration: 321.063709ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -582,8 +582,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -593,13 +593,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.324ms
+        duration: 927.985916ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -617,8 +617,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -628,13 +628,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 372.783458ms
+        duration: 333.772875ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -652,8 +652,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -663,13 +663,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.16425ms
+        duration: 333.539666ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -687,8 +687,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -698,13 +698,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.190084ms
+        duration: 346.384916ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -722,8 +722,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -733,13 +733,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 419.676459ms
+        duration: 365.133292ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,13 +768,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.55725ms
+        duration: 433.424ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -792,8 +792,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -809,7 +809,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 365.559666ms
+        duration: 381.101166ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -827,8 +827,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -838,13 +838,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 343.911333ms
+        status: 403 Forbidden
+        code: 403
+        duration: 345.973917ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -862,8 +862,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -873,13 +873,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.744334ms
+        duration: 336.4495ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -897,8 +897,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -908,13 +908,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.397667ms
+        duration: 393.605792ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -932,8 +932,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -943,13 +943,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.9345ms
+        duration: 381.845459ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -967,8 +967,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -978,13 +978,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.11125ms
+        duration: 361.53075ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1003,8 +1003,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1014,13 +1014,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.646208ms
+        duration: 400.458209ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1038,8 +1038,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -1049,13 +1049,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.960208ms
+        duration: 363.450334ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1073,8 +1073,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1084,13 +1084,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.932333ms
+        duration: 376.156334ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1108,8 +1108,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1119,13 +1119,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 385.582542ms
+        duration: 354.05375ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1143,8 +1143,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1160,7 +1160,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 406.79825ms
+        duration: 352.019417ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1178,8 +1178,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1189,13 +1189,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 407.563875ms
+        status: 403 Forbidden
+        code: 403
+        duration: 312.678125ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1213,8 +1213,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1224,13 +1224,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.407792ms
+        duration: 452.310458ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1248,8 +1248,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1259,13 +1259,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.602417ms
+        duration: 359.650292ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1283,8 +1283,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1300,7 +1300,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 428.62325ms
+        duration: 367.667833ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1318,8 +1318,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1329,13 +1329,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 359.510083ms
+        status: 403 Forbidden
+        code: 403
+        duration: 356.959583ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1353,8 +1353,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -1364,13 +1364,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.065083ms
+        duration: 389.551792ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1388,8 +1388,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -1399,13 +1399,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 381.559958ms
+        duration: 341.318417ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1423,8 +1423,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1434,13 +1434,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.835875ms
+        duration: 340.082667ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1458,8 +1458,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -1469,13 +1469,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 360.379208ms
+        duration: 352.0205ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1493,8 +1493,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1504,13 +1504,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.711917ms
+        duration: 339.856167ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1528,8 +1528,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1539,13 +1539,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 372.068542ms
+        duration: 366.66475ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1563,8 +1563,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1580,7 +1580,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.335083ms
+        duration: 334.028709ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1598,8 +1598,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1609,13 +1609,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 393.804583ms
+        status: 403 Forbidden
+        code: 403
+        duration: 334.237417ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1633,8 +1633,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -1644,13 +1644,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 368.059917ms
+        duration: 360.645834ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1668,8 +1668,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -1679,13 +1679,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.073792ms
+        duration: 352.82ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1703,8 +1703,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,13 +1714,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 454.112375ms
+        duration: 366.634125ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1738,8 +1738,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -1749,13 +1749,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 384.515625ms
+        duration: 386.161542ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1768,14 +1768,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true}
+            {"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -1785,13 +1785,13 @@ interactions:
         trailer: {}
         content_length: 206
         uncompressed: false
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 341.853791ms
+        duration: 360.123375ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1809,8 +1809,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -1820,13 +1820,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 406.16025ms
+        duration: 364.237458ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1844,8 +1844,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1855,13 +1855,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.627541ms
+        duration: 359.167334ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1879,8 +1879,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1890,13 +1890,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.1355ms
+        duration: 489.856209ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1914,8 +1914,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1931,7 +1931,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 386.141375ms
+        duration: 384.608875ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1949,8 +1949,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1960,13 +1960,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 351.355334ms
+        status: 403 Forbidden
+        code: 403
+        duration: 338.626458ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -1984,8 +1984,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1995,13 +1995,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 322.376083ms
+        duration: 530.153833ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2019,8 +2019,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2030,13 +2030,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.048292ms
+        duration: 430.525083ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2054,8 +2054,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2071,7 +2071,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 326.373375ms
+        duration: 357.399875ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2089,8 +2089,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2100,13 +2100,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 361.024583ms
+        status: 403 Forbidden
+        code: 403
+        duration: 320.8355ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2124,8 +2124,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -2135,13 +2135,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.169125ms
+        duration: 359.417208ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -2159,8 +2159,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -2170,13 +2170,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 424.95925ms
+        duration: 334.153542ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -2194,8 +2194,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -2205,13 +2205,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 386.735291ms
+        duration: 332.488375ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -2229,8 +2229,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -2240,13 +2240,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 404.766333ms
+        duration: 334.157459ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -2264,8 +2264,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -2275,13 +2275,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 402.521291ms
+        duration: 350.911292ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -2299,8 +2299,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -2310,13 +2310,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 322.571ms
+        duration: 372.036167ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -2334,8 +2334,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2345,13 +2345,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 387.193458ms
+        duration: 323.897333ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -2369,8 +2369,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2386,7 +2386,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.19125ms
+        duration: 366.572042ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -2404,8 +2404,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2415,13 +2415,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 384.129834ms
+        status: 403 Forbidden
+        code: 403
+        duration: 343.428708ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -2439,8 +2439,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -2450,13 +2450,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.719959ms
+        duration: 334.5625ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -2474,8 +2474,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -2485,13 +2485,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 357.928583ms
+        duration: 346.778084ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -2509,8 +2509,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -2520,13 +2520,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 363.140125ms
+        duration: 351.758833ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -2544,8 +2544,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -2555,13 +2555,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 403.102667ms
+        duration: 932.064417ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -2579,8 +2579,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -2590,13 +2590,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 386.983958ms
+        duration: 345.58175ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -2614,8 +2614,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -2625,13 +2625,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 403.578709ms
+        duration: 371.645792ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -2649,8 +2649,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2660,13 +2660,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 379.79875ms
+        duration: 354.244083ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -2684,8 +2684,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2701,7 +2701,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 357.112ms
+        duration: 362.862875ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -2719,8 +2719,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2730,13 +2730,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 326.858333ms
+        status: 403 Forbidden
+        code: 403
+        duration: 313.414083ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -2754,8 +2754,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2771,7 +2771,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 331.677625ms
+        duration: 342.61825ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -2789,8 +2789,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2806,7 +2806,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 336.250125ms
+        duration: 369.754583ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -2824,8 +2824,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -2835,13 +2835,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 448.129375ms
+        duration: 371.610166ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -2859,8 +2859,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2876,7 +2876,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 509.939666ms
+        duration: 356.666541ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -2894,8 +2894,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2911,7 +2911,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.0465ms
+        duration: 353.983625ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -2929,8 +2929,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2940,13 +2940,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 524.941584ms
+        status: 403 Forbidden
+        code: 403
+        duration: 444.964167ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -2964,8 +2964,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -2975,13 +2975,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 357.738125ms
+        duration: 345.514958ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -2999,8 +2999,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -3010,13 +3010,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.182125ms
+        duration: 357.484167ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -3034,8 +3034,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -3045,13 +3045,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.659166ms
+        duration: 370.83425ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -3069,8 +3069,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -3080,13 +3080,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 391.199875ms
+        duration: 335.274ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -3104,8 +3104,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3121,7 +3121,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 889.221958ms
+        duration: 360.208417ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -3139,8 +3139,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3156,7 +3156,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.801458ms
+        duration: 378.792958ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -3174,8 +3174,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3185,13 +3185,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 345.913459ms
+        status: 403 Forbidden
+        code: 403
+        duration: 325.230208ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -3209,8 +3209,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -3220,13 +3220,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.730542ms
+        duration: 397.943167ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -3244,8 +3244,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -3255,13 +3255,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 380.461709ms
+        duration: 369.171459ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -3279,8 +3279,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -3290,13 +3290,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.481625ms
+        duration: 349.99325ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -3314,8 +3314,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -3325,13 +3325,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 323.524709ms
+        duration: 317.738708ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -3349,8 +3349,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3366,7 +3366,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.782291ms
+        duration: 331.081958ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -3384,8 +3384,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3401,7 +3401,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 369.326375ms
+        duration: 363.440667ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -3419,8 +3419,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3430,13 +3430,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 332.981583ms
+        status: 403 Forbidden
+        code: 403
+        duration: 359.731416ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -3454,8 +3454,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -3465,13 +3465,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.126083ms
+        duration: 390.538417ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -3489,8 +3489,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -3500,13 +3500,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.381542ms
+        duration: 388.722833ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -3524,8 +3524,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -3535,13 +3535,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.239667ms
+        duration: 363.754125ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -3559,8 +3559,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -3570,13 +3570,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 512.820375ms
+        duration: 377.624583ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -3594,8 +3594,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3611,7 +3611,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.490333ms
+        duration: 447.859625ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -3629,8 +3629,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3646,7 +3646,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 374.483292ms
+        duration: 388.317875ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -3664,8 +3664,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3675,13 +3675,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 370.61275ms
+        status: 403 Forbidden
+        code: 403
+        duration: 311.593292ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -3699,8 +3699,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -3710,13 +3710,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.692ms
+        duration: 380.220375ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -3734,8 +3734,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -3745,13 +3745,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.276917ms
+        duration: 367.758833ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -3769,8 +3769,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -3780,13 +3780,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.196583ms
+        duration: 350.635292ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -3799,14 +3799,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_mKS2oQqsOoFCJpCq","show_as_button":true}
+            {"connection_id":"con_LMo3BvmX5SQqTijh","show_as_button":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -3816,13 +3816,13 @@ interactions:
         trailer: {}
         content_length: 207
         uncompressed: false
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 356.1665ms
+        duration: 354.338167ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -3840,8 +3840,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -3851,13 +3851,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 408.207917ms
+        duration: 507.462541ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -3875,8 +3875,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -3886,13 +3886,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 402.062583ms
+        duration: 406.235292ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -3910,8 +3910,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3921,13 +3921,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.871708ms
+        duration: 352.604875ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -3945,8 +3945,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3962,7 +3962,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.097ms
+        duration: 353.604458ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -3980,8 +3980,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3991,13 +3991,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 359.906958ms
+        status: 403 Forbidden
+        code: 403
+        duration: 328.416083ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -4015,8 +4015,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -4026,13 +4026,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 455.933542ms
+        duration: 339.717458ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -4050,8 +4050,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4061,13 +4061,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 404.208292ms
+        duration: 365.086834ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -4085,8 +4085,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4102,7 +4102,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.563666ms
+        duration: 365.650375ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -4120,8 +4120,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4131,13 +4131,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 348.507167ms
+        status: 403 Forbidden
+        code: 403
+        duration: 362.410292ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -4155,8 +4155,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -4166,13 +4166,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.683375ms
+        duration: 337.575458ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -4190,8 +4190,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -4201,13 +4201,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 330.421083ms
+        duration: 704.586708ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -4225,8 +4225,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -4236,13 +4236,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.695083ms
+        duration: 347.808125ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -4260,8 +4260,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -4271,13 +4271,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.847333ms
+        duration: 439.432458ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -4295,8 +4295,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -4306,13 +4306,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 349.157459ms
+        duration: 351.331584ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -4330,8 +4330,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4341,13 +4341,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 380.320125ms
+        duration: 367.836166ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -4365,8 +4365,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4382,7 +4382,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 384.786166ms
+        duration: 348.396709ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -4400,8 +4400,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4411,13 +4411,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 352.996292ms
+        status: 403 Forbidden
+        code: 403
+        duration: 421.342542ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -4435,8 +4435,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -4446,13 +4446,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.339167ms
+        duration: 428.421875ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -4470,8 +4470,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -4481,13 +4481,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.132875ms
+        duration: 374.227ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -4505,8 +4505,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -4516,13 +4516,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 408.698666ms
+        duration: 337.212125ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -4540,8 +4540,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -4551,13 +4551,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400.254959ms
+        duration: 925.306542ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -4576,8 +4576,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -4587,13 +4587,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.204292ms
+        duration: 376.085791ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -4611,8 +4611,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -4622,13 +4622,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.485916ms
+        duration: 333.280083ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -4646,8 +4646,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -4657,13 +4657,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 434.832958ms
+        duration: 335.770083ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -4681,8 +4681,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4692,13 +4692,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.353958ms
+        duration: 377.47375ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -4716,8 +4716,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4733,7 +4733,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 375.153375ms
+        duration: 377.112166ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -4751,8 +4751,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4762,13 +4762,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 329.654833ms
+        status: 403 Forbidden
+        code: 403
+        duration: 331.691667ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -4786,8 +4786,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -4797,13 +4797,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 377.928292ms
+        duration: 787.25475ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -4821,8 +4821,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4832,13 +4832,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 398.336417ms
+        duration: 352.043584ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -4856,8 +4856,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4873,7 +4873,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.088583ms
+        duration: 376.553333ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -4891,8 +4891,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4902,13 +4902,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 380.11875ms
+        status: 403 Forbidden
+        code: 403
+        duration: 309.01125ms
     - id: 140
       request:
         proto: HTTP/1.1
@@ -4926,8 +4926,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -4937,13 +4937,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.059875ms
+        duration: 381.087083ms
     - id: 141
       request:
         proto: HTTP/1.1
@@ -4961,8 +4961,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -4972,13 +4972,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.913709ms
+        duration: 367.086666ms
     - id: 142
       request:
         proto: HTTP/1.1
@@ -4996,8 +4996,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -5007,13 +5007,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 375.209208ms
+        duration: 359.816291ms
     - id: 143
       request:
         proto: HTTP/1.1
@@ -5031,8 +5031,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -5042,13 +5042,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.622458ms
+        duration: 354.765042ms
     - id: 144
       request:
         proto: HTTP/1.1
@@ -5066,8 +5066,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -5077,13 +5077,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 577.361833ms
+        duration: 359.029208ms
     - id: 145
       request:
         proto: HTTP/1.1
@@ -5101,8 +5101,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5112,13 +5112,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 433.639334ms
+        duration: 367.897334ms
     - id: 146
       request:
         proto: HTTP/1.1
@@ -5136,8 +5136,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5153,7 +5153,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 407.109458ms
+        duration: 345.369458ms
     - id: 147
       request:
         proto: HTTP/1.1
@@ -5171,8 +5171,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5182,13 +5182,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 408.64ms
+        status: 403 Forbidden
+        code: 403
+        duration: 341.45275ms
     - id: 148
       request:
         proto: HTTP/1.1
@@ -5206,8 +5206,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -5217,13 +5217,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 438.468292ms
+        duration: 359.81325ms
     - id: 149
       request:
         proto: HTTP/1.1
@@ -5241,8 +5241,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -5252,13 +5252,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 517.539ms
+        duration: 408.864875ms
     - id: 150
       request:
         proto: HTTP/1.1
@@ -5276,8 +5276,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -5287,13 +5287,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 457.225959ms
+        duration: 479.666125ms
     - id: 151
       request:
         proto: HTTP/1.1
@@ -5311,8 +5311,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -5322,13 +5322,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 392.76ms
+        duration: 379.186167ms
     - id: 152
       request:
         proto: HTTP/1.1
@@ -5346,8 +5346,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -5357,13 +5357,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 402.580334ms
+        duration: 335.704833ms
     - id: 153
       request:
         proto: HTTP/1.1
@@ -5381,8 +5381,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5392,13 +5392,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400.692583ms
+        duration: 347.936875ms
     - id: 154
       request:
         proto: HTTP/1.1
@@ -5416,8 +5416,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5433,7 +5433,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 415.086209ms
+        duration: 354.165541ms
     - id: 155
       request:
         proto: HTTP/1.1
@@ -5451,8 +5451,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5462,13 +5462,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 354.277792ms
+        status: 403 Forbidden
+        code: 403
+        duration: 359.408042ms
     - id: 156
       request:
         proto: HTTP/1.1
@@ -5486,8 +5486,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5503,7 +5503,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 348.440791ms
+        duration: 369.048375ms
     - id: 157
       request:
         proto: HTTP/1.1
@@ -5521,8 +5521,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -5532,13 +5532,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.376958ms
+        duration: 355.036375ms
     - id: 158
       request:
         proto: HTTP/1.1
@@ -5556,8 +5556,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5573,7 +5573,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 379.157958ms
+        duration: 333.980208ms
     - id: 159
       request:
         proto: HTTP/1.1
@@ -5591,8 +5591,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5608,7 +5608,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.916667ms
+        duration: 367.112583ms
     - id: 160
       request:
         proto: HTTP/1.1
@@ -5626,8 +5626,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5637,13 +5637,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 347.0605ms
+        status: 403 Forbidden
+        code: 403
+        duration: 353.21ms
     - id: 161
       request:
         proto: HTTP/1.1
@@ -5661,8 +5661,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -5672,13 +5672,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.285125ms
+        duration: 352.080375ms
     - id: 162
       request:
         proto: HTTP/1.1
@@ -5696,8 +5696,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -5707,13 +5707,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.206417ms
+        duration: 336.932666ms
     - id: 163
       request:
         proto: HTTP/1.1
@@ -5731,8 +5731,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -5742,13 +5742,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.415291ms
+        duration: 392.180708ms
     - id: 164
       request:
         proto: HTTP/1.1
@@ -5766,8 +5766,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -5777,13 +5777,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 326.646667ms
+        duration: 322.2615ms
     - id: 165
       request:
         proto: HTTP/1.1
@@ -5801,8 +5801,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5818,7 +5818,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.118625ms
+        duration: 374.810084ms
     - id: 166
       request:
         proto: HTTP/1.1
@@ -5836,8 +5836,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5853,7 +5853,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 325.699292ms
+        duration: 389.057667ms
     - id: 167
       request:
         proto: HTTP/1.1
@@ -5871,8 +5871,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5882,13 +5882,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 336.374042ms
+        status: 403 Forbidden
+        code: 403
+        duration: 323.961167ms
     - id: 168
       request:
         proto: HTTP/1.1
@@ -5906,8 +5906,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -5917,13 +5917,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 318.337333ms
+        duration: 358.493542ms
     - id: 169
       request:
         proto: HTTP/1.1
@@ -5941,8 +5941,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -5952,13 +5952,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.201917ms
+        duration: 351.707208ms
     - id: 170
       request:
         proto: HTTP/1.1
@@ -5976,8 +5976,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -5987,13 +5987,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.30675ms
+        duration: 368.63075ms
     - id: 171
       request:
         proto: HTTP/1.1
@@ -6011,8 +6011,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -6022,13 +6022,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.48925ms
+        duration: 364.749375ms
     - id: 172
       request:
         proto: HTTP/1.1
@@ -6046,8 +6046,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6063,7 +6063,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.634708ms
+        duration: 344.508708ms
     - id: 173
       request:
         proto: HTTP/1.1
@@ -6081,8 +6081,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6098,7 +6098,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.920166ms
+        duration: 321.409041ms
     - id: 174
       request:
         proto: HTTP/1.1
@@ -6116,8 +6116,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6127,13 +6127,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 330.982584ms
+        status: 403 Forbidden
+        code: 403
+        duration: 341.355958ms
     - id: 175
       request:
         proto: HTTP/1.1
@@ -6151,8 +6151,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -6162,13 +6162,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 326.461166ms
+        duration: 358.764ms
     - id: 176
       request:
         proto: HTTP/1.1
@@ -6186,8 +6186,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -6197,13 +6197,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.013708ms
+        duration: 355.37675ms
     - id: 177
       request:
         proto: HTTP/1.1
@@ -6221,8 +6221,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -6232,13 +6232,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 434.822792ms
+        duration: 396.440875ms
     - id: 178
       request:
         proto: HTTP/1.1
@@ -6256,8 +6256,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -6267,13 +6267,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.374ms
+        duration: 340.013917ms
     - id: 179
       request:
         proto: HTTP/1.1
@@ -6291,8 +6291,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6308,7 +6308,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.598917ms
+        duration: 340.176125ms
     - id: 180
       request:
         proto: HTTP/1.1
@@ -6326,8 +6326,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6343,7 +6343,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.255042ms
+        duration: 380.945166ms
     - id: 181
       request:
         proto: HTTP/1.1
@@ -6361,8 +6361,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6372,13 +6372,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 420.467667ms
+        status: 403 Forbidden
+        code: 403
+        duration: 358.469292ms
     - id: 182
       request:
         proto: HTTP/1.1
@@ -6396,8 +6396,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -6407,13 +6407,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.262875ms
+        duration: 343.258958ms
     - id: 183
       request:
         proto: HTTP/1.1
@@ -6431,8 +6431,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -6442,13 +6442,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.350541ms
+        duration: 501.788458ms
     - id: 184
       request:
         proto: HTTP/1.1
@@ -6466,8 +6466,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -6477,13 +6477,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 326.432584ms
+        duration: 359.746625ms
     - id: 185
       request:
         proto: HTTP/1.1
@@ -6496,14 +6496,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":true}
+            {"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -6513,13 +6513,13 @@ interactions:
         trailer: {}
         content_length: 224
         uncompressed: false
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 357.34675ms
+        duration: 354.2655ms
     - id: 186
       request:
         proto: HTTP/1.1
@@ -6537,8 +6537,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -6548,13 +6548,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 330.947833ms
+        duration: 369.932208ms
     - id: 187
       request:
         proto: HTTP/1.1
@@ -6572,8 +6572,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -6583,13 +6583,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.459916ms
+        duration: 356.037584ms
     - id: 188
       request:
         proto: HTTP/1.1
@@ -6607,8 +6607,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6618,13 +6618,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 972.123334ms
+        duration: 413.29875ms
     - id: 189
       request:
         proto: HTTP/1.1
@@ -6642,8 +6642,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6659,7 +6659,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 408.988334ms
+        duration: 341.51925ms
     - id: 190
       request:
         proto: HTTP/1.1
@@ -6677,8 +6677,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6688,13 +6688,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 340.855417ms
+        status: 403 Forbidden
+        code: 403
+        duration: 336.475792ms
     - id: 191
       request:
         proto: HTTP/1.1
@@ -6712,8 +6712,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -6723,13 +6723,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.554416ms
+        duration: 355.613083ms
     - id: 192
       request:
         proto: HTTP/1.1
@@ -6747,8 +6747,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6758,13 +6758,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.06175ms
+        duration: 345.340458ms
     - id: 193
       request:
         proto: HTTP/1.1
@@ -6782,8 +6782,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6799,7 +6799,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 432.621209ms
+        duration: 383.099791ms
     - id: 194
       request:
         proto: HTTP/1.1
@@ -6817,8 +6817,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6828,13 +6828,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 512.058625ms
+        status: 403 Forbidden
+        code: 403
+        duration: 410.246208ms
     - id: 195
       request:
         proto: HTTP/1.1
@@ -6852,8 +6852,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -6863,13 +6863,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.37825ms
+        duration: 352.690125ms
     - id: 196
       request:
         proto: HTTP/1.1
@@ -6887,8 +6887,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -6898,13 +6898,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.274375ms
+        duration: 363.038209ms
     - id: 197
       request:
         proto: HTTP/1.1
@@ -6922,8 +6922,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -6933,13 +6933,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.682458ms
+        duration: 341.4855ms
     - id: 198
       request:
         proto: HTTP/1.1
@@ -6957,8 +6957,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -6968,13 +6968,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 393.927959ms
+        duration: 353.710042ms
     - id: 199
       request:
         proto: HTTP/1.1
@@ -6992,8 +6992,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -7003,13 +7003,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.61125ms
+        duration: 347.138375ms
     - id: 200
       request:
         proto: HTTP/1.1
@@ -7027,8 +7027,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7038,13 +7038,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 461.816083ms
+        duration: 384.197959ms
     - id: 201
       request:
         proto: HTTP/1.1
@@ -7062,8 +7062,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7079,7 +7079,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 406.794709ms
+        duration: 347.8725ms
     - id: 202
       request:
         proto: HTTP/1.1
@@ -7097,8 +7097,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7108,13 +7108,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 345.849084ms
+        status: 403 Forbidden
+        code: 403
+        duration: 318.057042ms
     - id: 203
       request:
         proto: HTTP/1.1
@@ -7132,8 +7132,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -7143,13 +7143,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 374.059958ms
+        duration: 348.7385ms
     - id: 204
       request:
         proto: HTTP/1.1
@@ -7167,8 +7167,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -7178,13 +7178,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 372.670541ms
+        duration: 380.662459ms
     - id: 205
       request:
         proto: HTTP/1.1
@@ -7202,8 +7202,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -7213,13 +7213,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.400667ms
+        duration: 329.584ms
     - id: 206
       request:
         proto: HTTP/1.1
@@ -7237,8 +7237,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -7248,13 +7248,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.494542ms
+        duration: 344.55025ms
     - id: 207
       request:
         proto: HTTP/1.1
@@ -7273,8 +7273,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -7284,13 +7284,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.603625ms
+        duration: 379.379084ms
     - id: 208
       request:
         proto: HTTP/1.1
@@ -7308,8 +7308,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -7319,13 +7319,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.112ms
+        duration: 353.391458ms
     - id: 209
       request:
         proto: HTTP/1.1
@@ -7343,8 +7343,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -7354,13 +7354,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.467125ms
+        duration: 336.704084ms
     - id: 210
       request:
         proto: HTTP/1.1
@@ -7378,8 +7378,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7389,13 +7389,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 933.8885ms
+        duration: 337.957542ms
     - id: 211
       request:
         proto: HTTP/1.1
@@ -7413,8 +7413,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7430,7 +7430,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 381.673125ms
+        duration: 349.559875ms
     - id: 212
       request:
         proto: HTTP/1.1
@@ -7448,8 +7448,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7459,13 +7459,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 340.262333ms
+        status: 403 Forbidden
+        code: 403
+        duration: 367.939833ms
     - id: 213
       request:
         proto: HTTP/1.1
@@ -7483,8 +7483,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -7494,13 +7494,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.206667ms
+        duration: 358.866708ms
     - id: 214
       request:
         proto: HTTP/1.1
@@ -7518,8 +7518,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7529,13 +7529,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.4085ms
+        duration: 386.587083ms
     - id: 215
       request:
         proto: HTTP/1.1
@@ -7553,8 +7553,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7570,7 +7570,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.2215ms
+        duration: 361.226041ms
     - id: 216
       request:
         proto: HTTP/1.1
@@ -7588,8 +7588,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7599,13 +7599,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 349.816959ms
+        status: 403 Forbidden
+        code: 403
+        duration: 347.056458ms
     - id: 217
       request:
         proto: HTTP/1.1
@@ -7623,8 +7623,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -7634,13 +7634,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.838ms
+        duration: 373.213875ms
     - id: 218
       request:
         proto: HTTP/1.1
@@ -7658,8 +7658,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -7669,13 +7669,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.409916ms
+        duration: 329.57175ms
     - id: 219
       request:
         proto: HTTP/1.1
@@ -7693,8 +7693,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -7704,13 +7704,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 349.834666ms
+        duration: 359.26425ms
     - id: 220
       request:
         proto: HTTP/1.1
@@ -7728,8 +7728,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -7739,13 +7739,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 382.48275ms
+        duration: 342.555125ms
     - id: 221
       request:
         proto: HTTP/1.1
@@ -7763,8 +7763,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -7774,13 +7774,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 349.689208ms
+        duration: 324.952708ms
     - id: 222
       request:
         proto: HTTP/1.1
@@ -7798,8 +7798,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7809,13 +7809,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.0945ms
+        duration: 345.344458ms
     - id: 223
       request:
         proto: HTTP/1.1
@@ -7833,8 +7833,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7850,7 +7850,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.294834ms
+        duration: 332.005083ms
     - id: 224
       request:
         proto: HTTP/1.1
@@ -7868,8 +7868,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7879,13 +7879,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 327.818ms
+        status: 403 Forbidden
+        code: 403
+        duration: 406.398167ms
     - id: 225
       request:
         proto: HTTP/1.1
@@ -7903,8 +7903,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -7914,13 +7914,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.195917ms
+        duration: 344.152041ms
     - id: 226
       request:
         proto: HTTP/1.1
@@ -7938,8 +7938,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -7949,13 +7949,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 694.135625ms
+        duration: 359.951583ms
     - id: 227
       request:
         proto: HTTP/1.1
@@ -7973,8 +7973,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -7984,13 +7984,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.63875ms
+        duration: 365.507542ms
     - id: 228
       request:
         proto: HTTP/1.1
@@ -8008,8 +8008,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -8019,13 +8019,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.003416ms
+        duration: 354.160541ms
     - id: 229
       request:
         proto: HTTP/1.1
@@ -8043,8 +8043,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -8054,13 +8054,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 326.992583ms
+        duration: 331.780333ms
     - id: 230
       request:
         proto: HTTP/1.1
@@ -8078,8 +8078,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8089,13 +8089,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.680625ms
+        duration: 362.08875ms
     - id: 231
       request:
         proto: HTTP/1.1
@@ -8113,8 +8113,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8130,7 +8130,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.792584ms
+        duration: 616.540458ms
     - id: 232
       request:
         proto: HTTP/1.1
@@ -8148,8 +8148,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8159,13 +8159,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 375.51475ms
+        status: 403 Forbidden
+        code: 403
+        duration: 332.59125ms
     - id: 233
       request:
         proto: HTTP/1.1
@@ -8183,8 +8183,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -8200,7 +8200,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 368.430708ms
+        duration: 364.64425ms
     - id: 234
       request:
         proto: HTTP/1.1
@@ -8218,8 +8218,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -8229,13 +8229,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 378.912333ms
+        duration: 527.227417ms
     - id: 235
       request:
         proto: HTTP/1.1
@@ -8253,8 +8253,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8270,7 +8270,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 421.553625ms
+        duration: 349.132833ms
     - id: 236
       request:
         proto: HTTP/1.1
@@ -8288,8 +8288,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8305,7 +8305,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.259542ms
+        duration: 428.669125ms
     - id: 237
       request:
         proto: HTTP/1.1
@@ -8323,8 +8323,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8334,13 +8334,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 408.757875ms
+        status: 403 Forbidden
+        code: 403
+        duration: 328.37725ms
     - id: 238
       request:
         proto: HTTP/1.1
@@ -8358,8 +8358,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -8369,13 +8369,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 368.219542ms
+        duration: 482.433958ms
     - id: 239
       request:
         proto: HTTP/1.1
@@ -8393,8 +8393,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -8404,13 +8404,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.882917ms
+        duration: 341.342917ms
     - id: 240
       request:
         proto: HTTP/1.1
@@ -8428,8 +8428,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -8439,13 +8439,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 363.098ms
+        duration: 341.312542ms
     - id: 241
       request:
         proto: HTTP/1.1
@@ -8463,8 +8463,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -8474,13 +8474,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.864375ms
+        duration: 335.328084ms
     - id: 242
       request:
         proto: HTTP/1.1
@@ -8498,8 +8498,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8515,7 +8515,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.02475ms
+        duration: 346.519959ms
     - id: 243
       request:
         proto: HTTP/1.1
@@ -8533,8 +8533,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8550,7 +8550,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 371.14175ms
+        duration: 341.839042ms
     - id: 244
       request:
         proto: HTTP/1.1
@@ -8568,8 +8568,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8579,13 +8579,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 393.614875ms
+        status: 403 Forbidden
+        code: 403
+        duration: 322.272209ms
     - id: 245
       request:
         proto: HTTP/1.1
@@ -8603,8 +8603,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -8614,13 +8614,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 424.386834ms
+        duration: 338.167417ms
     - id: 246
       request:
         proto: HTTP/1.1
@@ -8638,8 +8638,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -8649,13 +8649,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 386.174291ms
+        duration: 369.108583ms
     - id: 247
       request:
         proto: HTTP/1.1
@@ -8673,8 +8673,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -8684,13 +8684,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 318.904167ms
+        duration: 383.883625ms
     - id: 248
       request:
         proto: HTTP/1.1
@@ -8708,8 +8708,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -8719,13 +8719,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 323.251708ms
+        duration: 321.279459ms
     - id: 249
       request:
         proto: HTTP/1.1
@@ -8743,8 +8743,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8760,7 +8760,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.306458ms
+        duration: 385.739375ms
     - id: 250
       request:
         proto: HTTP/1.1
@@ -8778,8 +8778,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8795,7 +8795,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.941625ms
+        duration: 334.354167ms
     - id: 251
       request:
         proto: HTTP/1.1
@@ -8813,8 +8813,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8824,13 +8824,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 346.03825ms
+        status: 403 Forbidden
+        code: 403
+        duration: 317.554292ms
     - id: 252
       request:
         proto: HTTP/1.1
@@ -8848,8 +8848,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -8859,13 +8859,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 325.400666ms
+        duration: 382.904375ms
     - id: 253
       request:
         proto: HTTP/1.1
@@ -8883,8 +8883,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -8894,13 +8894,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.579375ms
+        duration: 320.216708ms
     - id: 254
       request:
         proto: HTTP/1.1
@@ -8918,8 +8918,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -8929,13 +8929,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.570916ms
+        duration: 331.476583ms
     - id: 255
       request:
         proto: HTTP/1.1
@@ -8953,8 +8953,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -8964,13 +8964,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.802958ms
+        duration: 396.526208ms
     - id: 256
       request:
         proto: HTTP/1.1
@@ -8988,8 +8988,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9005,7 +9005,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.050542ms
+        duration: 363.244834ms
     - id: 257
       request:
         proto: HTTP/1.1
@@ -9023,8 +9023,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9040,7 +9040,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 401.158375ms
+        duration: 334.141875ms
     - id: 258
       request:
         proto: HTTP/1.1
@@ -9058,8 +9058,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -9069,13 +9069,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 392.285334ms
+        status: 403 Forbidden
+        code: 403
+        duration: 335.514375ms
     - id: 259
       request:
         proto: HTTP/1.1
@@ -9093,8 +9093,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -9104,13 +9104,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.181375ms
+        duration: 359.637667ms
     - id: 260
       request:
         proto: HTTP/1.1
@@ -9128,8 +9128,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -9139,13 +9139,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.512875ms
+        duration: 334.747667ms
     - id: 261
       request:
         proto: HTTP/1.1
@@ -9163,8 +9163,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -9174,13 +9174,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.5335ms
+        duration: 381.304958ms
     - id: 262
       request:
         proto: HTTP/1.1
@@ -9198,8 +9198,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9215,7 +9215,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 524.852792ms
+        duration: 363.003041ms
     - id: 263
       request:
         proto: HTTP/1.1
@@ -9228,14 +9228,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true}
+            {"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -9245,13 +9245,13 @@ interactions:
         trailer: {}
         content_length: 225
         uncompressed: false
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 361.931125ms
+        duration: 346.501625ms
     - id: 264
       request:
         proto: HTTP/1.1
@@ -9264,14 +9264,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true}
+            {"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -9281,13 +9281,13 @@ interactions:
         trailer: {}
         content_length: 206
         uncompressed: false
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 407.681167ms
+        duration: 371.511875ms
     - id: 265
       request:
         proto: HTTP/1.1
@@ -9305,8 +9305,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9316,13 +9316,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 410.049792ms
+        duration: 362.053708ms
     - id: 266
       request:
         proto: HTTP/1.1
@@ -9340,8 +9340,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -9351,13 +9351,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.500709ms
+        duration: 362.11375ms
     - id: 267
       request:
         proto: HTTP/1.1
@@ -9375,8 +9375,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -9386,13 +9386,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.112125ms
+        duration: 363.78925ms
     - id: 268
       request:
         proto: HTTP/1.1
@@ -9410,8 +9410,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -9421,13 +9421,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.771709ms
+        duration: 356.599083ms
     - id: 269
       request:
         proto: HTTP/1.1
@@ -9445,8 +9445,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9456,13 +9456,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 391.280042ms
+        duration: 337.675125ms
     - id: 270
       request:
         proto: HTTP/1.1
@@ -9480,8 +9480,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -9491,13 +9491,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.931417ms
+        duration: 370.179666ms
     - id: 271
       request:
         proto: HTTP/1.1
@@ -9515,8 +9515,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -9526,13 +9526,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 356.192875ms
+        duration: 337.619083ms
     - id: 272
       request:
         proto: HTTP/1.1
@@ -9550,8 +9550,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9561,13 +9561,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 406.946958ms
+        duration: 352.942917ms
     - id: 273
       request:
         proto: HTTP/1.1
@@ -9585,8 +9585,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9602,7 +9602,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.226416ms
+        duration: 361.09125ms
     - id: 274
       request:
         proto: HTTP/1.1
@@ -9620,8 +9620,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -9631,13 +9631,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 343.746917ms
+        status: 403 Forbidden
+        code: 403
+        duration: 330.464041ms
     - id: 275
       request:
         proto: HTTP/1.1
@@ -9655,8 +9655,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -9666,13 +9666,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.852583ms
+        duration: 419.290041ms
     - id: 276
       request:
         proto: HTTP/1.1
@@ -9690,8 +9690,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -9701,13 +9701,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.21925ms
+        duration: 350.380167ms
     - id: 277
       request:
         proto: HTTP/1.1
@@ -9725,8 +9725,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9736,13 +9736,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 349.060541ms
+        duration: 359.706125ms
     - id: 278
       request:
         proto: HTTP/1.1
@@ -9760,8 +9760,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9777,7 +9777,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.16675ms
+        duration: 366.899667ms
     - id: 279
       request:
         proto: HTTP/1.1
@@ -9795,8 +9795,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -9806,13 +9806,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 358.0295ms
+        status: 403 Forbidden
+        code: 403
+        duration: 332.037375ms
     - id: 280
       request:
         proto: HTTP/1.1
@@ -9830,8 +9830,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -9841,13 +9841,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 364.869084ms
+        duration: 352.290208ms
     - id: 281
       request:
         proto: HTTP/1.1
@@ -9865,8 +9865,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -9876,13 +9876,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.863209ms
+        duration: 409.465666ms
     - id: 282
       request:
         proto: HTTP/1.1
@@ -9900,8 +9900,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -9911,13 +9911,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.903417ms
+        duration: 332.529208ms
     - id: 283
       request:
         proto: HTTP/1.1
@@ -9935,8 +9935,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9946,13 +9946,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 870.35425ms
+        duration: 348.390166ms
     - id: 284
       request:
         proto: HTTP/1.1
@@ -9970,8 +9970,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -9981,13 +9981,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.731458ms
+        duration: 390.223458ms
     - id: 285
       request:
         proto: HTTP/1.1
@@ -10005,8 +10005,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -10016,13 +10016,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.464542ms
+        duration: 332.2155ms
     - id: 286
       request:
         proto: HTTP/1.1
@@ -10040,8 +10040,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -10051,13 +10051,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.060042ms
+        duration: 340.833959ms
     - id: 287
       request:
         proto: HTTP/1.1
@@ -10075,8 +10075,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10086,13 +10086,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.190375ms
+        duration: 364.949584ms
     - id: 288
       request:
         proto: HTTP/1.1
@@ -10110,8 +10110,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10127,7 +10127,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 371.929833ms
+        duration: 313.013166ms
     - id: 289
       request:
         proto: HTTP/1.1
@@ -10145,8 +10145,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -10156,13 +10156,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 333.474208ms
+        status: 403 Forbidden
+        code: 403
+        duration: 418.205084ms
     - id: 290
       request:
         proto: HTTP/1.1
@@ -10180,8 +10180,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -10191,13 +10191,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 881.557042ms
+        duration: 386.555583ms
     - id: 291
       request:
         proto: HTTP/1.1
@@ -10215,8 +10215,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10226,13 +10226,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 349.399ms
+        duration: 361.52575ms
     - id: 292
       request:
         proto: HTTP/1.1
@@ -10250,8 +10250,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10267,7 +10267,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.175583ms
+        duration: 347.811667ms
     - id: 293
       request:
         proto: HTTP/1.1
@@ -10285,8 +10285,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -10296,13 +10296,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 409.913292ms
+        status: 403 Forbidden
+        code: 403
+        duration: 320.077458ms
     - id: 294
       request:
         proto: HTTP/1.1
@@ -10320,8 +10320,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -10331,13 +10331,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_FN85UGAI9ZKnZMcb","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_EBx4mMAQOb3A26jy","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.379792ms
+        duration: 349.447583ms
     - id: 295
       request:
         proto: HTTP/1.1
@@ -10355,8 +10355,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -10366,13 +10366,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_mKS2oQqsOoFCJpCq","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
+        body: '{"id":"con_LMo3BvmX5SQqTijh","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnection","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnection"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.082917ms
+        duration: 322.979542ms
     - id: 296
       request:
         proto: HTTP/1.1
@@ -10390,8 +10390,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -10401,13 +10401,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.885541ms
+        duration: 336.298417ms
     - id: 297
       request:
         proto: HTTP/1.1
@@ -10425,8 +10425,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10436,13 +10436,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 365.628833ms
+        duration: 626.327959ms
     - id: 298
       request:
         proto: HTTP/1.1
@@ -10460,8 +10460,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: GET
       response:
         proto: HTTP/2.0
@@ -10471,13 +10471,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
+        body: '{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.246584ms
+        duration: 354.627875ms
     - id: 299
       request:
         proto: HTTP/1.1
@@ -10495,8 +10495,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: GET
       response:
         proto: HTTP/2.0
@@ -10506,13 +10506,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
+        body: '{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.643167ms
+        duration: 359.76975ms
     - id: 300
       request:
         proto: HTTP/1.1
@@ -10530,8 +10530,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: GET
       response:
         proto: HTTP/2.0
@@ -10541,13 +10541,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_5WBes4tPvZU22pKC","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
+        body: '{"id":"org_F2tcBRGUdYlYRKMH","name":"some-org-testaccorganizationconnection","display_name":"testaccorganizationconnection"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 425.351ms
+        duration: 377.025792ms
     - id: 301
       request:
         proto: HTTP/1.1
@@ -10565,8 +10565,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10576,13 +10576,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_FN85UGAI9ZKnZMcb","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_mKS2oQqsOoFCJpCq","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_EBx4mMAQOb3A26jy","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnection","strategy":"auth0"}},{"connection_id":"con_LMo3BvmX5SQqTijh","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnection","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 406.452875ms
+        duration: 421.917167ms
     - id: 302
       request:
         proto: HTTP/1.1
@@ -10600,8 +10600,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10617,7 +10617,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.597167ms
+        duration: 330.479ms
     - id: 303
       request:
         proto: HTTP/1.1
@@ -10635,8 +10635,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -10646,13 +10646,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 329.892958ms
+        status: 403 Forbidden
+        code: 403
+        duration: 335.094292ms
     - id: 304
       request:
         proto: HTTP/1.1
@@ -10670,8 +10670,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -10687,7 +10687,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 340.022583ms
+        duration: 316.797792ms
     - id: 305
       request:
         proto: HTTP/1.1
@@ -10705,8 +10705,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -10722,7 +10722,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 369.959834ms
+        duration: 354.106167ms
     - id: 306
       request:
         proto: HTTP/1.1
@@ -10740,8 +10740,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_EBx4mMAQOb3A26jy
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -10757,7 +10757,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 347.551792ms
+        duration: 331.213625ms
     - id: 307
       request:
         proto: HTTP/1.1
@@ -10775,8 +10775,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC/enabled_connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH/enabled_connections/con_LMo3BvmX5SQqTijh
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -10792,7 +10792,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 320.469916ms
+        duration: 379.297542ms
     - id: 308
       request:
         proto: HTTP/1.1
@@ -10810,8 +10810,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_5WBes4tPvZU22pKC
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_F2tcBRGUdYlYRKMH
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -10827,7 +10827,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 536.640208ms
+        duration: 336.926ms
     - id: 309
       request:
         proto: HTTP/1.1
@@ -10845,8 +10845,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mKS2oQqsOoFCJpCq
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LMo3BvmX5SQqTijh
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -10856,13 +10856,13 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2024-09-23T06:20:05.372Z"}'
+        body: '{"deleted_at":"2025-05-05T14:56:38.175Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 390.850584ms
+        duration: 349.982458ms
     - id: 310
       request:
         proto: HTTP/1.1
@@ -10880,8 +10880,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_FN85UGAI9ZKnZMcb
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_EBx4mMAQOb3A26jy
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -10891,10 +10891,10 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2024-09-23T06:20:05.771Z"}'
+        body: '{"deleted_at":"2025-05-05T14:56:38.573Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 344.423333ms
+        duration: 385.315625ms

--- a/test/data/recordings/TestAccOrganizationConnections.yaml
+++ b/test/data/recordings/TestAccOrganizationConnections.yaml
@@ -19,7 +19,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
+                - Go-Auth0/1.19.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: 576
         uncompressed: false
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 420.668333ms
+        duration: 391.578084ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -54,8 +54,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,32 +65,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 391.439083ms
+        duration: 378.14475ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 452
+        content_length: 483
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","display_name":"testaccorganizationconnections","strategy":"okta","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token"}}
+            {"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","display_name":"testaccorganizationconnections","strategy":"okta","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","scope":"email openid profile"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
+                - Go-Auth0/1.19.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -99,15 +99,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 770
+        content_length: 801
         uncompressed: false
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","scope":"email openid profile","schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 470.266208ms
+        duration: 417.153625ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -125,8 +125,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -136,13 +136,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 349.47325ms
+        duration: 383.522708ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -161,7 +161,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
+                - Go-Auth0/1.19.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations
         method: POST
       response:
@@ -172,13 +172,13 @@ interactions:
         trailer: {}
         content_length: 126
         uncompressed: false
-        body: '{"id":"org_gAovmvcsx3u3w9en","display_name":"testaccorganizationconnections","name":"some-org-testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","display_name":"testaccorganizationconnections","name":"some-org-testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 357.845042ms
+        duration: 567.035709ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -196,8 +196,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -207,13 +207,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.512166ms
+        duration: 441.892ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -226,14 +226,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_7Ys4WX2IP8FNuMN7"}
+            {"connection_id":"con_x2eMWPyj74cIPY66"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -243,13 +243,13 @@ interactions:
         trailer: {}
         content_length: 227
         uncompressed: false
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 385.079167ms
+        duration: 371.837958ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -267,8 +267,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -278,13 +278,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.596625ms
+        duration: 358.848459ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -302,8 +302,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -313,13 +313,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 372.05325ms
+        duration: 396.274583ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -337,8 +337,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -348,13 +348,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.217333ms
+        duration: 344.241584ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -372,8 +372,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -383,13 +383,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 401.403417ms
+        duration: 350.989459ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -407,8 +407,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -418,13 +418,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.983834ms
+        duration: 385.606416ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -442,8 +442,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -453,13 +453,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.570166ms
+        duration: 361.037125ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -477,8 +477,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -488,13 +488,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.904584ms
+        duration: 349.764625ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -512,8 +512,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -523,13 +523,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.34225ms
+        duration: 327.737833ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -547,8 +547,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -564,7 +564,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.44625ms
+        duration: 335.8025ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -582,8 +582,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -593,13 +593,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 360.915458ms
+        status: 403 Forbidden
+        code: 403
+        duration: 332.073584ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -617,8 +617,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -634,7 +634,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 373.735ms
+        duration: 347.10575ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -652,8 +652,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -663,13 +663,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.052125ms
+        duration: 329.202916ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -687,8 +687,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -704,7 +704,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.654417ms
+        duration: 371.129709ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -722,8 +722,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -739,7 +739,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.778167ms
+        duration: 345.529083ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,13 +768,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 374.692291ms
+        status: 403 Forbidden
+        code: 403
+        duration: 309.120542ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -792,8 +792,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -803,13 +803,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.863916ms
+        duration: 381.040417ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -827,8 +827,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -838,13 +838,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 330.834166ms
+        duration: 370.159167ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -862,8 +862,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -873,13 +873,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.095958ms
+        duration: 336.7765ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -897,8 +897,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -908,13 +908,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.17675ms
+        duration: 341.464125ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -932,8 +932,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -949,7 +949,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 349.903875ms
+        duration: 364.811167ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -967,8 +967,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -984,7 +984,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.294083ms
+        duration: 336.429917ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1002,8 +1002,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1013,13 +1013,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 545.28275ms
+        status: 403 Forbidden
+        code: 403
+        duration: 332.879208ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1037,8 +1037,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -1048,13 +1048,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.863ms
+        duration: 360.423167ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1072,8 +1072,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1083,13 +1083,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.19925ms
+        duration: 323.421625ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1107,8 +1107,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -1118,13 +1118,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 402.137667ms
+        duration: 314.69925ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1142,8 +1142,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -1153,13 +1153,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 363.900833ms
+        duration: 342.677041ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1177,8 +1177,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1194,7 +1194,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.344916ms
+        duration: 314.977959ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1212,8 +1212,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1229,7 +1229,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 422.972584ms
+        duration: 318.218ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1247,8 +1247,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1258,13 +1258,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 376.290291ms
+        status: 403 Forbidden
+        code: 403
+        duration: 328.72425ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1282,8 +1282,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -1293,13 +1293,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 357.146292ms
+        duration: 908.378167ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1317,8 +1317,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1328,13 +1328,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.304166ms
+        duration: 363.03125ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1352,8 +1352,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -1363,13 +1363,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.215333ms
+        duration: 364.056958ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1387,8 +1387,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -1398,13 +1398,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.056ms
+        duration: 308.426083ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1422,8 +1422,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1439,7 +1439,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.893292ms
+        duration: 349.5245ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1457,8 +1457,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1474,7 +1474,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.809167ms
+        duration: 691.570792ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1492,8 +1492,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1503,13 +1503,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 334.806292ms
+        status: 403 Forbidden
+        code: 403
+        duration: 335.070625ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1527,8 +1527,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -1538,13 +1538,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 549.142875ms
+        duration: 319.093917ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1562,8 +1562,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -1573,13 +1573,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.890833ms
+        duration: 318.874291ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1597,8 +1597,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -1608,13 +1608,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 440.973708ms
+        duration: 349.267542ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1632,8 +1632,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1649,7 +1649,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.028542ms
+        duration: 943.742167ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1662,14 +1662,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_7Ys4WX2IP8FNuMN7"}
+            {"connection_id":"con_x2eMWPyj74cIPY66"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -1679,13 +1679,13 @@ interactions:
         trailer: {}
         content_length: 227
         uncompressed: false
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 337.211458ms
+        duration: 355.669916ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1703,8 +1703,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1714,13 +1714,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.207541ms
+        duration: 373.410166ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1738,8 +1738,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -1749,13 +1749,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 413.628583ms
+        duration: 393.340208ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1773,8 +1773,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1784,13 +1784,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 414.729791ms
+        duration: 344.976667ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1808,8 +1808,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1825,7 +1825,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 402.212208ms
+        duration: 332.115708ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1843,8 +1843,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1854,13 +1854,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 409.890542ms
+        status: 403 Forbidden
+        code: 403
+        duration: 303.726917ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1878,8 +1878,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -1889,13 +1889,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 379.966583ms
+        duration: 321.312792ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1913,8 +1913,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1924,13 +1924,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 386.35325ms
+        duration: 348.31125ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1948,8 +1948,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -1965,7 +1965,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.547792ms
+        duration: 318.989083ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -1983,8 +1983,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1994,13 +1994,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 340.633292ms
+        status: 403 Forbidden
+        code: 403
+        duration: 316.780167ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -2018,8 +2018,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -2029,13 +2029,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.067292ms
+        duration: 318.66425ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -2053,8 +2053,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -2064,13 +2064,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 383.853458ms
+        duration: 342.758917ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -2088,8 +2088,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -2099,13 +2099,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 365.628583ms
+        duration: 322.800125ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2123,8 +2123,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2134,13 +2134,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.909042ms
+        duration: 349.20675ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -2158,8 +2158,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -2169,13 +2169,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.118ms
+        duration: 355.2225ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -2193,8 +2193,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2204,13 +2204,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.412375ms
+        duration: 372.139417ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -2228,8 +2228,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2245,7 +2245,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 360.689875ms
+        duration: 444.648791ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -2263,8 +2263,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2274,13 +2274,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 341.144625ms
+        status: 403 Forbidden
+        code: 403
+        duration: 307.281417ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -2298,8 +2298,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -2309,13 +2309,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 387.716041ms
+        duration: 354.481833ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -2333,8 +2333,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -2344,13 +2344,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 421.091958ms
+        duration: 357.15ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -2368,8 +2368,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -2379,13 +2379,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.68ms
+        duration: 330.109792ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -2403,8 +2403,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2414,13 +2414,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.58525ms
+        duration: 342.079417ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -2438,8 +2438,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -2449,13 +2449,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.939667ms
+        duration: 329.522458ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -2473,8 +2473,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2484,13 +2484,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.238542ms
+        duration: 361.21775ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -2508,8 +2508,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2525,7 +2525,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.659792ms
+        duration: 346.060583ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -2543,8 +2543,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2554,13 +2554,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 368.818667ms
+        status: 403 Forbidden
+        code: 403
+        duration: 325.364375ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -2578,8 +2578,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -2589,13 +2589,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 909.337333ms
+        duration: 383.770292ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -2613,8 +2613,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -2624,13 +2624,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 497.488334ms
+        duration: 336.282333ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -2648,8 +2648,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -2659,13 +2659,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.563084ms
+        duration: 317.20025ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -2683,8 +2683,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2694,13 +2694,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.4225ms
+        duration: 329.596625ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -2718,8 +2718,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -2729,13 +2729,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.733667ms
+        duration: 313.940792ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -2753,8 +2753,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2764,13 +2764,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.774834ms
+        duration: 342.081583ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -2788,8 +2788,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2805,7 +2805,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 325.128458ms
+        duration: 338.153958ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -2823,8 +2823,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2834,13 +2834,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 376.729625ms
+        status: 403 Forbidden
+        code: 403
+        duration: 328.579667ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -2858,8 +2858,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -2869,13 +2869,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 462.277916ms
+        duration: 351.322583ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -2893,8 +2893,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -2904,13 +2904,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 356.4045ms
+        duration: 365.087125ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -2928,8 +2928,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -2939,13 +2939,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 377.55175ms
+        duration: 335.433125ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -2963,8 +2963,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -2974,13 +2974,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 378.841875ms
+        duration: 341.082042ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -2993,14 +2993,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_ZR1gVd2o5zDVZzhR"}
+            {"connection_id":"con_eF58BsNR5zEhazKa"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -3010,13 +3010,13 @@ interactions:
         trailer: {}
         content_length: 208
         uncompressed: false
-        body: '{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
+        body: '{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 385.659292ms
+        duration: 357.66275ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -3034,8 +3034,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3045,13 +3045,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 403.03275ms
+        duration: 322.363916ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -3069,8 +3069,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -3080,13 +3080,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 328.127708ms
+        duration: 525.987584ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -3104,8 +3104,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3115,13 +3115,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 476.114542ms
+        duration: 347.652667ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -3139,8 +3139,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3156,7 +3156,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.306417ms
+        duration: 351.095ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -3174,8 +3174,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3185,13 +3185,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 351.488458ms
+        status: 403 Forbidden
+        code: 403
+        duration: 318.7415ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -3209,8 +3209,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -3220,13 +3220,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.615083ms
+        duration: 326.043375ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -3244,8 +3244,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3255,13 +3255,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.603958ms
+        duration: 347.815958ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -3279,8 +3279,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3296,7 +3296,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.212625ms
+        duration: 342.834ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -3314,8 +3314,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3325,13 +3325,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 332.40925ms
+        status: 403 Forbidden
+        code: 403
+        duration: 321.639417ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -3349,8 +3349,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -3360,13 +3360,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 386.845ms
+        duration: 342.12825ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -3384,8 +3384,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -3395,13 +3395,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.021875ms
+        duration: 362.48ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -3419,8 +3419,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -3430,13 +3430,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.856084ms
+        duration: 324.184792ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -3454,8 +3454,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3465,13 +3465,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.41275ms
+        duration: 366.198291ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -3489,8 +3489,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -3500,13 +3500,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.022834ms
+        duration: 349.807416ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -3524,8 +3524,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3535,13 +3535,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.219125ms
+        duration: 380.343333ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -3559,8 +3559,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3576,7 +3576,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.373125ms
+        duration: 328.308375ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -3594,8 +3594,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3605,13 +3605,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 346.705333ms
+        status: 403 Forbidden
+        code: 403
+        duration: 311.572292ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -3629,8 +3629,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -3640,13 +3640,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 497.304333ms
+        duration: 351.482ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -3664,8 +3664,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -3675,13 +3675,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.443625ms
+        duration: 342.886083ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -3699,8 +3699,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -3710,13 +3710,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.7165ms
+        duration: 310.184292ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -3734,8 +3734,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3745,13 +3745,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.322709ms
+        duration: 322.587459ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -3769,8 +3769,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -3780,13 +3780,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 556.333084ms
+        duration: 325.322292ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -3804,8 +3804,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3815,13 +3815,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 448.272917ms
+        duration: 350.180292ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -3839,8 +3839,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -3856,7 +3856,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 401.804166ms
+        duration: 367.269208ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -3874,8 +3874,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -3885,13 +3885,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 333.554042ms
+        status: 403 Forbidden
+        code: 403
+        duration: 360.835584ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -3909,8 +3909,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -3920,13 +3920,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.60175ms
+        duration: 372.174917ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -3944,8 +3944,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -3955,13 +3955,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 442.125417ms
+        duration: 337.979583ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -3979,8 +3979,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -3990,13 +3990,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.619792ms
+        duration: 328.093125ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -4014,8 +4014,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4025,13 +4025,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.784792ms
+        duration: 357.392625ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -4049,8 +4049,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -4060,13 +4060,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.745875ms
+        duration: 386.722792ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -4084,8 +4084,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4095,13 +4095,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.759542ms
+        duration: 376.849708ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -4119,8 +4119,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4136,7 +4136,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 312.7405ms
+        duration: 338.953875ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -4154,8 +4154,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4165,13 +4165,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 323.138583ms
+        status: 403 Forbidden
+        code: 403
+        duration: 313.498291ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -4189,8 +4189,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -4200,13 +4200,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.476917ms
+        duration: 342.818292ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -4224,8 +4224,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -4235,13 +4235,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.27125ms
+        duration: 352.851167ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -4259,8 +4259,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -4270,13 +4270,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.990292ms
+        duration: 321.290459ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -4294,8 +4294,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4305,13 +4305,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":false,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 364.724917ms
+        duration: 349.142792ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -4329,8 +4329,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4346,7 +4346,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 368.228917ms
+        duration: 906.377958ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -4364,8 +4364,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_eF58BsNR5zEhazKa
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -4381,7 +4381,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 373.42025ms
+        duration: 366.59525ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -4394,14 +4394,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true}
+            {"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -4409,15 +4409,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 226
+        content_length: 207
         uncompressed: false
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 412.25875ms
+        duration: 363.12775ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -4430,14 +4430,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true}
+            {"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -4445,15 +4445,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 207
+        content_length: 226
         uncompressed: false
-        body: '{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 366.102292ms
+        duration: 404.508334ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -4471,8 +4471,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4482,13 +4482,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.278292ms
+        duration: 346.586375ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -4506,8 +4506,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -4517,13 +4517,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 401.946125ms
+        duration: 336.053584ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -4541,8 +4541,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4552,13 +4552,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 407.909458ms
+        duration: 345.728292ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -4576,8 +4576,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4593,7 +4593,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 406.356041ms
+        duration: 341.961375ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -4611,8 +4611,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4622,13 +4622,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 328.211375ms
+        status: 403 Forbidden
+        code: 403
+        duration: 335.26975ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -4646,8 +4646,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -4657,13 +4657,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 383.513167ms
+        duration: 318.828125ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -4681,8 +4681,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4692,13 +4692,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.727875ms
+        duration: 359.236709ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -4716,8 +4716,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4733,7 +4733,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 443.383167ms
+        duration: 348.175333ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -4751,8 +4751,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -4762,13 +4762,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 323.401667ms
+        status: 403 Forbidden
+        code: 403
+        duration: 472.477083ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -4786,8 +4786,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -4797,13 +4797,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.044708ms
+        duration: 344.254791ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -4821,8 +4821,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -4832,13 +4832,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.951958ms
+        duration: 339.446375ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -4856,8 +4856,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -4867,13 +4867,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 395.253292ms
+        duration: 366.371625ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -4891,8 +4891,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4902,13 +4902,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.456167ms
+        duration: 372.9385ms
     - id: 140
       request:
         proto: HTTP/1.1
@@ -4926,8 +4926,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -4937,13 +4937,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 378.150209ms
+        duration: 317.818459ms
     - id: 141
       request:
         proto: HTTP/1.1
@@ -4961,8 +4961,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -4972,13 +4972,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 408.130208ms
+        duration: 355.767208ms
     - id: 142
       request:
         proto: HTTP/1.1
@@ -4996,8 +4996,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5013,7 +5013,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 408.664292ms
+        duration: 361.16775ms
     - id: 143
       request:
         proto: HTTP/1.1
@@ -5031,8 +5031,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5042,13 +5042,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 344.517542ms
+        status: 403 Forbidden
+        code: 403
+        duration: 336.733042ms
     - id: 144
       request:
         proto: HTTP/1.1
@@ -5066,8 +5066,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -5077,13 +5077,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 356.317ms
+        duration: 361.485583ms
     - id: 145
       request:
         proto: HTTP/1.1
@@ -5101,8 +5101,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -5112,13 +5112,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 441.920667ms
+        duration: 350.389209ms
     - id: 146
       request:
         proto: HTTP/1.1
@@ -5136,8 +5136,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -5147,13 +5147,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.306ms
+        duration: 328.510209ms
     - id: 147
       request:
         proto: HTTP/1.1
@@ -5171,8 +5171,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5182,13 +5182,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.828625ms
+        duration: 463.073542ms
     - id: 148
       request:
         proto: HTTP/1.1
@@ -5206,8 +5206,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -5217,13 +5217,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 368.892917ms
+        duration: 372.130333ms
     - id: 149
       request:
         proto: HTTP/1.1
@@ -5241,8 +5241,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5252,13 +5252,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 381.178166ms
+        duration: 371.203708ms
     - id: 150
       request:
         proto: HTTP/1.1
@@ -5276,8 +5276,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5293,7 +5293,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.887708ms
+        duration: 340.517042ms
     - id: 151
       request:
         proto: HTTP/1.1
@@ -5311,8 +5311,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5322,13 +5322,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 350.670125ms
+        status: 403 Forbidden
+        code: 403
+        duration: 372.43375ms
     - id: 152
       request:
         proto: HTTP/1.1
@@ -5346,8 +5346,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -5357,13 +5357,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.238125ms
+        duration: 378.108709ms
     - id: 153
       request:
         proto: HTTP/1.1
@@ -5381,8 +5381,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -5392,13 +5392,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.889875ms
+        duration: 314.791125ms
     - id: 154
       request:
         proto: HTTP/1.1
@@ -5416,8 +5416,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -5427,13 +5427,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.262458ms
+        duration: 342.2725ms
     - id: 155
       request:
         proto: HTTP/1.1
@@ -5451,8 +5451,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5462,13 +5462,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.244459ms
+        duration: 379.071667ms
     - id: 156
       request:
         proto: HTTP/1.1
@@ -5486,8 +5486,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -5497,13 +5497,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.460875ms
+        duration: 357.274792ms
     - id: 157
       request:
         proto: HTTP/1.1
@@ -5521,8 +5521,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5532,13 +5532,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.261125ms
+        duration: 340.905292ms
     - id: 158
       request:
         proto: HTTP/1.1
@@ -5556,8 +5556,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5573,7 +5573,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.28475ms
+        duration: 334.027208ms
     - id: 159
       request:
         proto: HTTP/1.1
@@ -5591,8 +5591,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5602,13 +5602,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 339.736417ms
+        status: 403 Forbidden
+        code: 403
+        duration: 351.280292ms
     - id: 160
       request:
         proto: HTTP/1.1
@@ -5626,8 +5626,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -5637,13 +5637,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.281458ms
+        duration: 328.440666ms
     - id: 161
       request:
         proto: HTTP/1.1
@@ -5661,8 +5661,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -5672,13 +5672,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.050333ms
+        duration: 361.57ms
     - id: 162
       request:
         proto: HTTP/1.1
@@ -5696,8 +5696,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -5707,13 +5707,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 330.10175ms
+        duration: 325.91575ms
     - id: 163
       request:
         proto: HTTP/1.1
@@ -5731,8 +5731,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5742,13 +5742,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 356.830792ms
+        duration: 344.111708ms
     - id: 164
       request:
         proto: HTTP/1.1
@@ -5766,8 +5766,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -5783,7 +5783,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 360.315541ms
+        duration: 343.111917ms
     - id: 165
       request:
         proto: HTTP/1.1
@@ -5801,8 +5801,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5812,13 +5812,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.627833ms
+        duration: 323.349875ms
     - id: 166
       request:
         proto: HTTP/1.1
@@ -5836,8 +5836,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -5847,13 +5847,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.258125ms
+        duration: 364.767375ms
     - id: 167
       request:
         proto: HTTP/1.1
@@ -5871,8 +5871,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5882,13 +5882,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 453.506541ms
+        duration: 345.282125ms
     - id: 168
       request:
         proto: HTTP/1.1
@@ -5906,8 +5906,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -5923,7 +5923,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.617125ms
+        duration: 334.979875ms
     - id: 169
       request:
         proto: HTTP/1.1
@@ -5941,8 +5941,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -5952,13 +5952,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 382.532042ms
+        status: 403 Forbidden
+        code: 403
+        duration: 349.088834ms
     - id: 170
       request:
         proto: HTTP/1.1
@@ -5976,8 +5976,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -5987,13 +5987,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 370.39025ms
+        duration: 421.151375ms
     - id: 171
       request:
         proto: HTTP/1.1
@@ -6011,8 +6011,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6022,13 +6022,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 468.258708ms
+        duration: 341.167916ms
     - id: 172
       request:
         proto: HTTP/1.1
@@ -6046,8 +6046,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6063,7 +6063,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.667542ms
+        duration: 313.120167ms
     - id: 173
       request:
         proto: HTTP/1.1
@@ -6081,8 +6081,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6092,13 +6092,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 330.666625ms
+        status: 403 Forbidden
+        code: 403
+        duration: 853.231958ms
     - id: 174
       request:
         proto: HTTP/1.1
@@ -6116,8 +6116,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -6127,13 +6127,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.826167ms
+        duration: 347.18975ms
     - id: 175
       request:
         proto: HTTP/1.1
@@ -6151,8 +6151,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -6162,13 +6162,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 386.200375ms
+        duration: 357.437292ms
     - id: 176
       request:
         proto: HTTP/1.1
@@ -6186,8 +6186,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -6197,13 +6197,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.201875ms
+        duration: 350.283ms
     - id: 177
       request:
         proto: HTTP/1.1
@@ -6221,8 +6221,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6232,13 +6232,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 371.241208ms
+        duration: 355.011916ms
     - id: 178
       request:
         proto: HTTP/1.1
@@ -6256,8 +6256,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -6267,13 +6267,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 368.773208ms
+        duration: 886.968875ms
     - id: 179
       request:
         proto: HTTP/1.1
@@ -6291,8 +6291,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6302,13 +6302,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.524792ms
+        duration: 330.68875ms
     - id: 180
       request:
         proto: HTTP/1.1
@@ -6326,8 +6326,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6343,7 +6343,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.06525ms
+        duration: 332.717084ms
     - id: 181
       request:
         proto: HTTP/1.1
@@ -6361,8 +6361,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6372,13 +6372,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 336.078334ms
+        status: 403 Forbidden
+        code: 403
+        duration: 312.323292ms
     - id: 182
       request:
         proto: HTTP/1.1
@@ -6396,8 +6396,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -6407,13 +6407,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.030334ms
+        duration: 338.428333ms
     - id: 183
       request:
         proto: HTTP/1.1
@@ -6431,8 +6431,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -6442,13 +6442,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.4305ms
+        duration: 344.458084ms
     - id: 184
       request:
         proto: HTTP/1.1
@@ -6466,8 +6466,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -6477,13 +6477,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.023161667s
+        duration: 383.636917ms
     - id: 185
       request:
         proto: HTTP/1.1
@@ -6501,8 +6501,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6512,13 +6512,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 349.769417ms
+        duration: 359.397709ms
     - id: 186
       request:
         proto: HTTP/1.1
@@ -6536,8 +6536,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -6547,13 +6547,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 323.671667ms
+        duration: 306.527667ms
     - id: 187
       request:
         proto: HTTP/1.1
@@ -6571,8 +6571,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6582,13 +6582,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.397ms
+        duration: 331.153959ms
     - id: 188
       request:
         proto: HTTP/1.1
@@ -6606,8 +6606,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6623,7 +6623,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.540791ms
+        duration: 332.812084ms
     - id: 189
       request:
         proto: HTTP/1.1
@@ -6641,8 +6641,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6652,13 +6652,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 346.678541ms
+        status: 403 Forbidden
+        code: 403
+        duration: 419.971ms
     - id: 190
       request:
         proto: HTTP/1.1
@@ -6676,8 +6676,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -6687,13 +6687,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 365.258542ms
+        duration: 364.867667ms
     - id: 191
       request:
         proto: HTTP/1.1
@@ -6711,8 +6711,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -6722,13 +6722,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 397.661833ms
+        duration: 389.52225ms
     - id: 192
       request:
         proto: HTTP/1.1
@@ -6746,8 +6746,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -6757,13 +6757,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.1085ms
+        duration: 336.8315ms
     - id: 193
       request:
         proto: HTTP/1.1
@@ -6781,8 +6781,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6792,13 +6792,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.445209ms
+        duration: 361.466584ms
     - id: 194
       request:
         proto: HTTP/1.1
@@ -6816,8 +6816,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -6827,13 +6827,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.83175ms
+        duration: 341.747791ms
     - id: 195
       request:
         proto: HTTP/1.1
@@ -6851,8 +6851,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6862,13 +6862,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.704417ms
+        duration: 348.992ms
     - id: 196
       request:
         proto: HTTP/1.1
@@ -6886,8 +6886,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6903,7 +6903,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.014ms
+        duration: 383.04375ms
     - id: 197
       request:
         proto: HTTP/1.1
@@ -6921,8 +6921,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -6932,13 +6932,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 321.218375ms
+        status: 403 Forbidden
+        code: 403
+        duration: 335.966292ms
     - id: 198
       request:
         proto: HTTP/1.1
@@ -6956,8 +6956,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -6967,13 +6967,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.680167ms
+        duration: 333.118041ms
     - id: 199
       request:
         proto: HTTP/1.1
@@ -6991,8 +6991,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -7002,13 +7002,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.62775ms
+        duration: 342.196875ms
     - id: 200
       request:
         proto: HTTP/1.1
@@ -7026,8 +7026,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -7037,13 +7037,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.942917ms
+        duration: 364.648084ms
     - id: 201
       request:
         proto: HTTP/1.1
@@ -7061,8 +7061,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -7072,13 +7072,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.701833ms
+        duration: 345.011625ms
     - id: 202
       request:
         proto: HTTP/1.1
@@ -7096,8 +7096,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -7107,13 +7107,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 325.505875ms
+        duration: 384.50725ms
     - id: 203
       request:
         proto: HTTP/1.1
@@ -7131,8 +7131,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7142,13 +7142,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.60425ms
+        duration: 408.910333ms
     - id: 204
       request:
         proto: HTTP/1.1
@@ -7166,8 +7166,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7183,7 +7183,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.453042ms
+        duration: 324.45775ms
     - id: 205
       request:
         proto: HTTP/1.1
@@ -7201,8 +7201,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7212,13 +7212,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 333.944875ms
+        status: 403 Forbidden
+        code: 403
+        duration: 345.051875ms
     - id: 206
       request:
         proto: HTTP/1.1
@@ -7236,8 +7236,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_eF58BsNR5zEhazKa
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -7253,7 +7253,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 330.614625ms
+        duration: 354.799458ms
     - id: 207
       request:
         proto: HTTP/1.1
@@ -7271,8 +7271,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -7282,13 +7282,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.552875ms
+        duration: 332.391458ms
     - id: 208
       request:
         proto: HTTP/1.1
@@ -7306,8 +7306,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7323,7 +7323,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.33425ms
+        duration: 370.740041ms
     - id: 209
       request:
         proto: HTTP/1.1
@@ -7341,8 +7341,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7358,7 +7358,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.096584ms
+        duration: 327.9645ms
     - id: 210
       request:
         proto: HTTP/1.1
@@ -7376,8 +7376,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7387,13 +7387,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 350.776833ms
+        status: 403 Forbidden
+        code: 403
+        duration: 324.705292ms
     - id: 211
       request:
         proto: HTTP/1.1
@@ -7411,8 +7411,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -7422,13 +7422,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.240125ms
+        duration: 335.484666ms
     - id: 212
       request:
         proto: HTTP/1.1
@@ -7446,8 +7446,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -7457,13 +7457,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.358833ms
+        duration: 330.126833ms
     - id: 213
       request:
         proto: HTTP/1.1
@@ -7481,8 +7481,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -7492,13 +7492,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.051ms
+        duration: 339.092583ms
     - id: 214
       request:
         proto: HTTP/1.1
@@ -7516,8 +7516,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -7527,13 +7527,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 364.037625ms
+        duration: 341.085167ms
     - id: 215
       request:
         proto: HTTP/1.1
@@ -7551,8 +7551,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7568,7 +7568,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.857291ms
+        duration: 355.781541ms
     - id: 216
       request:
         proto: HTTP/1.1
@@ -7586,8 +7586,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7603,7 +7603,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 388.077834ms
+        duration: 329.344834ms
     - id: 217
       request:
         proto: HTTP/1.1
@@ -7621,8 +7621,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7632,13 +7632,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 400.308083ms
+        status: 403 Forbidden
+        code: 403
+        duration: 331.703541ms
     - id: 218
       request:
         proto: HTTP/1.1
@@ -7656,8 +7656,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -7667,13 +7667,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.029541ms
+        duration: 369.867542ms
     - id: 219
       request:
         proto: HTTP/1.1
@@ -7691,8 +7691,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -7702,13 +7702,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 388.12525ms
+        duration: 355.325458ms
     - id: 220
       request:
         proto: HTTP/1.1
@@ -7726,8 +7726,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -7737,13 +7737,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.233333ms
+        duration: 364.11775ms
     - id: 221
       request:
         proto: HTTP/1.1
@@ -7761,8 +7761,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -7772,13 +7772,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.015833ms
+        duration: 415.074083ms
     - id: 222
       request:
         proto: HTTP/1.1
@@ -7796,8 +7796,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7813,7 +7813,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.579292ms
+        duration: 370.67ms
     - id: 223
       request:
         proto: HTTP/1.1
@@ -7831,8 +7831,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -7848,7 +7848,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.993333ms
+        duration: 344.020958ms
     - id: 224
       request:
         proto: HTTP/1.1
@@ -7866,8 +7866,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -7877,13 +7877,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 345.870375ms
+        status: 403 Forbidden
+        code: 403
+        duration: 356.778625ms
     - id: 225
       request:
         proto: HTTP/1.1
@@ -7901,8 +7901,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -7912,13 +7912,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.006542ms
+        duration: 379.904709ms
     - id: 226
       request:
         proto: HTTP/1.1
@@ -7936,8 +7936,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -7947,13 +7947,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.052791ms
+        duration: 396.42ms
     - id: 227
       request:
         proto: HTTP/1.1
@@ -7971,8 +7971,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -7982,13 +7982,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.345917ms
+        duration: 365.351959ms
     - id: 228
       request:
         proto: HTTP/1.1
@@ -8006,8 +8006,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -8017,13 +8017,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.029875ms
+        duration: 365.469583ms
     - id: 229
       request:
         proto: HTTP/1.1
@@ -8041,8 +8041,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8058,7 +8058,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.668958ms
+        duration: 334.3165ms
     - id: 230
       request:
         proto: HTTP/1.1
@@ -8076,8 +8076,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8093,7 +8093,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.502833ms
+        duration: 359.024917ms
     - id: 231
       request:
         proto: HTTP/1.1
@@ -8111,8 +8111,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8122,13 +8122,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 344.767958ms
+        status: 403 Forbidden
+        code: 403
+        duration: 339.966833ms
     - id: 232
       request:
         proto: HTTP/1.1
@@ -8146,8 +8146,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -8157,13 +8157,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.272625ms
+        duration: 347.718375ms
     - id: 233
       request:
         proto: HTTP/1.1
@@ -8181,8 +8181,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -8192,13 +8192,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 388.782083ms
+        duration: 340.120958ms
     - id: 234
       request:
         proto: HTTP/1.1
@@ -8216,8 +8216,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -8227,13 +8227,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 392.740958ms
+        duration: 317.430167ms
     - id: 235
       request:
         proto: HTTP/1.1
@@ -8251,8 +8251,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8268,7 +8268,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.774917ms
+        duration: 359.414625ms
     - id: 236
       request:
         proto: HTTP/1.1
@@ -8281,14 +8281,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_ZR1gVd2o5zDVZzhR","show_as_button":true}
+            {"connection_id":"con_eF58BsNR5zEhazKa","show_as_button":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -8298,13 +8298,13 @@ interactions:
         trailer: {}
         content_length: 208
         uncompressed: false
-        body: '{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
+        body: '{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 356.690958ms
+        duration: 441.8445ms
     - id: 237
       request:
         proto: HTTP/1.1
@@ -8322,8 +8322,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8333,13 +8333,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.108125ms
+        duration: 381.814834ms
     - id: 238
       request:
         proto: HTTP/1.1
@@ -8357,8 +8357,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -8368,13 +8368,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 321.176916ms
+        duration: 511.3185ms
     - id: 239
       request:
         proto: HTTP/1.1
@@ -8392,8 +8392,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8403,13 +8403,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400.479458ms
+        duration: 340.296584ms
     - id: 240
       request:
         proto: HTTP/1.1
@@ -8427,8 +8427,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8444,7 +8444,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.06ms
+        duration: 332.547333ms
     - id: 241
       request:
         proto: HTTP/1.1
@@ -8462,8 +8462,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8473,13 +8473,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 340.542708ms
+        status: 403 Forbidden
+        code: 403
+        duration: 374.5125ms
     - id: 242
       request:
         proto: HTTP/1.1
@@ -8497,8 +8497,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -8508,13 +8508,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.338042ms
+        duration: 339.545625ms
     - id: 243
       request:
         proto: HTTP/1.1
@@ -8532,8 +8532,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8543,13 +8543,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.916458ms
+        duration: 381.684583ms
     - id: 244
       request:
         proto: HTTP/1.1
@@ -8567,8 +8567,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8584,7 +8584,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.996917ms
+        duration: 344.513667ms
     - id: 245
       request:
         proto: HTTP/1.1
@@ -8602,8 +8602,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8613,13 +8613,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 336.097166ms
+        status: 403 Forbidden
+        code: 403
+        duration: 318.781375ms
     - id: 246
       request:
         proto: HTTP/1.1
@@ -8637,8 +8637,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -8648,13 +8648,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.934959ms
+        duration: 332.626791ms
     - id: 247
       request:
         proto: HTTP/1.1
@@ -8672,8 +8672,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -8683,13 +8683,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.62175ms
+        duration: 342.93275ms
     - id: 248
       request:
         proto: HTTP/1.1
@@ -8707,8 +8707,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -8718,13 +8718,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.555542ms
+        duration: 334.0975ms
     - id: 249
       request:
         proto: HTTP/1.1
@@ -8742,8 +8742,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8753,13 +8753,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.696625ms
+        duration: 325.355166ms
     - id: 250
       request:
         proto: HTTP/1.1
@@ -8777,8 +8777,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -8788,13 +8788,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.121292ms
+        duration: 322.247875ms
     - id: 251
       request:
         proto: HTTP/1.1
@@ -8812,8 +8812,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8823,13 +8823,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.950333ms
+        duration: 360.030542ms
     - id: 252
       request:
         proto: HTTP/1.1
@@ -8847,8 +8847,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -8864,7 +8864,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.659833ms
+        duration: 346.076042ms
     - id: 253
       request:
         proto: HTTP/1.1
@@ -8882,8 +8882,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -8893,13 +8893,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 345.342792ms
+        status: 403 Forbidden
+        code: 403
+        duration: 371.597042ms
     - id: 254
       request:
         proto: HTTP/1.1
@@ -8917,8 +8917,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -8928,13 +8928,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.096542ms
+        duration: 355.417542ms
     - id: 255
       request:
         proto: HTTP/1.1
@@ -8952,8 +8952,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -8963,13 +8963,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.599ms
+        duration: 312.292625ms
     - id: 256
       request:
         proto: HTTP/1.1
@@ -8987,8 +8987,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -8998,13 +8998,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.839709ms
+        duration: 334.990833ms
     - id: 257
       request:
         proto: HTTP/1.1
@@ -9022,8 +9022,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9033,13 +9033,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.399375ms
+        duration: 353.679667ms
     - id: 258
       request:
         proto: HTTP/1.1
@@ -9057,8 +9057,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -9068,13 +9068,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.196458ms
+        duration: 325.17925ms
     - id: 259
       request:
         proto: HTTP/1.1
@@ -9092,8 +9092,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9103,13 +9103,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.025292ms
+        duration: 335.797834ms
     - id: 260
       request:
         proto: HTTP/1.1
@@ -9127,8 +9127,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9144,7 +9144,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.35525ms
+        duration: 349.949166ms
     - id: 261
       request:
         proto: HTTP/1.1
@@ -9162,8 +9162,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -9173,13 +9173,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 438.7705ms
+        status: 403 Forbidden
+        code: 403
+        duration: 335.952917ms
     - id: 262
       request:
         proto: HTTP/1.1
@@ -9197,8 +9197,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -9208,13 +9208,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 322.54375ms
+        duration: 460.482541ms
     - id: 263
       request:
         proto: HTTP/1.1
@@ -9232,8 +9232,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -9243,13 +9243,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 370.438041ms
+        duration: 390.750208ms
     - id: 264
       request:
         proto: HTTP/1.1
@@ -9267,8 +9267,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -9278,13 +9278,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 326.112708ms
+        duration: 358.935167ms
     - id: 265
       request:
         proto: HTTP/1.1
@@ -9302,8 +9302,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9313,13 +9313,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.752208ms
+        duration: 376.69875ms
     - id: 266
       request:
         proto: HTTP/1.1
@@ -9337,8 +9337,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -9348,13 +9348,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.152667ms
+        duration: 406.589667ms
     - id: 267
       request:
         proto: HTTP/1.1
@@ -9372,8 +9372,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9383,13 +9383,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.017541ms
+        duration: 386.332084ms
     - id: 268
       request:
         proto: HTTP/1.1
@@ -9407,8 +9407,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9424,7 +9424,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.146625ms
+        duration: 400.358083ms
     - id: 269
       request:
         proto: HTTP/1.1
@@ -9442,8 +9442,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -9453,13 +9453,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 346.200958ms
+        status: 403 Forbidden
+        code: 403
+        duration: 344.603ms
     - id: 270
       request:
         proto: HTTP/1.1
@@ -9477,8 +9477,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -9488,13 +9488,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.8125ms
+        duration: 335.291708ms
     - id: 271
       request:
         proto: HTTP/1.1
@@ -9512,8 +9512,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -9523,13 +9523,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.952958ms
+        duration: 348.709209ms
     - id: 272
       request:
         proto: HTTP/1.1
@@ -9547,8 +9547,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -9558,13 +9558,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.165125ms
+        duration: 325.482208ms
     - id: 273
       request:
         proto: HTTP/1.1
@@ -9582,8 +9582,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9593,13 +9593,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.975625ms
+        duration: 344.702542ms
     - id: 274
       request:
         proto: HTTP/1.1
@@ -9617,8 +9617,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_eF58BsNR5zEhazKa
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -9634,7 +9634,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 349.895292ms
+        duration: 385.779583ms
     - id: 275
       request:
         proto: HTTP/1.1
@@ -9647,14 +9647,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_ZR1gVd2o5zDVZzhR","show_as_button":false}
+            {"connection_id":"con_eF58BsNR5zEhazKa","show_as_button":false}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -9664,13 +9664,13 @@ interactions:
         trailer: {}
         content_length: 209
         uncompressed: false
-        body: '{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
+        body: '{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 361.682375ms
+        duration: 405.188792ms
     - id: 276
       request:
         proto: HTTP/1.1
@@ -9688,8 +9688,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9699,13 +9699,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.071542ms
+        duration: 412.570084ms
     - id: 277
       request:
         proto: HTTP/1.1
@@ -9723,8 +9723,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -9734,13 +9734,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.113875ms
+        duration: 407.00625ms
     - id: 278
       request:
         proto: HTTP/1.1
@@ -9758,8 +9758,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9769,13 +9769,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.580875ms
+        duration: 364.429167ms
     - id: 279
       request:
         proto: HTTP/1.1
@@ -9793,8 +9793,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9810,7 +9810,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 363.504208ms
+        duration: 359.104291ms
     - id: 280
       request:
         proto: HTTP/1.1
@@ -9828,8 +9828,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -9839,13 +9839,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 326.966166ms
+        status: 403 Forbidden
+        code: 403
+        duration: 322.615541ms
     - id: 281
       request:
         proto: HTTP/1.1
@@ -9863,8 +9863,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -9874,13 +9874,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.697084ms
+        duration: 329.844833ms
     - id: 282
       request:
         proto: HTTP/1.1
@@ -9898,8 +9898,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9909,13 +9909,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.3905ms
+        duration: 383.942834ms
     - id: 283
       request:
         proto: HTTP/1.1
@@ -9933,8 +9933,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -9950,7 +9950,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.040416ms
+        duration: 336.404791ms
     - id: 284
       request:
         proto: HTTP/1.1
@@ -9968,8 +9968,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -9979,13 +9979,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 338.5825ms
+        status: 403 Forbidden
+        code: 403
+        duration: 345.517667ms
     - id: 285
       request:
         proto: HTTP/1.1
@@ -10003,8 +10003,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -10014,13 +10014,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.458875ms
+        duration: 363.905083ms
     - id: 286
       request:
         proto: HTTP/1.1
@@ -10038,8 +10038,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -10049,13 +10049,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 370.6965ms
+        duration: 363.716791ms
     - id: 287
       request:
         proto: HTTP/1.1
@@ -10073,8 +10073,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -10084,13 +10084,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.01925ms
+        duration: 339.010625ms
     - id: 288
       request:
         proto: HTTP/1.1
@@ -10108,8 +10108,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10119,13 +10119,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.380458ms
+        duration: 365.427667ms
     - id: 289
       request:
         proto: HTTP/1.1
@@ -10143,8 +10143,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -10154,13 +10154,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.5055ms
+        duration: 331.666958ms
     - id: 290
       request:
         proto: HTTP/1.1
@@ -10178,8 +10178,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10189,13 +10189,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.809042ms
+        duration: 381.88525ms
     - id: 291
       request:
         proto: HTTP/1.1
@@ -10213,8 +10213,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10230,7 +10230,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.160416ms
+        duration: 355.999209ms
     - id: 292
       request:
         proto: HTTP/1.1
@@ -10248,8 +10248,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -10259,13 +10259,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 408.25625ms
+        status: 403 Forbidden
+        code: 403
+        duration: 323.836875ms
     - id: 293
       request:
         proto: HTTP/1.1
@@ -10283,8 +10283,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -10294,13 +10294,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.349333ms
+        duration: 370.9575ms
     - id: 294
       request:
         proto: HTTP/1.1
@@ -10318,8 +10318,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -10329,13 +10329,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.764208ms
+        duration: 354.275083ms
     - id: 295
       request:
         proto: HTTP/1.1
@@ -10353,8 +10353,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -10364,13 +10364,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.856209ms
+        duration: 308.750959ms
     - id: 296
       request:
         proto: HTTP/1.1
@@ -10388,8 +10388,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10399,13 +10399,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 371.576875ms
+        duration: 381.359667ms
     - id: 297
       request:
         proto: HTTP/1.1
@@ -10423,8 +10423,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -10434,13 +10434,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.828791ms
+        duration: 313.27125ms
     - id: 298
       request:
         proto: HTTP/1.1
@@ -10458,8 +10458,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10469,13 +10469,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.987708ms
+        duration: 343.71325ms
     - id: 299
       request:
         proto: HTTP/1.1
@@ -10493,8 +10493,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10510,7 +10510,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.101959ms
+        duration: 544.271291ms
     - id: 300
       request:
         proto: HTTP/1.1
@@ -10528,8 +10528,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -10539,13 +10539,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 350.957417ms
+        status: 403 Forbidden
+        code: 403
+        duration: 325.322958ms
     - id: 301
       request:
         proto: HTTP/1.1
@@ -10563,8 +10563,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -10574,13 +10574,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.349ms
+        duration: 377.390791ms
     - id: 302
       request:
         proto: HTTP/1.1
@@ -10598,8 +10598,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -10609,13 +10609,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.043333ms
+        duration: 433.859ms
     - id: 303
       request:
         proto: HTTP/1.1
@@ -10633,8 +10633,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -10644,13 +10644,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.821166ms
+        duration: 348.036833ms
     - id: 304
       request:
         proto: HTTP/1.1
@@ -10668,8 +10668,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10679,13 +10679,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.22175ms
+        duration: 537.863125ms
     - id: 305
       request:
         proto: HTTP/1.1
@@ -10703,8 +10703,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -10714,13 +10714,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.407041ms
+        duration: 391.078791ms
     - id: 306
       request:
         proto: HTTP/1.1
@@ -10738,8 +10738,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10749,13 +10749,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.703667ms
+        duration: 351.839334ms
     - id: 307
       request:
         proto: HTTP/1.1
@@ -10773,8 +10773,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10790,7 +10790,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.025708ms
+        duration: 343.198292ms
     - id: 308
       request:
         proto: HTTP/1.1
@@ -10808,8 +10808,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -10819,13 +10819,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 339.110417ms
+        status: 403 Forbidden
+        code: 403
+        duration: 351.111541ms
     - id: 309
       request:
         proto: HTTP/1.1
@@ -10843,8 +10843,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -10854,13 +10854,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.27875ms
+        duration: 373.222583ms
     - id: 310
       request:
         proto: HTTP/1.1
@@ -10878,8 +10878,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -10889,13 +10889,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.874417ms
+        duration: 386.445375ms
     - id: 311
       request:
         proto: HTTP/1.1
@@ -10913,8 +10913,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -10924,13 +10924,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.153875ms
+        duration: 341.163916ms
     - id: 312
       request:
         proto: HTTP/1.1
@@ -10948,8 +10948,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -10959,13 +10959,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.542708ms
+        duration: 390.130542ms
     - id: 313
       request:
         proto: HTTP/1.1
@@ -10983,8 +10983,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -10994,13 +10994,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.509625ms
+        duration: 355.47975ms
     - id: 314
       request:
         proto: HTTP/1.1
@@ -11018,8 +11018,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -11029,13 +11029,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":false,"show_as_button":false,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.205958ms
+        duration: 384.784625ms
     - id: 315
       request:
         proto: HTTP/1.1
@@ -11053,8 +11053,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -11070,7 +11070,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 363.490667ms
+        duration: 375.519708ms
     - id: 316
       request:
         proto: HTTP/1.1
@@ -11088,8 +11088,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -11099,13 +11099,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 373.944416ms
+        status: 403 Forbidden
+        code: 403
+        duration: 345.199083ms
     - id: 317
       request:
         proto: HTTP/1.1
@@ -11123,8 +11123,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_eF58BsNR5zEhazKa
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -11140,7 +11140,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 421.059833ms
+        duration: 384.564208ms
     - id: 318
       request:
         proto: HTTP/1.1
@@ -11158,8 +11158,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -11169,13 +11169,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.344458ms
+        duration: 445.447ms
     - id: 319
       request:
         proto: HTTP/1.1
@@ -11193,8 +11193,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -11210,7 +11210,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 378.791625ms
+        duration: 470.183208ms
     - id: 320
       request:
         proto: HTTP/1.1
@@ -11228,8 +11228,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -11245,7 +11245,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 407.703458ms
+        duration: 496.554292ms
     - id: 321
       request:
         proto: HTTP/1.1
@@ -11263,8 +11263,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -11274,13 +11274,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 331.7665ms
+        status: 403 Forbidden
+        code: 403
+        duration: 435.644875ms
     - id: 322
       request:
         proto: HTTP/1.1
@@ -11298,8 +11298,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -11309,13 +11309,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.437042ms
+        duration: 665.487333ms
     - id: 323
       request:
         proto: HTTP/1.1
@@ -11333,8 +11333,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -11344,13 +11344,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.8465ms
+        duration: 379.326459ms
     - id: 324
       request:
         proto: HTTP/1.1
@@ -11368,8 +11368,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -11379,13 +11379,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.914ms
+        duration: 691.126084ms
     - id: 325
       request:
         proto: HTTP/1.1
@@ -11403,8 +11403,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -11414,13 +11414,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 318.126375ms
+        duration: 575.137709ms
     - id: 326
       request:
         proto: HTTP/1.1
@@ -11438,8 +11438,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -11455,7 +11455,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.047083ms
+        duration: 396.927375ms
     - id: 327
       request:
         proto: HTTP/1.1
@@ -11473,8 +11473,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -11490,7 +11490,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 356.385625ms
+        duration: 439.697667ms
     - id: 328
       request:
         proto: HTTP/1.1
@@ -11508,8 +11508,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -11519,13 +11519,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 337.762625ms
+        status: 403 Forbidden
+        code: 403
+        duration: 328.6555ms
     - id: 329
       request:
         proto: HTTP/1.1
@@ -11543,8 +11543,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -11554,13 +11554,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 328.119958ms
+        duration: 325.342916ms
     - id: 330
       request:
         proto: HTTP/1.1
@@ -11578,8 +11578,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -11589,13 +11589,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.225292ms
+        duration: 394.009583ms
     - id: 331
       request:
         proto: HTTP/1.1
@@ -11613,8 +11613,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -11624,13 +11624,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 518.324709ms
+        duration: 392.042042ms
     - id: 332
       request:
         proto: HTTP/1.1
@@ -11648,8 +11648,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -11659,13 +11659,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.539083ms
+        duration: 331.720333ms
     - id: 333
       request:
         proto: HTTP/1.1
@@ -11683,8 +11683,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -11700,7 +11700,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.788167ms
+        duration: 337.083375ms
     - id: 334
       request:
         proto: HTTP/1.1
@@ -11718,8 +11718,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -11735,7 +11735,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.088625ms
+        duration: 331.651625ms
     - id: 335
       request:
         proto: HTTP/1.1
@@ -11753,8 +11753,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -11764,13 +11764,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 343.68425ms
+        status: 403 Forbidden
+        code: 403
+        duration: 365.204458ms
     - id: 336
       request:
         proto: HTTP/1.1
@@ -11788,8 +11788,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -11799,13 +11799,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.004708ms
+        duration: 343.251167ms
     - id: 337
       request:
         proto: HTTP/1.1
@@ -11823,8 +11823,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -11834,13 +11834,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.283334ms
+        duration: 364.583541ms
     - id: 338
       request:
         proto: HTTP/1.1
@@ -11858,8 +11858,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -11869,13 +11869,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.506458ms
+        duration: 327.59625ms
     - id: 339
       request:
         proto: HTTP/1.1
@@ -11893,8 +11893,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -11904,13 +11904,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.41575ms
+        duration: 375.197375ms
     - id: 340
       request:
         proto: HTTP/1.1
@@ -11928,8 +11928,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -11945,7 +11945,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.299958ms
+        duration: 357.847709ms
     - id: 341
       request:
         proto: HTTP/1.1
@@ -11963,8 +11963,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -11980,7 +11980,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 323.352667ms
+        duration: 342.4395ms
     - id: 342
       request:
         proto: HTTP/1.1
@@ -11998,8 +11998,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -12009,13 +12009,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 344.12ms
+        status: 403 Forbidden
+        code: 403
+        duration: 337.095292ms
     - id: 343
       request:
         proto: HTTP/1.1
@@ -12033,8 +12033,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -12044,13 +12044,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.660708ms
+        duration: 399.589042ms
     - id: 344
       request:
         proto: HTTP/1.1
@@ -12068,8 +12068,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -12079,13 +12079,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.515042ms
+        duration: 327.032334ms
     - id: 345
       request:
         proto: HTTP/1.1
@@ -12103,8 +12103,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -12114,13 +12114,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.189333ms
+        duration: 368.481542ms
     - id: 346
       request:
         proto: HTTP/1.1
@@ -12138,8 +12138,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -12155,7 +12155,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.695958ms
+        duration: 445.682125ms
     - id: 347
       request:
         proto: HTTP/1.1
@@ -12168,14 +12168,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true}
+            {"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -12185,13 +12185,13 @@ interactions:
         trailer: {}
         content_length: 225
         uncompressed: false
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 343.367291ms
+        duration: 342.890416ms
     - id: 348
       request:
         proto: HTTP/1.1
@@ -12209,8 +12209,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -12220,13 +12220,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 349.313167ms
+        duration: 344.068959ms
     - id: 349
       request:
         proto: HTTP/1.1
@@ -12244,8 +12244,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -12255,13 +12255,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.874667ms
+        duration: 338.250834ms
     - id: 350
       request:
         proto: HTTP/1.1
@@ -12279,8 +12279,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -12290,13 +12290,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 349.333125ms
+        duration: 346.513667ms
     - id: 351
       request:
         proto: HTTP/1.1
@@ -12314,8 +12314,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -12331,7 +12331,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.12925ms
+        duration: 377.650833ms
     - id: 352
       request:
         proto: HTTP/1.1
@@ -12349,8 +12349,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -12360,13 +12360,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 337.079709ms
+        status: 403 Forbidden
+        code: 403
+        duration: 342.643834ms
     - id: 353
       request:
         proto: HTTP/1.1
@@ -12384,8 +12384,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -12395,13 +12395,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.216542ms
+        duration: 345.869375ms
     - id: 354
       request:
         proto: HTTP/1.1
@@ -12419,8 +12419,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -12430,13 +12430,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 369.228125ms
+        duration: 426.906125ms
     - id: 355
       request:
         proto: HTTP/1.1
@@ -12454,8 +12454,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -12471,7 +12471,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 328.396375ms
+        duration: 357.384334ms
     - id: 356
       request:
         proto: HTTP/1.1
@@ -12489,8 +12489,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -12500,13 +12500,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 338.464625ms
+        status: 403 Forbidden
+        code: 403
+        duration: 313.93875ms
     - id: 357
       request:
         proto: HTTP/1.1
@@ -12524,8 +12524,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -12535,13 +12535,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.694834ms
+        duration: 342.536041ms
     - id: 358
       request:
         proto: HTTP/1.1
@@ -12559,8 +12559,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -12570,13 +12570,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.663ms
+        duration: 338.690166ms
     - id: 359
       request:
         proto: HTTP/1.1
@@ -12594,8 +12594,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -12605,13 +12605,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 371.465541ms
+        duration: 337.17325ms
     - id: 360
       request:
         proto: HTTP/1.1
@@ -12629,8 +12629,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -12640,13 +12640,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.89075ms
+        duration: 350.159375ms
     - id: 361
       request:
         proto: HTTP/1.1
@@ -12664,8 +12664,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -12675,13 +12675,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 330.330792ms
+        duration: 322.661875ms
     - id: 362
       request:
         proto: HTTP/1.1
@@ -12699,8 +12699,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -12710,13 +12710,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.837708ms
+        duration: 368.000458ms
     - id: 363
       request:
         proto: HTTP/1.1
@@ -12734,8 +12734,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -12751,7 +12751,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 380.737541ms
+        duration: 348.071958ms
     - id: 364
       request:
         proto: HTTP/1.1
@@ -12769,8 +12769,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -12780,13 +12780,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 406.936416ms
+        status: 403 Forbidden
+        code: 403
+        duration: 299.566459ms
     - id: 365
       request:
         proto: HTTP/1.1
@@ -12804,8 +12804,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -12815,13 +12815,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.468708ms
+        duration: 346.953917ms
     - id: 366
       request:
         proto: HTTP/1.1
@@ -12839,8 +12839,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -12850,13 +12850,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.845416ms
+        duration: 423.829958ms
     - id: 367
       request:
         proto: HTTP/1.1
@@ -12874,8 +12874,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -12885,13 +12885,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 375.805ms
+        duration: 696.020833ms
     - id: 368
       request:
         proto: HTTP/1.1
@@ -12909,8 +12909,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -12920,13 +12920,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 382.55375ms
+        duration: 331.960416ms
     - id: 369
       request:
         proto: HTTP/1.1
@@ -12944,8 +12944,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -12955,13 +12955,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 619.680833ms
+        duration: 334.281375ms
     - id: 370
       request:
         proto: HTTP/1.1
@@ -12979,8 +12979,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -12990,13 +12990,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 415.266833ms
+        duration: 373.512292ms
     - id: 371
       request:
         proto: HTTP/1.1
@@ -13014,8 +13014,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -13031,7 +13031,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.020583ms
+        duration: 341.961417ms
     - id: 372
       request:
         proto: HTTP/1.1
@@ -13049,8 +13049,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -13060,13 +13060,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 440.166291ms
+        status: 403 Forbidden
+        code: 403
+        duration: 339.679417ms
     - id: 373
       request:
         proto: HTTP/1.1
@@ -13084,8 +13084,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -13095,13 +13095,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.701917ms
+        duration: 377.061708ms
     - id: 374
       request:
         proto: HTTP/1.1
@@ -13119,8 +13119,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -13130,13 +13130,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.780125ms
+        duration: 377.36075ms
     - id: 375
       request:
         proto: HTTP/1.1
@@ -13154,8 +13154,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -13165,13 +13165,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.774791ms
+        duration: 344.87975ms
     - id: 376
       request:
         proto: HTTP/1.1
@@ -13189,8 +13189,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -13200,13 +13200,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.426458ms
+        duration: 377.840958ms
     - id: 377
       request:
         proto: HTTP/1.1
@@ -13224,8 +13224,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -13235,13 +13235,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.146583ms
+        duration: 330.519667ms
     - id: 378
       request:
         proto: HTTP/1.1
@@ -13259,8 +13259,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -13270,13 +13270,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 371.484417ms
+        duration: 368.840416ms
     - id: 379
       request:
         proto: HTTP/1.1
@@ -13294,8 +13294,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -13311,7 +13311,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 330.2195ms
+        duration: 340.972875ms
     - id: 380
       request:
         proto: HTTP/1.1
@@ -13329,8 +13329,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -13340,13 +13340,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 330.118916ms
+        status: 403 Forbidden
+        code: 403
+        duration: 307.13125ms
     - id: 381
       request:
         proto: HTTP/1.1
@@ -13364,8 +13364,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -13375,13 +13375,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.432666ms
+        duration: 338.698875ms
     - id: 382
       request:
         proto: HTTP/1.1
@@ -13399,8 +13399,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -13410,13 +13410,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 415.393541ms
+        duration: 383.462666ms
     - id: 383
       request:
         proto: HTTP/1.1
@@ -13434,8 +13434,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -13445,13 +13445,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.244333ms
+        duration: 340.648333ms
     - id: 384
       request:
         proto: HTTP/1.1
@@ -13469,8 +13469,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -13480,13 +13480,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 563.360791ms
+        duration: 336.981834ms
     - id: 385
       request:
         proto: HTTP/1.1
@@ -13504,8 +13504,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -13521,7 +13521,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 364.235417ms
+        duration: 339.977459ms
     - id: 386
       request:
         proto: HTTP/1.1
@@ -13534,14 +13534,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false}
+            {"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -13551,13 +13551,13 @@ interactions:
         trailer: {}
         content_length: 226
         uncompressed: false
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 391.798333ms
+        duration: 327.91825ms
     - id: 387
       request:
         proto: HTTP/1.1
@@ -13575,8 +13575,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -13586,13 +13586,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 378.222125ms
+        duration: 368.218041ms
     - id: 388
       request:
         proto: HTTP/1.1
@@ -13610,8 +13610,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -13621,13 +13621,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 383.0255ms
+        duration: 310.878833ms
     - id: 389
       request:
         proto: HTTP/1.1
@@ -13645,8 +13645,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -13656,13 +13656,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 446.06725ms
+        duration: 343.208709ms
     - id: 390
       request:
         proto: HTTP/1.1
@@ -13680,8 +13680,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -13697,7 +13697,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.281708ms
+        duration: 346.6315ms
     - id: 391
       request:
         proto: HTTP/1.1
@@ -13715,8 +13715,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -13726,13 +13726,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 343.562042ms
+        status: 403 Forbidden
+        code: 403
+        duration: 330.242625ms
     - id: 392
       request:
         proto: HTTP/1.1
@@ -13750,8 +13750,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -13761,13 +13761,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 411.049583ms
+        duration: 334.319125ms
     - id: 393
       request:
         proto: HTTP/1.1
@@ -13785,8 +13785,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -13796,13 +13796,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 476.373458ms
+        duration: 352.041ms
     - id: 394
       request:
         proto: HTTP/1.1
@@ -13820,8 +13820,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -13837,7 +13837,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.135542ms
+        duration: 353.229708ms
     - id: 395
       request:
         proto: HTTP/1.1
@@ -13855,8 +13855,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -13866,13 +13866,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 329.9885ms
+        status: 403 Forbidden
+        code: 403
+        duration: 385.368042ms
     - id: 396
       request:
         proto: HTTP/1.1
@@ -13890,8 +13890,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -13901,13 +13901,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 336.867042ms
+        duration: 344.385333ms
     - id: 397
       request:
         proto: HTTP/1.1
@@ -13925,8 +13925,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -13936,13 +13936,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.43625ms
+        duration: 329.844583ms
     - id: 398
       request:
         proto: HTTP/1.1
@@ -13960,8 +13960,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -13971,13 +13971,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 368.801417ms
+        duration: 432.131333ms
     - id: 399
       request:
         proto: HTTP/1.1
@@ -13995,8 +13995,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14006,13 +14006,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 385.101ms
+        duration: 383.409208ms
     - id: 400
       request:
         proto: HTTP/1.1
@@ -14030,8 +14030,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -14041,13 +14041,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.97075ms
+        duration: 326.877084ms
     - id: 401
       request:
         proto: HTTP/1.1
@@ -14065,8 +14065,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14076,13 +14076,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.079333ms
+        duration: 377.610791ms
     - id: 402
       request:
         proto: HTTP/1.1
@@ -14100,8 +14100,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14117,7 +14117,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.534ms
+        duration: 376.7875ms
     - id: 403
       request:
         proto: HTTP/1.1
@@ -14135,8 +14135,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -14146,13 +14146,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 364.125583ms
+        status: 403 Forbidden
+        code: 403
+        duration: 458.974ms
     - id: 404
       request:
         proto: HTTP/1.1
@@ -14170,8 +14170,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -14181,13 +14181,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.318417ms
+        duration: 355.343917ms
     - id: 405
       request:
         proto: HTTP/1.1
@@ -14205,8 +14205,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -14216,13 +14216,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.261791ms
+        duration: 466.202959ms
     - id: 406
       request:
         proto: HTTP/1.1
@@ -14240,8 +14240,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -14251,13 +14251,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 406.516708ms
+        duration: 386.663916ms
     - id: 407
       request:
         proto: HTTP/1.1
@@ -14275,8 +14275,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14286,13 +14286,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 375.105708ms
+        duration: 354.763959ms
     - id: 408
       request:
         proto: HTTP/1.1
@@ -14310,8 +14310,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -14321,13 +14321,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.608375ms
+        duration: 350.196667ms
     - id: 409
       request:
         proto: HTTP/1.1
@@ -14345,8 +14345,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14356,13 +14356,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.380959ms
+        duration: 358.506375ms
     - id: 410
       request:
         proto: HTTP/1.1
@@ -14380,8 +14380,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14397,7 +14397,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.927042ms
+        duration: 344.364417ms
     - id: 411
       request:
         proto: HTTP/1.1
@@ -14415,8 +14415,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -14426,13 +14426,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 469.877375ms
+        status: 403 Forbidden
+        code: 403
+        duration: 337.794125ms
     - id: 412
       request:
         proto: HTTP/1.1
@@ -14450,8 +14450,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -14461,13 +14461,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.279959ms
+        duration: 348.099458ms
     - id: 413
       request:
         proto: HTTP/1.1
@@ -14485,8 +14485,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -14496,13 +14496,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 384.318833ms
+        duration: 347.954958ms
     - id: 414
       request:
         proto: HTTP/1.1
@@ -14520,8 +14520,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -14531,13 +14531,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.458083ms
+        duration: 381.268208ms
     - id: 415
       request:
         proto: HTTP/1.1
@@ -14555,8 +14555,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14566,13 +14566,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.043833ms
+        duration: 352.701292ms
     - id: 416
       request:
         proto: HTTP/1.1
@@ -14590,8 +14590,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -14601,13 +14601,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 961.445917ms
+        duration: 345.477541ms
     - id: 417
       request:
         proto: HTTP/1.1
@@ -14625,8 +14625,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14636,13 +14636,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.073333ms
+        duration: 414.891416ms
     - id: 418
       request:
         proto: HTTP/1.1
@@ -14660,8 +14660,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14677,7 +14677,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.533791ms
+        duration: 335.341958ms
     - id: 419
       request:
         proto: HTTP/1.1
@@ -14695,8 +14695,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -14706,13 +14706,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 407.610541ms
+        status: 403 Forbidden
+        code: 403
+        duration: 302.420667ms
     - id: 420
       request:
         proto: HTTP/1.1
@@ -14730,8 +14730,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -14741,13 +14741,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.275625ms
+        duration: 341.714958ms
     - id: 421
       request:
         proto: HTTP/1.1
@@ -14765,8 +14765,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14776,13 +14776,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.960416ms
+        duration: 345.540709ms
     - id: 422
       request:
         proto: HTTP/1.1
@@ -14800,8 +14800,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -14811,13 +14811,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.01ms
+        duration: 347.197459ms
     - id: 423
       request:
         proto: HTTP/1.1
@@ -14835,8 +14835,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -14846,13 +14846,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.64025ms
+        duration: 318.675ms
     - id: 424
       request:
         proto: HTTP/1.1
@@ -14870,8 +14870,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -14881,13 +14881,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.898625ms
+        duration: 328.03075ms
     - id: 425
       request:
         proto: HTTP/1.1
@@ -14905,8 +14905,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14916,13 +14916,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
+        body: '{"enabled_connections":[{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":1,"total":1}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.869375ms
+        duration: 327.366291ms
     - id: 426
       request:
         proto: HTTP/1.1
@@ -14940,8 +14940,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -14957,7 +14957,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.790708ms
+        duration: 336.852416ms
     - id: 427
       request:
         proto: HTTP/1.1
@@ -14975,8 +14975,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -14986,13 +14986,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 333.477208ms
+        status: 403 Forbidden
+        code: 403
+        duration: 333.104125ms
     - id: 428
       request:
         proto: HTTP/1.1
@@ -15010,8 +15010,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -15027,7 +15027,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 531.029584ms
+        duration: 350.337583ms
     - id: 429
       request:
         proto: HTTP/1.1
@@ -15045,8 +15045,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -15056,13 +15056,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.602625ms
+        duration: 353.126917ms
     - id: 430
       request:
         proto: HTTP/1.1
@@ -15080,8 +15080,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -15097,7 +15097,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 380.86825ms
+        duration: 346.272583ms
     - id: 431
       request:
         proto: HTTP/1.1
@@ -15115,8 +15115,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -15132,7 +15132,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.458542ms
+        duration: 377.464375ms
     - id: 432
       request:
         proto: HTTP/1.1
@@ -15150,8 +15150,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -15161,13 +15161,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 337.972417ms
+        status: 403 Forbidden
+        code: 403
+        duration: 309.197542ms
     - id: 433
       request:
         proto: HTTP/1.1
@@ -15185,8 +15185,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -15196,13 +15196,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 632.688542ms
+        duration: 359.563834ms
     - id: 434
       request:
         proto: HTTP/1.1
@@ -15220,8 +15220,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -15231,13 +15231,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 407.609167ms
+        duration: 432.168583ms
     - id: 435
       request:
         proto: HTTP/1.1
@@ -15255,8 +15255,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -15266,13 +15266,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 321.151166ms
+        duration: 393.235041ms
     - id: 436
       request:
         proto: HTTP/1.1
@@ -15290,8 +15290,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -15301,13 +15301,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 501.655959ms
+        duration: 323.063333ms
     - id: 437
       request:
         proto: HTTP/1.1
@@ -15325,8 +15325,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -15342,7 +15342,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.495541ms
+        duration: 330.807833ms
     - id: 438
       request:
         proto: HTTP/1.1
@@ -15360,8 +15360,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -15377,7 +15377,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.097959ms
+        duration: 357.012042ms
     - id: 439
       request:
         proto: HTTP/1.1
@@ -15395,8 +15395,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -15406,13 +15406,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 408.532625ms
+        status: 403 Forbidden
+        code: 403
+        duration: 326.634542ms
     - id: 440
       request:
         proto: HTTP/1.1
@@ -15430,8 +15430,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -15441,13 +15441,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 423.35575ms
+        duration: 339.222917ms
     - id: 441
       request:
         proto: HTTP/1.1
@@ -15465,8 +15465,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -15476,13 +15476,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.781083ms
+        duration: 367.555959ms
     - id: 442
       request:
         proto: HTTP/1.1
@@ -15500,8 +15500,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -15511,13 +15511,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.944334ms
+        duration: 341.433291ms
     - id: 443
       request:
         proto: HTTP/1.1
@@ -15535,8 +15535,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -15546,13 +15546,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 403.4665ms
+        duration: 432.751917ms
     - id: 444
       request:
         proto: HTTP/1.1
@@ -15570,8 +15570,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -15587,7 +15587,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 383.090459ms
+        duration: 357.210834ms
     - id: 445
       request:
         proto: HTTP/1.1
@@ -15605,8 +15605,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -15622,7 +15622,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 330.955542ms
+        duration: 353.6475ms
     - id: 446
       request:
         proto: HTTP/1.1
@@ -15640,8 +15640,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -15651,13 +15651,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 353.380167ms
+        status: 403 Forbidden
+        code: 403
+        duration: 320.984208ms
     - id: 447
       request:
         proto: HTTP/1.1
@@ -15675,8 +15675,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -15686,13 +15686,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.314209ms
+        duration: 366.4935ms
     - id: 448
       request:
         proto: HTTP/1.1
@@ -15710,8 +15710,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -15721,13 +15721,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 357.209959ms
+        duration: 325.110667ms
     - id: 449
       request:
         proto: HTTP/1.1
@@ -15745,8 +15745,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -15756,13 +15756,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.977833ms
+        duration: 338.879834ms
     - id: 450
       request:
         proto: HTTP/1.1
@@ -15780,8 +15780,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -15791,13 +15791,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 452.996458ms
+        duration: 330.096834ms
     - id: 451
       request:
         proto: HTTP/1.1
@@ -15815,8 +15815,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -15832,7 +15832,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 409.458292ms
+        duration: 374.021167ms
     - id: 452
       request:
         proto: HTTP/1.1
@@ -15850,8 +15850,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -15867,7 +15867,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 407.594209ms
+        duration: 367.064125ms
     - id: 453
       request:
         proto: HTTP/1.1
@@ -15885,8 +15885,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -15896,13 +15896,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 396.395792ms
+        status: 403 Forbidden
+        code: 403
+        duration: 380.61825ms
     - id: 454
       request:
         proto: HTTP/1.1
@@ -15920,8 +15920,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -15931,13 +15931,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 459.772875ms
+        duration: 338.168542ms
     - id: 455
       request:
         proto: HTTP/1.1
@@ -15955,8 +15955,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -15966,13 +15966,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 389.26325ms
+        duration: 350.685042ms
     - id: 456
       request:
         proto: HTTP/1.1
@@ -15990,8 +15990,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -16001,13 +16001,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 388.105458ms
+        duration: 471.731292ms
     - id: 457
       request:
         proto: HTTP/1.1
@@ -16020,14 +16020,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true}
+            {"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -16037,13 +16037,13 @@ interactions:
         trailer: {}
         content_length: 226
         uncompressed: false
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 398.950125ms
+        duration: 399.059708ms
     - id: 458
       request:
         proto: HTTP/1.1
@@ -16061,8 +16061,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -16072,13 +16072,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 384.72575ms
+        duration: 320.443541ms
     - id: 459
       request:
         proto: HTTP/1.1
@@ -16091,14 +16091,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true}
+            {"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections
         method: POST
       response:
         proto: HTTP/2.0
@@ -16108,13 +16108,13 @@ interactions:
         trailer: {}
         content_length: 207
         uncompressed: false
-        body: '{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
+        body: '{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 365.34875ms
+        duration: 338.997333ms
     - id: 460
       request:
         proto: HTTP/1.1
@@ -16132,8 +16132,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -16143,13 +16143,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
+        body: '{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 474.549916ms
+        duration: 386.574375ms
     - id: 461
       request:
         proto: HTTP/1.1
@@ -16167,8 +16167,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -16178,13 +16178,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.69175ms
+        duration: 538.633625ms
     - id: 462
       request:
         proto: HTTP/1.1
@@ -16202,8 +16202,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -16213,13 +16213,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 409.67125ms
+        duration: 346.3785ms
     - id: 463
       request:
         proto: HTTP/1.1
@@ -16237,8 +16237,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -16248,13 +16248,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.224263958s
+        duration: 349.697708ms
     - id: 464
       request:
         proto: HTTP/1.1
@@ -16272,8 +16272,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -16283,13 +16283,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.947959ms
+        duration: 328.749792ms
     - id: 465
       request:
         proto: HTTP/1.1
@@ -16307,8 +16307,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -16318,13 +16318,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
+        body: '{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 460.943291ms
+        duration: 375.75925ms
     - id: 466
       request:
         proto: HTTP/1.1
@@ -16342,8 +16342,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -16353,13 +16353,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.038208ms
+        duration: 345.284667ms
     - id: 467
       request:
         proto: HTTP/1.1
@@ -16377,8 +16377,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -16388,13 +16388,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.486083ms
+        duration: 328.473583ms
     - id: 468
       request:
         proto: HTTP/1.1
@@ -16412,8 +16412,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -16423,13 +16423,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 424.54775ms
+        duration: 431.001541ms
     - id: 469
       request:
         proto: HTTP/1.1
@@ -16447,8 +16447,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -16464,7 +16464,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 406.042ms
+        duration: 317.722167ms
     - id: 470
       request:
         proto: HTTP/1.1
@@ -16482,8 +16482,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -16493,13 +16493,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 371.998333ms
+        status: 403 Forbidden
+        code: 403
+        duration: 310.480917ms
     - id: 471
       request:
         proto: HTTP/1.1
@@ -16517,8 +16517,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -16528,13 +16528,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.767458ms
+        duration: 353.384208ms
     - id: 472
       request:
         proto: HTTP/1.1
@@ -16552,8 +16552,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -16563,13 +16563,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 391.285ms
+        duration: 327.765875ms
     - id: 473
       request:
         proto: HTTP/1.1
@@ -16587,8 +16587,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -16598,13 +16598,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.463125ms
+        duration: 325.844666ms
     - id: 474
       request:
         proto: HTTP/1.1
@@ -16622,8 +16622,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -16633,13 +16633,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.794583ms
+        duration: 349.491792ms
     - id: 475
       request:
         proto: HTTP/1.1
@@ -16657,8 +16657,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -16668,13 +16668,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 527.816833ms
+        duration: 361.281667ms
     - id: 476
       request:
         proto: HTTP/1.1
@@ -16692,8 +16692,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -16703,13 +16703,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.56875ms
+        duration: 328.969416ms
     - id: 477
       request:
         proto: HTTP/1.1
@@ -16727,8 +16727,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -16738,13 +16738,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.018959ms
+        duration: 347.680458ms
     - id: 478
       request:
         proto: HTTP/1.1
@@ -16762,8 +16762,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -16773,13 +16773,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 398.26325ms
+        duration: 383.015583ms
     - id: 479
       request:
         proto: HTTP/1.1
@@ -16797,8 +16797,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -16814,7 +16814,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 407.965375ms
+        duration: 330.688417ms
     - id: 480
       request:
         proto: HTTP/1.1
@@ -16832,8 +16832,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -16843,13 +16843,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 411.583584ms
+        status: 403 Forbidden
+        code: 403
+        duration: 312.205125ms
     - id: 481
       request:
         proto: HTTP/1.1
@@ -16867,8 +16867,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -16878,13 +16878,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.919ms
+        duration: 349.817584ms
     - id: 482
       request:
         proto: HTTP/1.1
@@ -16902,8 +16902,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -16913,13 +16913,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.541667ms
+        duration: 368.451458ms
     - id: 483
       request:
         proto: HTTP/1.1
@@ -16937,8 +16937,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -16954,7 +16954,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.513792ms
+        duration: 374.533166ms
     - id: 484
       request:
         proto: HTTP/1.1
@@ -16972,8 +16972,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -16983,13 +16983,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 447.152791ms
+        status: 403 Forbidden
+        code: 403
+        duration: 342.296625ms
     - id: 485
       request:
         proto: HTTP/1.1
@@ -17007,8 +17007,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -17018,13 +17018,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_7Ys4WX2IP8FNuMN7","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_x2eMWPyj74cIPY66","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-DB-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 412.118083ms
+        duration: 337.193875ms
     - id: 486
       request:
         proto: HTTP/1.1
@@ -17042,8 +17042,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -17053,13 +17053,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_ZR1gVd2o5zDVZzhR","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
+        body: '{"id":"con_eF58BsNR5zEhazKa","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","is_domain_connection":false,"show_as_button":false,"display_name":"testaccorganizationconnections","enabled_clients":[],"realms":["Acceptance-Test-Enterprise-Connection-testaccorganizationconnections"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400.28375ms
+        duration: 349.29825ms
     - id: 487
       request:
         proto: HTTP/1.1
@@ -17077,8 +17077,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -17088,13 +17088,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.480334ms
+        duration: 355.400334ms
     - id: 488
       request:
         proto: HTTP/1.1
@@ -17112,8 +17112,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: GET
       response:
         proto: HTTP/2.0
@@ -17123,13 +17123,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
+        body: '{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 435.726875ms
+        duration: 348.023166ms
     - id: 489
       request:
         proto: HTTP/1.1
@@ -17147,8 +17147,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -17158,13 +17158,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 435.054875ms
+        duration: 358.305083ms
     - id: 490
       request:
         proto: HTTP/1.1
@@ -17182,8 +17182,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: GET
       response:
         proto: HTTP/2.0
@@ -17193,13 +17193,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"org_gAovmvcsx3u3w9en","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
+        body: '{"id":"org_WR7N8vvOOkqT7W3t","name":"some-org-testaccorganizationconnections","display_name":"testaccorganizationconnections"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 322.794666ms
+        duration: 342.117ms
     - id: 491
       request:
         proto: HTTP/1.1
@@ -17217,8 +17217,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_eF58BsNR5zEhazKa
         method: GET
       response:
         proto: HTTP/2.0
@@ -17228,13 +17228,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
+        body: '{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.566333ms
+        duration: 364.953333ms
     - id: 492
       request:
         proto: HTTP/1.1
@@ -17252,8 +17252,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections?include_totals=true&page=0&per_page=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections?include_totals=true&page=0&per_page=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -17263,13 +17263,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_connections":[{"connection_id":"con_7Ys4WX2IP8FNuMN7","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}},{"connection_id":"con_ZR1gVd2o5zDVZzhR","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}}],"start":0,"limit":2,"total":2}'
+        body: '{"enabled_connections":[{"connection_id":"con_eF58BsNR5zEhazKa","assign_membership_on_login":true,"show_as_button":true,"connection":{"name":"Acceptance-Test-Enterprise-Connection-testaccorganizationconnections","strategy":"okta"}},{"connection_id":"con_x2eMWPyj74cIPY66","assign_membership_on_login":true,"is_signup_enabled":false,"show_as_button":true,"connection":{"name":"Acceptance-Test-DB-Connection-testaccorganizationconnections","strategy":"auth0"}}],"start":0,"limit":2,"total":2}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 387.296584ms
+        duration: 323.671791ms
     - id: 493
       request:
         proto: HTTP/1.1
@@ -17287,8 +17287,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
         method: GET
       response:
         proto: HTTP/2.0
@@ -17304,7 +17304,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.395167ms
+        duration: 334.115333ms
     - id: 494
       request:
         proto: HTTP/1.1
@@ -17322,8 +17322,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/client-grants?include_totals=true&per_page=50
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/client-grants?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -17333,13 +17333,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 377.657083ms
+        status: 403 Forbidden
+        code: 403
+        duration: 335.135542ms
     - id: 495
       request:
         proto: HTTP/1.1
@@ -17357,8 +17357,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_eF58BsNR5zEhazKa
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -17374,7 +17374,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 329.155708ms
+        duration: 326.977375ms
     - id: 496
       request:
         proto: HTTP/1.1
@@ -17392,8 +17392,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_eF58BsNR5zEhazKa
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -17409,7 +17409,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 341.741833ms
+        duration: 455.326166ms
     - id: 497
       request:
         proto: HTTP/1.1
@@ -17427,8 +17427,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -17444,7 +17444,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 321.655875ms
+        duration: 353.234959ms
     - id: 498
       request:
         proto: HTTP/1.1
@@ -17462,8 +17462,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en/enabled_connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t/enabled_connections/con_x2eMWPyj74cIPY66
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -17479,7 +17479,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 337.245083ms
+        duration: 324.572209ms
     - id: 499
       request:
         proto: HTTP/1.1
@@ -17497,8 +17497,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_gAovmvcsx3u3w9en
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_WR7N8vvOOkqT7W3t
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -17514,7 +17514,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 442.632291ms
+        duration: 315.457208ms
     - id: 500
       request:
         proto: HTTP/1.1
@@ -17532,8 +17532,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZR1gVd2o5zDVZzhR
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_eF58BsNR5zEhazKa
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -17543,13 +17543,13 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2024-09-23T06:23:51.076Z"}'
+        body: '{"deleted_at":"2025-05-05T15:01:44.309Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 381.447417ms
+        duration: 344.020417ms
     - id: 501
       request:
         proto: HTTP/1.1
@@ -17567,8 +17567,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_7Ys4WX2IP8FNuMN7
+                - Go-Auth0/1.19.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_x2eMWPyj74cIPY66
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -17578,10 +17578,10 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2024-09-23T06:23:51.457Z"}'
+        body: '{"deleted_at":"2025-05-05T15:01:44.871Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 337.4725ms
+        duration: 547.124125ms

--- a/test/data/recordings/TestAccSCIMConfiguration.yaml
+++ b/test/data/recordings/TestAccSCIMConfiguration.yaml
@@ -18,7 +18,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
+                - Go-Auth0/1.20.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_xxxxxxxxxxxxxxxx/scim-configuration
         method: POST
       response:
@@ -35,7 +35,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 404 Not Found
         code: 404
-        duration: 232.29625ms
+        duration: 390.905ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -54,7 +54,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
+                - Go-Auth0/1.20.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -63,15 +63,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 448
+        content_length: 643
         uncompressed: false
-        body: '{"id":"con_LjpuhLN7TudbLvJT","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"display_name":"Acceptance-Test-Non-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_nuuGKdCBu48DXrX3","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"display_name":"Acceptance-Test-Non-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 224.032292ms
+        duration: 327.343083ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -89,8 +89,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LjpuhLN7TudbLvJT
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_nuuGKdCBu48DXrX3
         method: GET
       response:
         proto: HTTP/2.0
@@ -100,13 +100,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_LjpuhLN7TudbLvJT","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"display_name":"Acceptance-Test-Non-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_nuuGKdCBu48DXrX3","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"display_name":"Acceptance-Test-Non-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 260.203583ms
+        duration: 319.035583ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -124,8 +124,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LjpuhLN7TudbLvJT/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_nuuGKdCBu48DXrX3/scim-configuration
         method: POST
       response:
         proto: HTTP/2.0
@@ -135,13 +135,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"statusCode":404,"error":"Not Found","message":"scim strategy not enabled"}'
+        body: '{"statusCode":404,"error":"Not Found","message":"This connection type does not support SCIM. Please see our documentation for the currently supported connection types: https://auth0.com/docs/authenticate/protocols/scim/configure-inbound-scim."}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 404 Not Found
         code: 404
-        duration: 244.838667ms
+        duration: 337.070459ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -159,8 +159,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LjpuhLN7TudbLvJT
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_nuuGKdCBu48DXrX3
         method: GET
       response:
         proto: HTTP/2.0
@@ -170,50 +170,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_LjpuhLN7TudbLvJT","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"display_name":"Acceptance-Test-Non-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_nuuGKdCBu48DXrX3","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"display_name":"Acceptance-Test-Non-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-Non-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 246.823417ms
+        duration: 345.4455ms
     - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 455
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","strategy":"okta","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token"}}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 761
-        uncompressed: false
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 201 Created
-        code: 201
-        duration: 314.66475ms
-    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -230,8 +194,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LjpuhLN7TudbLvJT
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_nuuGKdCBu48DXrX3
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -241,13 +205,49 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2024-07-17T18:27:43.762Z"}'
+        body: '{"deleted_at":"2025-05-06T04:11:00.978Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 314.728459ms
+        duration: 375.32225ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 486
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","strategy":"okta","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","scope":"email openid profile"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 792
+        uncompressed: false
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"client_id":"1234567","client_secret":"1234567","authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","userinfo_endpoint":null,"token_endpoint":"https://example.okta.com/oauth2/v1/token","scope":"email openid profile","schema_version":"oidc-V4","type":"back_channel","attribute_map":{"mapping_mode":"basic_profile"},"connection_settings":{"pkce":"auto"}},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 491.5625ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -265,8 +265,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,13 +276,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 205.551875ms
+        duration: 359.9065ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -300,8 +300,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: POST
       response:
         proto: HTTP/2.0
@@ -311,13 +311,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:44.297Z","created_at":"2024-07-17T18:27:44.297Z","user_id_attribute":"externalId"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:11:01.831Z","created_at":"2025-05-06T04:11:01.831Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 237.649792ms
+        duration: 344.062291ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -335,8 +335,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -346,13 +346,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:44.297Z","created_at":"2024-07-17T18:27:44.297Z","user_id_attribute":"externalId"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:11:01.831Z","created_at":"2025-05-06T04:11:01.831Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 293.6415ms
+        duration: 361.199416ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -370,8 +370,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: GET
       response:
         proto: HTTP/2.0
@@ -381,13 +381,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 215.382042ms
+        duration: 335.754834ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -405,8 +405,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -416,13 +416,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:44.297Z","created_at":"2024-07-17T18:27:44.297Z","user_id_attribute":"externalId"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:11:01.831Z","created_at":"2025-05-06T04:11:01.831Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 313.026791ms
+        duration: 337.004584ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -440,8 +440,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -451,13 +451,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:11:01.831Z","created_at":"2025-05-06T04:11:01.831Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 216.812125ms
+        duration: 349.521666ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -475,8 +475,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: GET
       response:
         proto: HTTP/2.0
@@ -486,13 +486,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:44.297Z","created_at":"2024-07-17T18:27:44.297Z","user_id_attribute":"externalId"}'
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 252.208083ms
+        duration: 366.306708ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -510,8 +510,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -521,13 +521,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2024-07-17T18:27:44.297Z","created_at":"2024-07-17T18:27:44.297Z","user_id_attribute":"externalId"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"userName","auth0":"preferred_username"},{"scim":"emails[primary eq true].value","auth0":"email"},{"scim":"externalId","auth0":"app_metadata.external_id"},{"scim":"active","auth0":"blocked"},{"scim":"displayName","auth0":"name"},{"scim":"name.givenName","auth0":"given_name"},{"scim":"name.familyName","auth0":"family_name"},{"scim":"name.middleName","auth0":"app_metadata.middle_name"},{"scim":"name.honorificPrefix","auth0":"app_metadata.honorific_prefix"},{"scim":"name.honorificSuffix","auth0":"app_metadata.honorific_suffix"},{"scim":"nickName","auth0":"nickname"},{"scim":"photos[type eq \"photo\"].value","auth0":"picture"},{"scim":"phoneNumbers[primary eq true].value","auth0":"app_metadata.primary_phone_number"},{"scim":"phoneNumbers[type eq \"mobile\"].value","auth0":"app_metadata.mobile_phone_number"},{"scim":"addresses[type eq \"work\"].streetAddress","auth0":"app_metadata.street_address"},{"scim":"addresses[type eq \"work\"].locality","auth0":"app_metadata.city"},{"scim":"addresses[type eq \"work\"].region","auth0":"app_metadata.state"},{"scim":"addresses[type eq \"work\"].postalCode","auth0":"app_metadata.postal_code"},{"scim":"addresses[type eq \"work\"].formatted","auth0":"app_metadata.postal_address"},{"scim":"addresses[type eq \"work\"].country","auth0":"app_metadata.country"},{"scim":"profileUrl","auth0":"app_metadata.profile_url"},{"scim":"userType","auth0":"app_metadata.user_type"},{"scim":"title","auth0":"app_metadata.title"},{"scim":"preferredLanguage","auth0":"app_metadata.language"},{"scim":"locale","auth0":"app_metadata.locale"},{"scim":"timezone","auth0":"app_metadata.timezone"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.employeeNumber","auth0":"app_metadata.employee_id"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.costCenter","auth0":"app_metadata.cost_center"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.organization","auth0":"app_metadata.organization"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.division","auth0":"app_metadata.division"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.department","auth0":"app_metadata.department"},{"scim":"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.manager","auth0":"app_metadata.manager"}],"updated_on":"2025-05-06T04:11:01.831Z","created_at":"2025-05-06T04:11:01.831Z","user_id_attribute":"externalId"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 268.976708ms
+        duration: 361.313167ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -545,8 +545,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration/default-mapping
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration/default-mapping
         method: GET
       response:
         proto: HTTP/2.0
@@ -562,7 +562,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 231.159375ms
+        duration: 357.328584ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -580,8 +580,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -592,12 +592,10 @@ interactions:
         content_length: 0
         uncompressed: false
         body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
+        headers: {}
         status: 204 No Content
         code: 204
-        duration: 328.67125ms
+        duration: 329.24625ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -615,8 +613,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -632,7 +630,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 404 Not Found
         code: 404
-        duration: 215.8985ms
+        duration: 345.610166ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -650,8 +648,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: GET
       response:
         proto: HTTP/2.0
@@ -661,13 +659,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.74475ms
+        duration: 334.73975ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -686,8 +684,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: POST
       response:
         proto: HTTP/2.0
@@ -695,15 +693,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 410
+        content_length: 383
         uncompressed: false
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim_1","auth0":"attr_auth0_1"},{"scim":"scim_2","auth0":"attr_auth0_2"}],"updated_on":"2024-07-17T18:27:49.770Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim_1","auth0":"attr_auth0_1"},{"scim":"scim_2","auth0":"attr_auth0_2"}],"updated_on":"2025-05-06T04:11:08.562Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 286.612208ms
+        duration: 355.110959ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -721,8 +719,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -732,13 +730,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim_1","auth0":"attr_auth0_1"},{"scim":"scim_2","auth0":"attr_auth0_2"}],"updated_on":"2024-07-17T18:27:49.770Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim_1","auth0":"attr_auth0_1"},{"scim":"scim_2","auth0":"attr_auth0_2"}],"updated_on":"2025-05-06T04:11:08.562Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 211.081833ms
+        duration: 333.457125ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -756,8 +754,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: GET
       response:
         proto: HTTP/2.0
@@ -767,13 +765,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 328.226209ms
+        duration: 319.845541ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -791,8 +789,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -802,13 +800,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim_1","auth0":"attr_auth0_1"},{"scim":"scim_2","auth0":"attr_auth0_2"}],"updated_on":"2024-07-17T18:27:49.770Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim_1","auth0":"attr_auth0_1"},{"scim":"scim_2","auth0":"attr_auth0_2"}],"updated_on":"2025-05-06T04:11:08.562Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 208.361333ms
+        duration: 338.556333ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -826,8 +824,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: GET
       response:
         proto: HTTP/2.0
@@ -837,13 +835,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 225.161292ms
+        duration: 404.264375ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -861,8 +859,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -872,13 +870,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim_1","auth0":"attr_auth0_1"},{"scim":"scim_2","auth0":"attr_auth0_2"}],"updated_on":"2024-07-17T18:27:49.770Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim_1","auth0":"attr_auth0_1"},{"scim":"scim_2","auth0":"attr_auth0_2"}],"updated_on":"2025-05-06T04:11:08.562Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 237.979875ms
+        duration: 390.259542ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -897,8 +895,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -908,13 +906,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2024-07-17T18:27:52.595Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2025-05-06T04:11:12.282Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.7985ms
+        duration: 371.163417ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -932,8 +930,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -943,13 +941,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2024-07-17T18:27:52.595Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2025-05-06T04:11:12.282Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 217.921667ms
+        duration: 347.9715ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -967,8 +965,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: GET
       response:
         proto: HTTP/2.0
@@ -978,13 +976,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 220.837708ms
+        duration: 379.859958ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1002,8 +1000,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -1013,13 +1011,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2024-07-17T18:27:52.595Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2025-05-06T04:11:12.282Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 221.667625ms
+        duration: 364.498834ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1037,8 +1035,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: GET
       response:
         proto: HTTP/2.0
@@ -1048,13 +1046,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 235.049708ms
+        duration: 351.338625ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1072,8 +1070,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -1083,13 +1081,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2024-07-17T18:27:52.595Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2025-05-06T04:11:12.282Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 220.020708ms
+        duration: 333.92475ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1108,8 +1106,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1119,13 +1117,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2024-07-17T18:27:55.590Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"modified_test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2025-05-06T04:11:15.937Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"modified_test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 228.995292ms
+        duration: 341.991417ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1143,8 +1141,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -1154,13 +1152,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2024-07-17T18:27:55.590Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"modified_test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2025-05-06T04:11:15.937Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"modified_test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 212.305ms
+        duration: 360.179583ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1178,8 +1176,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: GET
       response:
         proto: HTTP/2.0
@@ -1189,13 +1187,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 218.38325ms
+        duration: 334.971542ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1213,8 +1211,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -1224,13 +1222,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2024-07-17T18:27:55.590Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"modified_test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2025-05-06T04:11:15.937Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"modified_test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 219.429375ms
+        duration: 348.0465ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1248,8 +1246,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: GET
       response:
         proto: HTTP/2.0
@@ -1259,13 +1257,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_qiOVg5E84TQLWQC5","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2024-07-17T18:27:55.590Z","created_at":"2024-07-17T18:27:49.770Z","user_id_attribute":"modified_test_attribute"}'
+        body: '{"tenant_name":"terraform-provider-auth0-dev","connection_id":"con_mVCaBewj77K7HKZS","connection_name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","strategy":"okta","mapping":[{"scim":"scim","auth0":"attr_auth0"}],"updated_on":"2025-05-06T04:11:15.937Z","created_at":"2025-05-06T04:11:08.562Z","user_id_attribute":"modified_test_attribute"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 212.043416ms
+        duration: 334.122ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1283,8 +1281,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: GET
       response:
         proto: HTTP/2.0
@@ -1294,13 +1292,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 227.826541ms
+        duration: 347.89725ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1318,8 +1316,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5/scim-configuration
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS/scim-configuration
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1330,12 +1328,10 @@ interactions:
         content_length: 0
         uncompressed: false
         body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
+        headers: {}
         status: 204 No Content
         code: 204
-        duration: 358.406833ms
+        duration: 357.843792ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1353,8 +1349,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: GET
       response:
         proto: HTTP/2.0
@@ -1364,13 +1360,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_qiOVg5E84TQLWQC5","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
+        body: '{"id":"con_mVCaBewj77K7HKZS","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration","is_domain_connection":false,"show_as_button":false,"display_name":"Acceptance-Test-SCIM-TestAccSCIMConfiguration","enabled_clients":[],"realms":["Acceptance-Test-SCIM-Connection-TestAccSCIMConfiguration"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 195.3705ms
+        duration: 320.197208ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1388,8 +1384,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_qiOVg5E84TQLWQC5
+                - Go-Auth0/1.20.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mVCaBewj77K7HKZS
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1399,10 +1395,10 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2024-07-17T18:27:59.263Z"}'
+        body: '{"deleted_at":"2025-05-06T04:11:20.847Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 224.335541ms
+        duration: 340.506917ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Sometime in October 2023, the behavior of the Auth0 API changed. It used to automatically set the scopes `openid` and `profile` for all new Okta Workforce enterprise connections (the `okta` strategy).

The API simply stopped doing that - there is no docs to support this claim other than evidence (personal and other folks in the linked GitHub issue).

This change makes it so that the engineer making changes will see the error instead of their customers...

Creating an Okta workforce without the `openid` claim results in anyone trying to authenticate with this connection seeing the error:

```
Cannot read properties of undefined (reading 'trim')
```

Here's a screenshot from one of my very-unhappy customers:

![image](https://github.com/auth0/terraform-provider-auth0/assets/16856511/df1e4a5f-452f-4c4f-ab9f-8d5e6f90df46)

### 📚 References

Closes https://github.com/auth0/terraform-provider-auth0/issues/852

### 🔬 Testing

 N/A

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
