### PR TITLE
Add support for ```attributes``` and ```precedence``` to ConnectionOptions & ```phone_number``` to SignupRequest. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ test-acc: ## Run acceptance tests with http recordings. To run a specific test, 
 		-v \
 		-run "$(FILTER)" \
 		-timeout 120m \
+		--parallel 1 \
 		-coverprofile="${GO_TEST_COVERAGE_FILE}" \
 		${GO_PACKAGES}
 

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ test-acc-record: ## Run acceptance tests and record http interactions. To run a 
 		-v \
 		-run "$(FILTER)" \
 		-timeout 120m \
+		--parallel 1 \
 		${GO_PACKAGES}
 
 test-acc-e2e: ## Run acceptance tests without http recordings. To run a specific test, pass the FILTER var. Usage `make test-acc-e2e FILTER="TestAccResourceServer`

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ test-acc: ## Run acceptance tests with http recordings. To run a specific test, 
 		-v \
 		-run "$(FILTER)" \
 		-timeout 120m \
-		--parallel 1 \
+		-parallel 1 \
 		-coverprofile="${GO_TEST_COVERAGE_FILE}" \
 		${GO_PACKAGES}
 
@@ -139,7 +139,7 @@ test-acc-record: ## Run acceptance tests and record http interactions. To run a 
 		-v \
 		-run "$(FILTER)" \
 		-timeout 120m \
-		--parallel 1 \
+		-parallel 1 \
 		${GO_PACKAGES}
 
 test-acc-e2e: ## Run acceptance tests without http recordings. To run a specific test, pass the FILTER var. Usage `make test-acc-e2e FILTER="TestAccResourceServer`

--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -52,6 +52,7 @@ Read-Only:
 - `api_enable_users` (Boolean)
 - `app_id` (String)
 - `attribute_map` (List of Object) (see [below for nested schema](#nestedobjatt--options--attribute_map))
+- `attributes` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes))
 - `auth_params` (Map of String)
 - `authorization_endpoint` (String)
 - `brute_force_protection` (Boolean)
@@ -103,6 +104,7 @@ Read-Only:
 - `password_policy` (String)
 - `ping_federate_base_url` (String)
 - `pkce_enabled` (Boolean)
+- `precedence` (List of String)
 - `protocol_binding` (String)
 - `provider` (String)
 - `request_template` (String)
@@ -146,6 +148,132 @@ Read-Only:
 - `attributes` (String)
 - `mapping_mode` (String)
 - `userinfo_scope` (String)
+
+
+<a id="nestedobjatt--options--attributes"></a>
+### Nested Schema for `options.attributes`
+
+Read-Only:
+
+- `email` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--email))
+- `phone_number` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--phone_number))
+- `username` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--username))
+
+<a id="nestedobjatt--options--attributes--email"></a>
+### Nested Schema for `options.attributes.email`
+
+Read-Only:
+
+- `identifier` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--email--identifier))
+- `profile_required` (Boolean)
+- `signup` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--email--signup))
+
+<a id="nestedobjatt--options--attributes--email--identifier"></a>
+### Nested Schema for `options.attributes.email.identifier`
+
+Read-Only:
+
+- `active` (Boolean)
+
+
+<a id="nestedobjatt--options--attributes--email--signup"></a>
+### Nested Schema for `options.attributes.email.signup`
+
+Read-Only:
+
+- `status` (String)
+- `verification` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--email--signup--verification))
+
+<a id="nestedobjatt--options--attributes--email--signup--verification"></a>
+### Nested Schema for `options.attributes.email.signup.verification`
+
+Read-Only:
+
+- `active` (Boolean)
+
+
+
+
+<a id="nestedobjatt--options--attributes--phone_number"></a>
+### Nested Schema for `options.attributes.phone_number`
+
+Read-Only:
+
+- `identifier` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--phone_number--identifier))
+- `profile_required` (Boolean)
+- `signup` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--phone_number--signup))
+
+<a id="nestedobjatt--options--attributes--phone_number--identifier"></a>
+### Nested Schema for `options.attributes.phone_number.identifier`
+
+Read-Only:
+
+- `active` (Boolean)
+
+
+<a id="nestedobjatt--options--attributes--phone_number--signup"></a>
+### Nested Schema for `options.attributes.phone_number.signup`
+
+Read-Only:
+
+- `status` (String)
+- `verification` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--phone_number--signup--verification))
+
+<a id="nestedobjatt--options--attributes--phone_number--signup--verification"></a>
+### Nested Schema for `options.attributes.phone_number.signup.verification`
+
+Read-Only:
+
+- `active` (Boolean)
+
+
+
+
+<a id="nestedobjatt--options--attributes--username"></a>
+### Nested Schema for `options.attributes.username`
+
+Read-Only:
+
+- `identifier` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--username--identifier))
+- `profile_required` (Boolean)
+- `signup` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--username--signup))
+- `validation` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--username--validation))
+
+<a id="nestedobjatt--options--attributes--username--identifier"></a>
+### Nested Schema for `options.attributes.username.identifier`
+
+Read-Only:
+
+- `active` (Boolean)
+
+
+<a id="nestedobjatt--options--attributes--username--signup"></a>
+### Nested Schema for `options.attributes.username.signup`
+
+Read-Only:
+
+- `status` (String)
+
+
+<a id="nestedobjatt--options--attributes--username--validation"></a>
+### Nested Schema for `options.attributes.username.validation`
+
+Read-Only:
+
+- `allowed_types` (List of Object) (see [below for nested schema](#nestedobjatt--options--attributes--username--validation--allowed_types))
+- `max_length` (Number)
+- `min_length` (Number)
+
+<a id="nestedobjatt--options--attributes--username--validation--allowed_types"></a>
+### Nested Schema for `options.attributes.username.validation.allowed_types`
+
+Read-Only:
+
+- `email` (Boolean)
+- `phone_number` (Boolean)
+
+
+
 
 
 <a id="nestedobjatt--options--connection_settings"></a>

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -664,6 +664,7 @@ Optional:
 - `api_enable_users` (Boolean) Enable API Access to users.
 - `app_id` (String) App ID.
 - `attribute_map` (Block List, Max: 1) OpenID Connect and Okta Workforce connections can automatically map claims received from the identity provider (IdP). You can configure this mapping through a library template provided by Auth0 or by entering your own template directly. Click [here](https://auth0.com/docs/authenticate/identity-providers/enterprise-identity-providers/configure-pkce-claim-mapping-for-oidc#map-claims-for-oidc-connections) for more info. (see [below for nested schema](#nestedblock--options--attribute_map))
+- `attributes` (Block List) Order of attributes for precedence in identification.Valid values: email, phone_number, username. If Precedence is set, it must contain all values (email, phone_number, username) in specific order (see [below for nested schema](#nestedblock--options--attributes))
 - `auth_params` (Map of String) Query string parameters to be included as part of the generated passwordless email link.
 - `authorization_endpoint` (String) Authorization endpoint.
 - `brute_force_protection` (Boolean) Indicates whether to enable brute force protection, which will limit the number of signups and failed logins from a suspicious IP address.
@@ -715,6 +716,7 @@ Optional:
 - `password_policy` (String) Indicates level of password strength to enforce during authentication. A strong password policy will make it difficult, if not improbable, for someone to guess a password through either manual or automated means. Options include `none`, `low`, `fair`, `good`, `excellent`.
 - `ping_federate_base_url` (String) Ping Federate Server URL.
 - `pkce_enabled` (Boolean) Enables Proof Key for Code Exchange (PKCE) functionality for OAuth2 connections.
+- `precedence` (List of String) Order of attributes for precedence in identification.Valid values: email, phone_number, username. If Precedence is set, it must contain all values (email, phone_number, username) in specific order
 - `protocol_binding` (String) The SAML Response Binding: how the SAML token is received by Auth0 from the IdP.
 - `provider` (String) Defines the custom `sms_gateway` provider.
 - `request_template` (String) Template that formats the SAML request.
@@ -761,6 +763,132 @@ Optional:
 
 - `attributes` (String) This property is an object containing mapping information that allows Auth0 to interpret incoming claims from the IdP. Mapping information must be provided as key/value pairs.
 - `userinfo_scope` (String) This property defines the scopes that Auth0 sends to the IdP’s UserInfo endpoint when requested.
+
+
+<a id="nestedblock--options--attributes"></a>
+### Nested Schema for `options.attributes`
+
+Optional:
+
+- `email` (Block List) Connection Options for Email Attribute (see [below for nested schema](#nestedblock--options--attributes--email))
+- `phone_number` (Block List) Connection Options for Phone Number Attribute (see [below for nested schema](#nestedblock--options--attributes--phone_number))
+- `username` (Block List) Connection Options for User Name Attribute (see [below for nested schema](#nestedblock--options--attributes--username))
+
+<a id="nestedblock--options--attributes--email"></a>
+### Nested Schema for `options.attributes.email`
+
+Optional:
+
+- `identifier` (Block List) Connection Options Email Attribute Identifier (see [below for nested schema](#nestedblock--options--attributes--email--identifier))
+- `profile_required` (Boolean) Defines whether Profile is required
+- `signup` (Block List) Defines signup settings for Email attribute (see [below for nested schema](#nestedblock--options--attributes--email--signup))
+
+<a id="nestedblock--options--attributes--email--identifier"></a>
+### Nested Schema for `options.attributes.email.identifier`
+
+Optional:
+
+- `active` (Boolean) Defines whether email attribute is active as an identifier
+
+
+<a id="nestedblock--options--attributes--email--signup"></a>
+### Nested Schema for `options.attributes.email.signup`
+
+Optional:
+
+- `status` (String) Defines signup status for Email Attribute
+- `verification` (Block List) Defines settings for Verification under Email attribute (see [below for nested schema](#nestedblock--options--attributes--email--signup--verification))
+
+<a id="nestedblock--options--attributes--email--signup--verification"></a>
+### Nested Schema for `options.attributes.email.signup.verification`
+
+Optional:
+
+- `active` (Boolean) Defines verification settings for signup attribute
+
+
+
+
+<a id="nestedblock--options--attributes--phone_number"></a>
+### Nested Schema for `options.attributes.phone_number`
+
+Optional:
+
+- `identifier` (Block List) Connection Options Phone Number Attribute Identifier (see [below for nested schema](#nestedblock--options--attributes--phone_number--identifier))
+- `profile_required` (Boolean) Defines whether Profile is required
+- `signup` (Block List) Defines signup settings for Phone Number attribute (see [below for nested schema](#nestedblock--options--attributes--phone_number--signup))
+
+<a id="nestedblock--options--attributes--phone_number--identifier"></a>
+### Nested Schema for `options.attributes.phone_number.identifier`
+
+Optional:
+
+- `active` (Boolean) Defines whether Phone Number attribute is active as an identifier
+
+
+<a id="nestedblock--options--attributes--phone_number--signup"></a>
+### Nested Schema for `options.attributes.phone_number.signup`
+
+Optional:
+
+- `status` (String) Defines status of signup for Phone Number attribute
+- `verification` (Block List) Defines verification settings for Phone Number attribute (see [below for nested schema](#nestedblock--options--attributes--phone_number--signup--verification))
+
+<a id="nestedblock--options--attributes--phone_number--signup--verification"></a>
+### Nested Schema for `options.attributes.phone_number.signup.verification`
+
+Optional:
+
+- `active` (Boolean) Defines verification settings for Phone Number attribute
+
+
+
+
+<a id="nestedblock--options--attributes--username"></a>
+### Nested Schema for `options.attributes.username`
+
+Optional:
+
+- `identifier` (Block List) Connection options for User Name Attribute Identifier (see [below for nested schema](#nestedblock--options--attributes--username--identifier))
+- `profile_required` (Boolean) Defines whether Profile is required
+- `signup` (Block List) Defines signup settings for User Name attribute (see [below for nested schema](#nestedblock--options--attributes--username--signup))
+- `validation` (Block List) Defines validation settings for User Name attribute (see [below for nested schema](#nestedblock--options--attributes--username--validation))
+
+<a id="nestedblock--options--attributes--username--identifier"></a>
+### Nested Schema for `options.attributes.username.identifier`
+
+Optional:
+
+- `active` (Boolean) Defines whether UserName attribute is active as an identifier
+
+
+<a id="nestedblock--options--attributes--username--signup"></a>
+### Nested Schema for `options.attributes.username.signup`
+
+Optional:
+
+- `status` (String) Defines whether User Name attribute is active as an identifier
+
+
+<a id="nestedblock--options--attributes--username--validation"></a>
+### Nested Schema for `options.attributes.username.validation`
+
+Optional:
+
+- `allowed_types` (Block List) Defines allowed types for for UserName attribute (see [below for nested schema](#nestedblock--options--attributes--username--validation--allowed_types))
+- `max_length` (Number) Defines Max Length for User Name attribute
+- `min_length` (Number) Defines Min Length for User Name attribute
+
+<a id="nestedblock--options--attributes--username--validation--allowed_types"></a>
+### Nested Schema for `options.attributes.username.validation.allowed_types`
+
+Optional:
+
+- `email` (Boolean) One of the allowed types for UserName signup attribute
+- `phone_number` (Boolean) One of the allowed types for UserName signup attribute
+
+
+
 
 
 <a id="nestedblock--options--connection_settings"></a>

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/PuerkitoBio/rehttp v1.4.0
-	github.com/auth0/go-auth0 v1.8.1-0.20240716094022-bd6f66927723
+	github.com/auth0/go-auth0 v1.8.1-0.20240807031014-a1a9f657ea5f
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/PuerkitoBio/rehttp v1.4.0
-	github.com/auth0/go-auth0 v1.8.1-0.20240807031014-a1a9f657ea5f
+	github.com/auth0/go-auth0 v1.9.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1
@@ -77,7 +77,7 @@ require (
 	golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
-	golang.org/x/oauth2 v0.21.0 // indirect
+	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/PuerkitoBio/rehttp v1.4.0
-	github.com/auth0/go-auth0 v1.8.0
+	github.com/auth0/go-auth0 v1.8.1-0.20240716094022-bd6f66927723
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/auth0/go-auth0 v1.8.0 h1:3aawDXl446+ok8HVmrH4FBTG+ZzgS8qHaJaOGoQdg4k=
-github.com/auth0/go-auth0 v1.8.0/go.mod h1:J/t2M/i8XraHTRi9hX6VcMX2wiyWzKnUD04nigFwtfk=
+github.com/auth0/go-auth0 v1.8.1-0.20240716094022-bd6f66927723 h1:D+QRVcu17gb1BGs/6E9HT1p8BK/OLDAdI/VoCgv3jng=
+github.com/auth0/go-auth0 v1.8.1-0.20240716094022-bd6f66927723/go.mod h1:J/t2M/i8XraHTRi9hX6VcMX2wiyWzKnUD04nigFwtfk=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/auth0/go-auth0 v1.8.1-0.20240716094022-bd6f66927723 h1:D+QRVcu17gb1BGs/6E9HT1p8BK/OLDAdI/VoCgv3jng=
-github.com/auth0/go-auth0 v1.8.1-0.20240716094022-bd6f66927723/go.mod h1:J/t2M/i8XraHTRi9hX6VcMX2wiyWzKnUD04nigFwtfk=
+github.com/auth0/go-auth0 v1.8.1-0.20240807031014-a1a9f657ea5f h1:cpM/vvbamdti/cAF9HVnlkzAXNWjR3GQEA06cIFcvxM=
+github.com/auth0/go-auth0 v1.8.1-0.20240807031014-a1a9f657ea5f/go.mod h1:qDG+SvKH3zsgIqoob28jB4epKkUzVDf5mZvS40kf/jI=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/auth0/go-auth0 v1.8.1-0.20240807031014-a1a9f657ea5f h1:cpM/vvbamdti/cAF9HVnlkzAXNWjR3GQEA06cIFcvxM=
-github.com/auth0/go-auth0 v1.8.1-0.20240807031014-a1a9f657ea5f/go.mod h1:qDG+SvKH3zsgIqoob28jB4epKkUzVDf5mZvS40kf/jI=
+github.com/auth0/go-auth0 v1.9.0 h1:IRCMQ9zLmFn8aAKkd+lopFo6IAdpARYSRf8i9ZACG48=
+github.com/auth0/go-auth0 v1.9.0/go.mod h1:p9KEEkCehO7tcDf32r1r06Ji63mqZa1QZ6IfQ172bys=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -236,8 +236,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
 golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
-golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=
-golang.org/x/oauth2 v0.21.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.22.0 h1:BzDx2FehcG7jJwgWLELCdmLuxk2i+x9UDpSiss2u0ZA=
+golang.org/x/oauth2 v0.22.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/acctest/template.go
+++ b/internal/acctest/template.go
@@ -19,3 +19,18 @@ func ParseTestName(rawTemplate, testName string) string {
 
 	return buf.String()
 }
+
+// ParseParametersInTemplate renders templates defined with placeholders present in paramDictionary as input.
+func ParseParametersInTemplate(rawTemplate string, paramDictionary map[string]interface{}) string {
+	t, err := template.New("tpl").Parse(rawTemplate)
+	if err != nil {
+		return ""
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, paramDictionary); err != nil {
+		return ""
+	}
+
+	return buf.String()
+}

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -3,7 +3,6 @@ package connection
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
@@ -251,7 +250,6 @@ func expandConnectionOptionsAttributeIdentifier(config cty.Value) *management.Co
 }
 
 func expandConnectionOptionsAttributeUsernameSignup(config cty.Value) *management.ConnectionOptionsAttributeSignup {
-	log.Printf("config signup : %v ", config.GetAttr("signup"))
 	var coas *management.ConnectionOptionsAttributeSignup
 	config.GetAttr("signup").ForEachElement(
 		func(_ cty.Value, signup cty.Value) (stop bool) {

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -3,6 +3,7 @@ package connection
 import (
 	"context"
 	"fmt"
+
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-cty/cty"
@@ -180,9 +181,9 @@ func expandConnectionOptionsGitHub(data *schema.ResourceData, config cty.Value) 
 }
 
 func expandConnectionOptionsAttributes(data *schema.ResourceData) *management.ConnectionOptionsAttributes {
-	//if !data.HasChange("attributes") {
+	//If !data.HasChange("attributes") {
 	//	return nil
-	//}
+	//}.
 
 	var coa *management.ConnectionOptionsAttributes
 	data.GetRawConfig().GetAttr("attributes").ForEachElement(

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -182,7 +182,6 @@ func expandConnectionOptionsGitHub(data *schema.ResourceData, config cty.Value) 
 }
 
 func expandConnectionOptionsAttributes(config cty.Value) *management.ConnectionOptionsAttributes {
-	log.Printf("config: %v", config)
 	var coa *management.ConnectionOptionsAttributes
 	config.ForEachElement(
 		func(_ cty.Value, attributes cty.Value) (stop bool) {
@@ -296,7 +295,7 @@ func expandConnectionOptionsAttributeValidation(config cty.Value) *management.Co
 			coav = &management.ConnectionOptionsAttributeValidation{
 				MinLength:    value.Int(validation.GetAttr("min_length")),
 				MaxLength:    value.Int(validation.GetAttr("max_length")),
-				AllowedTypes: expandConnectionOptionsAttributeAllowedTypes(validation.GetAttr("allowed_types")),
+				AllowedTypes: expandConnectionOptionsAttributeAllowedTypes(validation),
 			}
 			return stop
 		})

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -181,9 +181,9 @@ func expandConnectionOptionsGitHub(data *schema.ResourceData, config cty.Value) 
 }
 
 func expandConnectionOptionsAttributes(data *schema.ResourceData) *management.ConnectionOptionsAttributes {
-	//If !data.HasChange("attributes") {
-	//	return nil
-	//}.
+	if !data.HasChange("attributes") {
+		return nil
+	}
 
 	var coa *management.ConnectionOptionsAttributes
 	data.GetRawConfig().GetAttr("attributes").ForEachElement(

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -216,7 +216,7 @@ func expandConnectionOptionsUsernameAttribute(config cty.Value) *management.Conn
 			coua = &management.ConnectionOptionsUsernameAttribute{
 				Identifier:      expandConnectionOptionsAttributeIdentifier(username),
 				ProfileRequired: value.Bool(username.GetAttr("profile_required")),
-				Signup:          expandConnectionOptionsAttributeSignup(username),
+				Signup:          expandConnectionOptionsAttributeUsernameSignup(username),
 				Validation:      expandConnectionOptionsAttributeValidation(username),
 			}
 			return stop
@@ -248,6 +248,19 @@ func expandConnectionOptionsAttributeIdentifier(config cty.Value) *management.Co
 			return stop
 		})
 	return coai
+}
+
+func expandConnectionOptionsAttributeUsernameSignup(config cty.Value) *management.ConnectionOptionsAttributeSignup {
+	log.Printf("config signup : %v ", config.GetAttr("signup"))
+	var coas *management.ConnectionOptionsAttributeSignup
+	config.GetAttr("signup").ForEachElement(
+		func(_ cty.Value, signup cty.Value) (stop bool) {
+			coas = &management.ConnectionOptionsAttributeSignup{
+				Status: value.String(signup.GetAttr("status")),
+			}
+			return stop
+		})
+	return coas
 }
 
 func expandConnectionOptionsAttributeSignup(config cty.Value) *management.ConnectionOptionsAttributeSignup {

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -3,12 +3,13 @@ package connection
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"log"
 
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
@@ -315,7 +316,7 @@ func expandConnectionOptionsAttributeAllowedTypes(config cty.Value) *management.
 	return coaat
 }
 
-func expandConnectionOptionsAuth0(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
+func expandConnectionOptionsAuth0(_ *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptions{
 		PasswordPolicy:                   value.String(config.GetAttr("password_policy")),
 		NonPersistentAttrs:               value.Strings(config.GetAttr("non_persistent_attrs")),

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -3,12 +3,12 @@ package connection
 import (
 	"context"
 	"fmt"
-
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
 
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
@@ -180,13 +180,10 @@ func expandConnectionOptionsGitHub(data *schema.ResourceData, config cty.Value) 
 	return options, diag.FromErr(err)
 }
 
-func expandConnectionOptionsAttributes(data *schema.ResourceData) *management.ConnectionOptionsAttributes {
-	if !data.HasChange("attributes") {
-		return nil
-	}
-
+func expandConnectionOptionsAttributes(config cty.Value) *management.ConnectionOptionsAttributes {
+	log.Printf("config: %v", config)
 	var coa *management.ConnectionOptionsAttributes
-	data.GetRawConfig().GetAttr("attributes").ForEachElement(
+	config.ForEachElement(
 		func(_ cty.Value, attributes cty.Value) (stop bool) {
 			coa = &management.ConnectionOptionsAttributes{
 				Email:       expandConnectionOptionsEmailAttribute(attributes),
@@ -320,7 +317,7 @@ func expandConnectionOptionsAuth0(data *schema.ResourceData, config cty.Value) (
 		CustomScripts:                    value.MapOfStrings(config.GetAttr("custom_scripts")),
 		Configuration:                    value.MapOfStrings(config.GetAttr("configuration")),
 		Precedence:                       value.Strings(config.GetAttr("precedence")),
-		Attributes:                       expandConnectionOptionsAttributes(data),
+		Attributes:                       expandConnectionOptionsAttributes(config.GetAttr("attributes")),
 	}
 
 	config.GetAttr("validation").ForEachElement(

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -3,7 +3,6 @@ package connection
 import (
 	"errors"
 	"fmt"
-
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/go-multierror"
@@ -170,6 +169,102 @@ func flattenConnectionOptionsWindowsLive(
 	return optionsMap, nil
 }
 
+func flattenAttributes(connAttributes *management.ConnectionOptionsAttributes) (interface{}, diag.Diagnostics) {
+	if connAttributes == nil {
+		return nil, nil
+	}
+
+	return map[string]interface{}{
+		"email":        flattenEmailAttribute(connAttributes.Email),
+		"username":     flattenUsernameAttribute(connAttributes.Username),
+		"phone_number": flattenPhoneNumberAttribute(connAttributes.PhoneNumber),
+	}, nil
+
+}
+
+func flattenEmailAttribute(emailAttribute *management.ConnectionOptionsEmailAttribute) (interface{}, diag.Diagnostics) {
+	if emailAttribute == nil {
+		return nil, nil
+	}
+
+	return map[string]interface{}{
+		"identifier":       flattenIdentifier(emailAttribute.Identifier),
+		"profile_required": emailAttribute.ProfileRequired,
+		"signup":           flattenSignUp(emailAttribute.Signup),
+	}, nil
+
+}
+
+func flattenUsernameAttribute(usernameAttribute *management.ConnectionOptionsUsernameAttribute) (interface{}, diag.Diagnostics) {
+	if usernameAttribute == nil {
+		return nil, nil
+	}
+
+	return map[string]interface{}{
+		"identifier":       flattenIdentifier(usernameAttribute.Identifier),
+		"profile_required": usernameAttribute.ProfileRequired,
+		"signup":           flattenSignUp(usernameAttribute.Signup),
+		"validation":       flattenValidation(usernameAttribute.Validation),
+	}, nil
+
+}
+
+func flattenPhoneNumberAttribute(phoneNumberAttribute *management.ConnectionOptionsPhoneNumberAttribute) (interface{}, diag.Diagnostics) {
+	if phoneNumberAttribute == nil {
+		return nil, nil
+	}
+
+	return map[string]interface{}{
+		"identifier":       flattenIdentifier(phoneNumberAttribute.Identifier),
+		"profile_required": phoneNumberAttribute.ProfileRequired,
+		"signup":           flattenSignUp(phoneNumberAttribute.Signup),
+	}, nil
+
+}
+
+func flattenIdentifier(identifier *management.ConnectionOptionsAttributeIdentifier) (interface{}, diag.Diagnostics) {
+	if identifier == nil {
+		return nil, nil
+	}
+	return map[string]interface{}{
+		"active": identifier.Active,
+	}, nil
+}
+
+func flattenSignUp(signup *management.ConnectionOptionsAttributeSignup) (interface{}, diag.Diagnostics) {
+	if signup == nil {
+		return nil, nil
+	}
+	return map[string]interface{}{
+		"status":       signup.Status,
+		"verification": flattenVerification(signup.Verification),
+	}, nil
+}
+
+func flattenValidation(validation *management.ConnectionOptionsAttributeValidation) (interface{}, diag.Diagnostics) {
+	if validation == nil {
+		return nil, nil
+	}
+	return map[string]interface{}{
+		"min_length": validation.MinLength,
+		"max_length": validation.MaxLength,
+		"allowed_types": map[string]interface{}{
+			"email":        validation.AllowedTypes.Email,
+			"phone_number": validation.AllowedTypes.PhoneNumber,
+		},
+	}, nil
+}
+
+func flattenVerification(verification *management.ConnectionOptionsAttributeVerification) (interface{}, diag.Diagnostics) {
+	if verification == nil {
+		return nil, nil
+	}
+
+	return map[string]interface{}{
+		"active": verification.Active,
+	}, nil
+}
+
 func flattenConnectionOptionsAuth0(
 	data *schema.ResourceData,
 	rawOptions interface{},
@@ -203,6 +298,8 @@ func flattenConnectionOptionsAuth0(
 		"non_persistent_attrs":                 options.GetNonPersistentAttrs(),
 		"set_user_root_attributes":             options.GetSetUserAttributes(),
 		"upstream_params":                      upstreamParams,
+		"precedence":                           options.GetPrecedence(),
+		"attributes":                           flattenAttributes(options.Attributes),
 	}
 
 	if options.PasswordComplexityOptions != nil {

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -182,83 +182,110 @@ func flattenAttributes(connAttributes *management.ConnectionOptionsAttributes) i
 	}
 }
 
-func flattenEmailAttribute(emailAttribute *management.ConnectionOptionsEmailAttribute) interface{} {
+func flattenEmailAttribute(emailAttribute *management.ConnectionOptionsEmailAttribute) []map[string]interface{} {
 	if emailAttribute == nil {
 		return nil
 	}
 
-	return map[string]interface{}{
-		"identifier":       flattenIdentifier(emailAttribute.GetIdentifier()),
-		"profile_required": emailAttribute.GetProfileRequired(),
-		"signup":           flattenSignUp(emailAttribute.GetSignup()),
-	}
-}
-
-func flattenUsernameAttribute(usernameAttribute *management.ConnectionOptionsUsernameAttribute) interface{} {
-	if usernameAttribute == nil {
-		return nil
-	}
-
-	return map[string]interface{}{
-		"identifier":       flattenIdentifier(usernameAttribute.GetIdentifier()),
-		"profile_required": usernameAttribute.GetProfileRequired(),
-		"signup":           flattenSignUp(usernameAttribute.GetSignup()),
-		"validation":       flattenValidation(usernameAttribute.GetValidation()),
-	}
-}
-
-func flattenPhoneNumberAttribute(phoneNumberAttribute *management.ConnectionOptionsPhoneNumberAttribute) interface{} {
-	if phoneNumberAttribute == nil {
-		return nil
-	}
-
-	return map[string]interface{}{
-		"identifier":       flattenIdentifier(phoneNumberAttribute.GetIdentifier()),
-		"profile_required": phoneNumberAttribute.GetProfileRequired(),
-		"signup":           flattenSignUp(phoneNumberAttribute.GetSignup()),
-	}
-}
-
-func flattenIdentifier(identifier *management.ConnectionOptionsAttributeIdentifier) interface{} {
-	if identifier == nil {
-		return nil
-	}
-	return map[string]interface{}{
-		"active": identifier.Active,
-	}
-}
-
-func flattenSignUp(signup *management.ConnectionOptionsAttributeSignup) interface{} {
-	if signup == nil {
-		return nil
-	}
-	return map[string]interface{}{
-		"status":       signup.Status,
-		"verification": flattenVerification(signup.Verification),
-	}
-}
-
-func flattenValidation(validation *management.ConnectionOptionsAttributeValidation) interface{} {
-	if validation == nil {
-		return nil
-	}
-	return map[string]interface{}{
-		"min_length": validation.MinLength,
-		"max_length": validation.MaxLength,
-		"allowed_types": map[string]interface{}{
-			"email":        validation.AllowedTypes.Email,
-			"phone_number": validation.AllowedTypes.PhoneNumber,
+	return []map[string]interface{}{
+		{
+			"identifier":       flattenIdentifier(emailAttribute.GetIdentifier()),
+			"profile_required": emailAttribute.GetProfileRequired(),
+			"signup":           flattenSignUp(emailAttribute.GetSignup()),
 		},
 	}
 }
 
-func flattenVerification(verification *management.ConnectionOptionsAttributeVerification) interface{} {
+func flattenUsernameAttribute(usernameAttribute *management.ConnectionOptionsUsernameAttribute) []map[string]interface{} {
+	if usernameAttribute == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"identifier":       flattenIdentifier(usernameAttribute.GetIdentifier()),
+			"profile_required": usernameAttribute.GetProfileRequired(),
+			"signup":           flattenUsernameSignUp(usernameAttribute.GetSignup()),
+			"validation":       flattenValidation(usernameAttribute.GetValidation()),
+		},
+	}
+}
+
+func flattenPhoneNumberAttribute(phoneNumberAttribute *management.ConnectionOptionsPhoneNumberAttribute) []map[string]interface{} {
+	if phoneNumberAttribute == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"identifier":       flattenIdentifier(phoneNumberAttribute.GetIdentifier()),
+			"profile_required": phoneNumberAttribute.GetProfileRequired(),
+			"signup":           flattenSignUp(phoneNumberAttribute.GetSignup()),
+		},
+	}
+}
+
+func flattenIdentifier(identifier *management.ConnectionOptionsAttributeIdentifier) []map[string]interface{} {
+	if identifier == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"active": identifier.GetActive(),
+		},
+	}
+}
+
+func flattenSignUp(signup *management.ConnectionOptionsAttributeSignup) []map[string]interface{} {
+	if signup == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"status":       signup.GetStatus(),
+			"verification": flattenVerification(signup.GetVerification()),
+		},
+	}
+}
+
+func flattenUsernameSignUp(signup *management.ConnectionOptionsAttributeSignup) []map[string]interface{} {
+	if signup == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"status": signup.GetStatus(),
+		},
+	}
+}
+
+func flattenValidation(validation *management.ConnectionOptionsAttributeValidation) []map[string]interface{} {
+	if validation == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"min_length": validation.GetMinLength(),
+			"max_length": validation.GetMaxLength(),
+			"allowed_types": []map[string]interface{}{
+				{
+					"email":        validation.GetAllowedTypes().GetEmail(),
+					"phone_number": validation.GetAllowedTypes().GetEmail(),
+				},
+			},
+		},
+	}
+}
+
+func flattenVerification(verification *management.ConnectionOptionsAttributeVerification) []map[string]interface{} {
 	if verification == nil {
 		return nil
 	}
 
-	return map[string]interface{}{
-		"active": verification.Active,
+	return []map[string]interface{}{
+		{
+			"active": verification.GetActive(),
+		},
 	}
 }
 

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -3,6 +3,7 @@ package connection
 import (
 	"errors"
 	"fmt"
+
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/go-multierror"
@@ -179,7 +180,6 @@ func flattenAttributes(connAttributes *management.ConnectionOptionsAttributes) i
 		"username":     flattenUsernameAttribute(connAttributes.Username),
 		"phone_number": flattenPhoneNumberAttribute(connAttributes.PhoneNumber),
 	}
-
 }
 
 func flattenEmailAttribute(emailAttribute *management.ConnectionOptionsEmailAttribute) interface{} {
@@ -192,7 +192,6 @@ func flattenEmailAttribute(emailAttribute *management.ConnectionOptionsEmailAttr
 		"profile_required": emailAttribute.ProfileRequired,
 		"signup":           flattenSignUp(emailAttribute.Signup),
 	}
-
 }
 
 func flattenUsernameAttribute(usernameAttribute *management.ConnectionOptionsUsernameAttribute) interface{} {
@@ -206,7 +205,6 @@ func flattenUsernameAttribute(usernameAttribute *management.ConnectionOptionsUse
 		"signup":           flattenSignUp(usernameAttribute.Signup),
 		"validation":       flattenValidation(usernameAttribute.Validation),
 	}
-
 }
 
 func flattenPhoneNumberAttribute(phoneNumberAttribute *management.ConnectionOptionsPhoneNumberAttribute) interface{} {
@@ -219,7 +217,6 @@ func flattenPhoneNumberAttribute(phoneNumberAttribute *management.ConnectionOpti
 		"profile_required": phoneNumberAttribute.ProfileRequired,
 		"signup":           flattenSignUp(phoneNumberAttribute.Signup),
 	}
-
 }
 
 func flattenIdentifier(identifier *management.ConnectionOptionsAttributeIdentifier) interface{} {

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -188,9 +188,9 @@ func flattenEmailAttribute(emailAttribute *management.ConnectionOptionsEmailAttr
 	}
 
 	return map[string]interface{}{
-		"identifier":       flattenIdentifier(emailAttribute.Identifier),
-		"profile_required": emailAttribute.ProfileRequired,
-		"signup":           flattenSignUp(emailAttribute.Signup),
+		"identifier":       flattenIdentifier(emailAttribute.GetIdentifier()),
+		"profile_required": emailAttribute.GetProfileRequired(),
+		"signup":           flattenSignUp(emailAttribute.GetSignup()),
 	}
 }
 
@@ -200,10 +200,10 @@ func flattenUsernameAttribute(usernameAttribute *management.ConnectionOptionsUse
 	}
 
 	return map[string]interface{}{
-		"identifier":       flattenIdentifier(usernameAttribute.Identifier),
-		"profile_required": usernameAttribute.ProfileRequired,
-		"signup":           flattenSignUp(usernameAttribute.Signup),
-		"validation":       flattenValidation(usernameAttribute.Validation),
+		"identifier":       flattenIdentifier(usernameAttribute.GetIdentifier()),
+		"profile_required": usernameAttribute.GetProfileRequired(),
+		"signup":           flattenSignUp(usernameAttribute.GetSignup()),
+		"validation":       flattenValidation(usernameAttribute.GetValidation()),
 	}
 }
 
@@ -213,9 +213,9 @@ func flattenPhoneNumberAttribute(phoneNumberAttribute *management.ConnectionOpti
 	}
 
 	return map[string]interface{}{
-		"identifier":       flattenIdentifier(phoneNumberAttribute.Identifier),
-		"profile_required": phoneNumberAttribute.ProfileRequired,
-		"signup":           flattenSignUp(phoneNumberAttribute.Signup),
+		"identifier":       flattenIdentifier(phoneNumberAttribute.GetIdentifier()),
+		"profile_required": phoneNumberAttribute.GetProfileRequired(),
+		"signup":           flattenSignUp(phoneNumberAttribute.GetSignup()),
 	}
 }
 
@@ -296,7 +296,10 @@ func flattenConnectionOptionsAuth0(
 		"set_user_root_attributes":             options.GetSetUserAttributes(),
 		"upstream_params":                      upstreamParams,
 		"precedence":                           options.GetPrecedence(),
-		"attributes":                           flattenAttributes(options.Attributes),
+	}
+
+	if options.Attributes != nil {
+		optionsMap["attributes"] = []interface{}{flattenAttributes(options.GetAttributes())}
 	}
 
 	if options.PasswordComplexityOptions != nil {

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -270,7 +270,7 @@ func flattenValidation(validation *management.ConnectionOptionsAttributeValidati
 			"allowed_types": []map[string]interface{}{
 				{
 					"email":        validation.GetAllowedTypes().GetEmail(),
-					"phone_number": validation.GetAllowedTypes().GetEmail(),
+					"phone_number": validation.GetAllowedTypes().GetPhoneNumber(),
 				},
 			},
 		},

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -169,35 +169,35 @@ func flattenConnectionOptionsWindowsLive(
 	return optionsMap, nil
 }
 
-func flattenAttributes(connAttributes *management.ConnectionOptionsAttributes) (interface{}, diag.Diagnostics) {
+func flattenAttributes(connAttributes *management.ConnectionOptionsAttributes) interface{} {
 	if connAttributes == nil {
-		return nil, nil
+		return nil
 	}
 
 	return map[string]interface{}{
 		"email":        flattenEmailAttribute(connAttributes.Email),
 		"username":     flattenUsernameAttribute(connAttributes.Username),
 		"phone_number": flattenPhoneNumberAttribute(connAttributes.PhoneNumber),
-	}, nil
+	}
 
 }
 
-func flattenEmailAttribute(emailAttribute *management.ConnectionOptionsEmailAttribute) (interface{}, diag.Diagnostics) {
+func flattenEmailAttribute(emailAttribute *management.ConnectionOptionsEmailAttribute) interface{} {
 	if emailAttribute == nil {
-		return nil, nil
+		return nil
 	}
 
 	return map[string]interface{}{
 		"identifier":       flattenIdentifier(emailAttribute.Identifier),
 		"profile_required": emailAttribute.ProfileRequired,
 		"signup":           flattenSignUp(emailAttribute.Signup),
-	}, nil
+	}
 
 }
 
-func flattenUsernameAttribute(usernameAttribute *management.ConnectionOptionsUsernameAttribute) (interface{}, diag.Diagnostics) {
+func flattenUsernameAttribute(usernameAttribute *management.ConnectionOptionsUsernameAttribute) interface{} {
 	if usernameAttribute == nil {
-		return nil, nil
+		return nil
 	}
 
 	return map[string]interface{}{
@@ -205,45 +205,45 @@ func flattenUsernameAttribute(usernameAttribute *management.ConnectionOptionsUse
 		"profile_required": usernameAttribute.ProfileRequired,
 		"signup":           flattenSignUp(usernameAttribute.Signup),
 		"validation":       flattenValidation(usernameAttribute.Validation),
-	}, nil
+	}
 
 }
 
-func flattenPhoneNumberAttribute(phoneNumberAttribute *management.ConnectionOptionsPhoneNumberAttribute) (interface{}, diag.Diagnostics) {
+func flattenPhoneNumberAttribute(phoneNumberAttribute *management.ConnectionOptionsPhoneNumberAttribute) interface{} {
 	if phoneNumberAttribute == nil {
-		return nil, nil
+		return nil
 	}
 
 	return map[string]interface{}{
 		"identifier":       flattenIdentifier(phoneNumberAttribute.Identifier),
 		"profile_required": phoneNumberAttribute.ProfileRequired,
 		"signup":           flattenSignUp(phoneNumberAttribute.Signup),
-	}, nil
+	}
 
 }
 
-func flattenIdentifier(identifier *management.ConnectionOptionsAttributeIdentifier) (interface{}, diag.Diagnostics) {
+func flattenIdentifier(identifier *management.ConnectionOptionsAttributeIdentifier) interface{} {
 	if identifier == nil {
-		return nil, nil
+		return nil
 	}
 	return map[string]interface{}{
 		"active": identifier.Active,
-	}, nil
+	}
 }
 
-func flattenSignUp(signup *management.ConnectionOptionsAttributeSignup) (interface{}, diag.Diagnostics) {
+func flattenSignUp(signup *management.ConnectionOptionsAttributeSignup) interface{} {
 	if signup == nil {
-		return nil, nil
+		return nil
 	}
 	return map[string]interface{}{
 		"status":       signup.Status,
 		"verification": flattenVerification(signup.Verification),
-	}, nil
+	}
 }
 
-func flattenValidation(validation *management.ConnectionOptionsAttributeValidation) (interface{}, diag.Diagnostics) {
+func flattenValidation(validation *management.ConnectionOptionsAttributeValidation) interface{} {
 	if validation == nil {
-		return nil, nil
+		return nil
 	}
 	return map[string]interface{}{
 		"min_length": validation.MinLength,
@@ -252,17 +252,17 @@ func flattenValidation(validation *management.ConnectionOptionsAttributeValidati
 			"email":        validation.AllowedTypes.Email,
 			"phone_number": validation.AllowedTypes.PhoneNumber,
 		},
-	}, nil
+	}
 }
 
-func flattenVerification(verification *management.ConnectionOptionsAttributeVerification) (interface{}, diag.Diagnostics) {
+func flattenVerification(verification *management.ConnectionOptionsAttributeVerification) interface{} {
 	if verification == nil {
-		return nil, nil
+		return nil
 	}
 
 	return map[string]interface{}{
 		"active": verification.Active,
-	}, nil
+	}
 }
 
 func flattenConnectionOptionsAuth0(

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -160,6 +160,312 @@ resource "auth0_connection" "my_connection" {
 }
 `
 
+const testAccConnectionOptionAttributesTemplate = `
+resource "auth0_connection" "my_connection" {
+	name = "Acceptance-Test-Connection-{{.testName}}"
+	is_domain_connection = true
+	strategy = "auth0"
+	options {
+		precedence = ["username","email","phone_number"]
+		{{.validation}}
+		{{.requires_username}}
+		{{.attributes}}
+		brute_force_protection = true
+	}
+}
+`
+
+func TestAccConnectionOptionsAttrPhoneNumber(t *testing.T) {
+	params := map[string]interface{}{
+		"testName":          t.Name(),
+		"requires_username": `requires_username = false`,
+		"validation":        ``,
+		"attributes": `attributes {
+							phone_number {
+								identifier {
+									active = true
+								}
+								profile_required = true
+								signup {
+									status = "required"
+									verification {
+										active = false
+									}
+								}
+							}
+						}`}
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseParametersInTemplate(testAccConnectionOptionAttributesTemplate, params),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "name", fmt.Sprintf("Acceptance-Test-Connection-%s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "is_domain_connection", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "strategy", "auth0"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.#", "1"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.phone_number.0.identifier.0.active", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.phone_number.0.profile_required", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.phone_number.0.signup.0.status", "required"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.phone_number.0.signup.0.verification.0.active", "false"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(`data "auth0_tenant" "test_tenant_data" {}`, t.Name()),
+			},
+			{
+				Config: acctest.ParseTestName(`
+											data "auth0_connection" "my_connection" {
+											name = "Acceptance-Test-Connection-{{.testName}}"
+										}`,
+					t.Name()),
+				ExpectError: regexp.MustCompile(" No connection found"),
+			},
+		},
+	})
+}
+
+func TestAccConnectionOptionsAttrEmail(t *testing.T) {
+	params := map[string]interface{}{
+		"testName":          t.Name(),
+		"requires_username": `requires_username = false`,
+		"validation":        ``,
+		"attributes": `attributes {
+							email {
+								identifier {
+									active = true
+								}
+								profile_required = true
+								signup {
+									status = "required"
+									verification {
+										active = false
+									}
+								}
+							}
+						}`}
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseParametersInTemplate(testAccConnectionOptionAttributesTemplate, params),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "name", fmt.Sprintf("Acceptance-Test-Connection-%s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "is_domain_connection", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "strategy", "auth0"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.#", "1"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.email.0.identifier.0.active", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.email.0.profile_required", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.email.0.signup.0.status", "required"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.email.0.signup.0.verification.0.active", "false"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(`data "auth0_tenant" "test_tenant_data" {}`, t.Name()),
+			},
+			{
+				Config: acctest.ParseTestName(`
+											data "auth0_connection" "my_connection" {
+											name = "Acceptance-Test-Connection-{{.testName}}"
+										}`,
+					t.Name()),
+				ExpectError: regexp.MustCompile(" No connection found"),
+			},
+		},
+	})
+}
+
+func TestAccConnectionOptionsAttrUserName(t *testing.T) {
+	params := map[string]interface{}{
+		"testName":          t.Name(),
+		"requires_username": `requires_username = false`,
+		"validation":        ``,
+		"attributes": `attributes {
+							username {
+								identifier {
+									active = true
+								}
+								profile_required = true
+								signup {
+									status = "required"
+								}
+							}
+						}`}
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseParametersInTemplate(testAccConnectionOptionAttributesTemplate, params),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "name", fmt.Sprintf("Acceptance-Test-Connection-%s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "is_domain_connection", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "strategy", "auth0"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.#", "1"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.username.0.identifier.0.active", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.username.0.profile_required", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.username.0.signup.0.status", "required"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(`data "auth0_tenant" "test_tenant_data" {}`, t.Name()),
+			},
+			{
+				Config: acctest.ParseTestName(`
+											data "auth0_connection" "my_connection" {
+											name = "Acceptance-Test-Connection-{{.testName}}"
+										}`,
+					t.Name()),
+				ExpectError: regexp.MustCompile(" No connection found"),
+			},
+		},
+	})
+}
+
+func TestAccConnectionOptionsAttrUserNameNegative(t *testing.T) {
+	params := map[string]interface{}{
+		"requires_username": `requires_username = true`,
+		"testName":          t.Name(),
+		"validation":        ``,
+		"attributes": `attributes {
+							username {
+								identifier {
+									active = true
+								}
+								profile_required = true
+								signup {
+									status = "required"
+								}
+							}
+						}`}
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:      acctest.ParseParametersInTemplate(testAccConnectionOptionAttributesTemplate, params),
+				ExpectError: regexp.MustCompile("400 Bad Request: Cannot set both options.attributes and options.requires_username"),
+			},
+		},
+	})
+}
+
+func TestAccConnectionOptionsAttrNoActiveNegative(t *testing.T) {
+	params := map[string]interface{}{
+		"testName":          t.Name(),
+		"requires_username": `requires_username = false`,
+		"validation":        ``,
+		"attributes": `attributes {
+							phone_number {
+								identifier {
+									active = false
+								}
+								profile_required = true
+								signup {
+									status = "required"
+									verification {
+										active = false
+									}
+								}
+							}
+							email {
+								identifier {
+									active = false
+								}
+								profile_required = true
+								signup {
+									status = "required"
+									verification {
+										active = false
+									}
+								}
+							}
+							username {
+								identifier {
+									active = false
+								}
+								profile_required = true
+								signup {
+									status = "required"
+								}
+							}
+						}`}
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:      acctest.ParseParametersInTemplate(testAccConnectionOptionAttributesTemplate, params),
+				ExpectError: regexp.MustCompile("400 Bad Request: attributes must contain one active identifier"),
+			},
+		},
+	})
+}
+
+func TestAccConnectionOptionsAttrSetValidationNegative(t *testing.T) {
+	params := map[string]interface{}{
+		"testName":          t.Name(),
+		"requires_username": `requires_username = false`,
+		"validation": `validation {
+							username {
+								min = 1
+								max =  5
+							}
+						}`,
+		"attributes": `attributes {
+							email {
+								identifier {
+									active = true
+								}
+								profile_required = true
+								signup {
+									status = "required"
+									verification {
+										active = false
+									}
+								}
+							}
+							username {
+								identifier {
+									active = false
+								}
+								profile_required = true
+								signup {
+									status = "required"
+								}
+							}
+						}`}
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:      acctest.ParseParametersInTemplate(testAccConnectionOptionAttributesTemplate, params),
+				ExpectError: regexp.MustCompile("400 Bad Request: Cannot set both options.attributes and options.validation"),
+			},
+		},
+	})
+}
+
+func TestAccConnectionOptionsAttrInactiveSignUpNegative(t *testing.T) {
+	params := map[string]interface{}{
+		"testName":          t.Name(),
+		"requires_username": `requires_username = false`,
+		"validation":        ``,
+		"attributes": `attributes {
+							phone_number {
+								identifier {
+									active = true
+								}
+								profile_required = true
+								signup {
+									status = "inactive"
+									verification {
+										active = false
+									}
+								}
+							}
+						}`}
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:      acctest.ParseParametersInTemplate(testAccConnectionOptionAttributesTemplate, params),
+				ExpectError: regexp.MustCompile("attribute phone_number must also be required on signup"),
+			},
+		},
+	})
+}
+
 func TestAccConnectionAD(t *testing.T) {
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -167,8 +167,8 @@ resource "auth0_connection" "my_connection" {
 	strategy = "auth0"
 	options {
 		precedence = ["username","email","phone_number"]
-		{{.validation}}
 		{{.requires_username}}
+		{{.validation}}
 		{{.attributes}}
 		brute_force_protection = true
 	}
@@ -181,19 +181,19 @@ func TestAccConnectionOptionsAttrPhoneNumber(t *testing.T) {
 		"requires_username": `requires_username = false`,
 		"validation":        ``,
 		"attributes": `attributes {
-							phone_number {
-								identifier {
-									active = true
-								}
-								profile_required = true
-								signup {
-									status = "required"
-									verification {
-										active = false
-									}
-								}
-							}
-						}`}
+			phone_number {
+				identifier {
+					active = true
+				}
+				profile_required = true
+				signup {
+					status = "required"
+					verification {
+						active = false
+					}
+				}
+			}
+		}`}
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
@@ -230,19 +230,19 @@ func TestAccConnectionOptionsAttrEmail(t *testing.T) {
 		"requires_username": `requires_username = false`,
 		"validation":        ``,
 		"attributes": `attributes {
-							email {
-								identifier {
-									active = true
-								}
-								profile_required = true
-								signup {
-									status = "required"
-									verification {
-										active = false
-									}
-								}
-							}
-						}`}
+			email {
+				identifier {
+					active = true
+				}
+				profile_required = true
+				signup {
+					status = "required"
+					verification {
+						active = false
+					}
+				}
+			}
+		}`}
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
@@ -279,16 +279,16 @@ func TestAccConnectionOptionsAttrUserName(t *testing.T) {
 		"requires_username": `requires_username = false`,
 		"validation":        ``,
 		"attributes": `attributes {
-							username {
-								identifier {
-									active = true
-								}
-								profile_required = true
-								signup {
-									status = "required"
-								}
-							}
-						}`}
+			username {
+				identifier {
+					active = true
+				}
+				profile_required = true
+				signup {
+					status = "required"
+				}
+			}
+		}`}
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
@@ -324,16 +324,16 @@ func TestAccConnectionOptionsAttrUserNameNegative(t *testing.T) {
 		"testName":          t.Name(),
 		"validation":        ``,
 		"attributes": `attributes {
-							username {
-								identifier {
-									active = true
-								}
-								profile_required = true
-								signup {
-									status = "required"
-								}
-							}
-						}`}
+			username {
+				identifier {
+					active = true
+				}
+				profile_required = true
+				signup {
+					status = "required"
+				}
+			}
+		}`}
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
@@ -350,40 +350,40 @@ func TestAccConnectionOptionsAttrNoActiveNegative(t *testing.T) {
 		"requires_username": `requires_username = false`,
 		"validation":        ``,
 		"attributes": `attributes {
-							phone_number {
-								identifier {
-									active = false
-								}
-								profile_required = true
-								signup {
-									status = "required"
-									verification {
-										active = false
-									}
-								}
-							}
-							email {
-								identifier {
-									active = false
-								}
-								profile_required = true
-								signup {
-									status = "required"
-									verification {
-										active = false
-									}
-								}
-							}
-							username {
-								identifier {
-									active = false
-								}
-								profile_required = true
-								signup {
-									status = "required"
-								}
-							}
-						}`}
+			phone_number {
+				identifier {
+					active = false
+				}
+				profile_required = true
+				signup {
+					status = "required"
+					verification {
+						active = false
+					}
+				}
+			}
+			email {
+				identifier {
+					active = false
+				}
+				profile_required = true
+				signup {
+					status = "required"
+					verification {
+						active = false
+					}
+				}
+			}
+			username {
+				identifier {
+					active = false
+				}
+				profile_required = true
+				signup {
+					status = "required"
+				}
+			}
+		}`}
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
@@ -399,34 +399,34 @@ func TestAccConnectionOptionsAttrSetValidationNegative(t *testing.T) {
 		"testName":          t.Name(),
 		"requires_username": `requires_username = false`,
 		"validation": `validation {
-							username {
-								min = 1
-								max =  5
-							}
-						}`,
+			username {
+				min = 1
+				max =  5
+			}
+		}`,
 		"attributes": `attributes {
-							email {
-								identifier {
-									active = true
-								}
-								profile_required = true
-								signup {
-									status = "required"
-									verification {
-										active = false
-									}
-								}
-							}
-							username {
-								identifier {
-									active = false
-								}
-								profile_required = true
-								signup {
-									status = "required"
-								}
-							}
-						}`}
+			email {
+				identifier {
+					active = true
+				}
+				profile_required = true
+				signup {
+					status = "required"
+					verification {
+						active = false
+					}
+				}
+			}
+			username {
+				identifier {
+					active = false
+				}
+				profile_required = true
+				signup {
+					status = "required"
+				}
+			}
+		}`}
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
@@ -443,19 +443,19 @@ func TestAccConnectionOptionsAttrInactiveSignUpNegative(t *testing.T) {
 		"requires_username": `requires_username = false`,
 		"validation":        ``,
 		"attributes": `attributes {
-							phone_number {
-								identifier {
-									active = true
-								}
-								profile_required = true
-								signup {
-									status = "inactive"
-									verification {
-										active = false
-									}
-								}
-							}
-						}`}
+			phone_number {
+				identifier {
+					active = true
+				}
+				profile_required = true
+				signup {
+					status = "inactive"
+					verification {
+						active = false
+					}
+				}
+			}
+		}`}
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -287,6 +287,14 @@ func TestAccConnectionOptionsAttrUserName(t *testing.T) {
 				signup {
 					status = "required"
 				}
+				validation {
+					min_length = 1
+					max_length = 3
+					allowed_types {
+						email = true
+						phone_number = false
+					}
+				}
 			}
 		}`}
 	acctest.Test(t, resource.TestCase{
@@ -301,6 +309,10 @@ func TestAccConnectionOptionsAttrUserName(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.username.0.identifier.0.active", "true"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.username.0.profile_required", "true"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.username.0.signup.0.status", "required"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.username.0.validation.0.min_length", "1"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.username.0.validation.0.max_length", "3"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.username.0.validation.0.allowed_types.0.email", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.username.0.validation.0.allowed_types.0.phone_number", "false"),
 				),
 			},
 			{

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -1,6 +1,7 @@
 package connection
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -850,6 +851,300 @@ var optionsSchema = &schema.Schema{
 					"to map `user_id` to 'id' instead. This can only be defined on a new Google Workspace connection " +
 					"and can not be changed once set.",
 			},
+			"precedence": {
+				Type:         schema.TypeSet,
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				Optional:     true,
+				Computed:     false,
+				MaxItems:     3,
+				ValidateFunc: validatePrecedence(),
+				Description: "Order of attributes for precedence in identification." +
+					"Valid values: email, phone_number, username. " +
+					"If Precedence is set, it must contain all values (email, phone_number, username) in specific order",
+			},
+			"attributes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: false,
+				Description: "Order of attributes for precedence in identification." +
+					"Valid values: email, phone_number, username. " +
+					"If Precedence is set, it must contain all values (email, phone_number, username) in specific order",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    false,
+							Description: "Connection Options for Email Attribute",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"identifier": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    false,
+										Description: "Connection Options Email Attribute Identifier",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"active": {
+													Type:        schema.TypeBool,
+													Optional:    true,
+													Computed:    false,
+													Description: "Defines whether email attribute is active as an identifier",
+													Elem:        &schema.Schema{Type: schema.TypeBool},
+												},
+											},
+										},
+									},
+									"profile_required": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Computed:    false,
+										Description: "Defines whether Profile is required",
+										Elem:        &schema.Schema{Type: schema.TypeBool},
+									},
+									"signup": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    false,
+										Description: "Defines signup settings for Email attribute",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"status": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    false,
+													Description: "Defines signup status for Email Attribute",
+													Elem:        &schema.Schema{Type: schema.TypeString},
+												},
+												"verification": {
+													Type:        schema.TypeList,
+													Optional:    true,
+													Computed:    false,
+													Description: "Defines settings for Verification under Email attribute",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"active": {
+																Type:        schema.TypeBool,
+																Optional:    true,
+																Computed:    false,
+																Description: "Defines verification settings for signup attribute",
+																Elem:        &schema.Schema{Type: schema.TypeBool},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"username": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    false,
+							Description: "Connection Options for User Name Attribute",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"identifier": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    false,
+										Description: "Connection options for User Name Attribute Identifier",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"active": {
+													Type:        schema.TypeBool,
+													Optional:    true,
+													Computed:    false,
+													Description: "Defines whether UserName attribute is active as an identifier",
+													Elem:        &schema.Schema{Type: schema.TypeBool},
+												},
+											},
+										},
+									},
+									"profile_required": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Computed:    false,
+										Description: "Defines whether Profile is required",
+										Elem:        &schema.Schema{Type: schema.TypeBool},
+									},
+									"signup": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    false,
+										Description: "Defines signup settings for User Name attribute",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"status": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    false,
+													Description: "Defines whether User Name attribute is active as an identifier",
+													Elem:        &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"validation": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    false,
+										Description: "Defines validation settings for User Name attribute",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"min_length": {
+													Type:        schema.TypeInt,
+													Optional:    true,
+													Computed:    false,
+													Description: "Defines Min Length for User Name attribute",
+													Elem:        &schema.Schema{Type: schema.TypeInt},
+												},
+												"max_length": {
+													Type:        schema.TypeInt,
+													Optional:    true,
+													Computed:    false,
+													Description: "Defines Max Length for User Name attribute",
+													Elem:        &schema.Schema{Type: schema.TypeInt},
+												},
+												"allowed_types": {
+													Type:        schema.TypeList,
+													Optional:    true,
+													Computed:    false,
+													Description: "Defines allowed types for for UserName attribute",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"email": {
+																Type:        schema.TypeBool,
+																Optional:    true,
+																Computed:    false,
+																Description: "One of the allowed types for UserName signup attribute",
+																Elem:        &schema.Schema{Type: schema.TypeBool},
+															},
+															"phone_number": {
+																Type:        schema.TypeBool,
+																Optional:    true,
+																Computed:    false,
+																Description: "One of the allowed types for UserName signup attribute",
+																Elem:        &schema.Schema{Type: schema.TypeBool},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"phone_number": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    false,
+							Description: "Connection Options for Phone Number Attribute",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"identifier": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    false,
+										Description: "Connection Options Phone Number Attribute Identifier",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"active": {
+													Type:        schema.TypeBool,
+													Optional:    true,
+													Computed:    false,
+													Description: "Defines whether Phone Number attribute is active as an identifier",
+													Elem:        &schema.Schema{Type: schema.TypeBool},
+												},
+											},
+										},
+									},
+									"profile_required": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Computed:    false,
+										Description: "Defines whether Profile is required",
+										Elem:        &schema.Schema{Type: schema.TypeBool},
+									},
+									"signup": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    false,
+										Description: "Defines signup settings for Phone Number attribute",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"status": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    false,
+													Description: "Defines status of signup for Phone Number attribute ",
+													Elem:        &schema.Schema{Type: schema.TypeString},
+												},
+												"verification": {
+													Type:        schema.TypeList,
+													Optional:    true,
+													Computed:    false,
+													Description: "Defines verification settings for Phone Number attribute",
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"active": {
+																Type:        schema.TypeBool,
+																Optional:    true,
+																Computed:    false,
+																Description: "Defines verification settings for Phone Number attribute",
+																Elem:        &schema.Schema{Type: schema.TypeBool},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	},
+}
+
+func validatePrecedence() schema.SchemaValidateFunc {
+	return func(val interface{}, key string) (warnings []string, errors []error) {
+		set, ok := val.(*schema.Set)
+		if !ok {
+			errors = append(errors, fmt.Errorf("'%s' must be a set", key))
+			return warnings, errors
+		}
+
+		if set.Len() == 0 {
+			return warnings, errors
+		}
+
+		if set.Len() != 3 {
+			errors = append(errors, fmt.Errorf("'%s' must contain exactly 3 elements", key))
+			return warnings, errors
+		}
+
+		requiredValues := []string{"email", "phone_number", "username"}
+		values := set.List()
+
+		for _, required := range requiredValues {
+			found := false
+			for _, v := range values {
+				if v.(string) == required {
+					found = true
+					break
+				}
+			}
+			if !found {
+				errors = append(errors, fmt.Errorf("missing value '%s' in '%s'", required, key))
+			}
+		}
+		return warnings, errors
+	}
 }

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -988,39 +988,39 @@ var optionsSchema = &schema.Schema{
 									"validation": {
 										Type:        schema.TypeList,
 										Optional:    true,
-										Computed:    false,
+										Computed:    true,
 										Description: "Defines validation settings for User Name attribute",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"min_length": {
 													Type:        schema.TypeInt,
 													Optional:    true,
-													Computed:    false,
+													Computed:    true,
 													Description: "Defines Min Length for User Name attribute",
 												},
 												"max_length": {
 													Type:        schema.TypeInt,
 													Optional:    true,
-													Computed:    false,
+													Computed:    true,
 													Description: "Defines Max Length for User Name attribute",
 												},
 												"allowed_types": {
 													Type:        schema.TypeList,
 													Optional:    true,
-													Computed:    false,
+													Computed:    true,
 													Description: "Defines allowed types for for UserName attribute",
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"email": {
 																Type:        schema.TypeBool,
 																Optional:    true,
-																Computed:    false,
+																Computed:    true,
 																Description: "One of the allowed types for UserName signup attribute",
 															},
 															"phone_number": {
 																Type:        schema.TypeBool,
 																Optional:    true,
-																Computed:    false,
+																Computed:    true,
 																Description: "One of the allowed types for UserName signup attribute",
 															},
 														},

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -2,6 +2,7 @@ package connection
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -515,7 +515,6 @@ var optionsSchema = &schema.Schema{
 				Optional:    true,
 				Description: "Specifies whether or not request info should be forwarded to sms gateway.",
 			},
-
 			"set_user_root_attributes": {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/test/data/recordings/TestAccClientAuthenticationMethods.yaml
+++ b/test/data/recordings/TestAccClientAuthenticationMethods.yaml
@@ -19,7 +19,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
+                - Go-Auth0/1.8.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients
         method: POST
       response:
@@ -30,33 +30,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 768.869166ms
+        duration: 444.361667ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -66,33 +65,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.192458ms
+        duration: 276.099834ms
     - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -102,33 +100,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 3.124887959s
+        duration: 272.156167ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -138,33 +135,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 2.068729791s
+        duration: 218.999291ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -174,33 +170,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 2.923138958s
+        duration: 261.66675ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -210,33 +205,68 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 2.380279s
+        duration: 196.853334ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 52
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '[]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 136.606167ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 89
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"token_endpoint_auth_method":"client_secret_post"}
+            {"client_authentication_methods":null,"token_endpoint_auth_method":"client_secret_post"}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -246,14 +276,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 530.838167ms
-    - id: 7
+        duration: 133.108334ms
+    - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -271,8 +301,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -282,69 +312,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 2.161564208s
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 1.40850975s
+        duration: 523.469709ms
     - id: 9
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -354,14 +347,49 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 478.28ms
+        duration: 167.823459ms
     - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 126.18925ms
+    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -379,8 +407,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials
         method: POST
       response:
         proto: HTTP/2.0
@@ -390,14 +418,14 @@ interactions:
         trailer: {}
         content_length: 284
         uncompressed: false
-        body: '{"id":"cred_pTAtpi8GnpdCXDu47QUuJb","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:06.674Z","updated_at":"2023-12-19T13:33:06.674Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:22.525Z","updated_at":"2024-08-08T21:38:22.525Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 1.19009825s
-    - id: 11
+        duration: 165.412416ms
+    - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -409,14 +437,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_pTAtpi8GnpdCXDu47QUuJb"}]}},"token_endpoint_auth_method":null}
+            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF"}]}},"token_endpoint_auth_method":null}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -426,69 +454,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_pTAtpi8GnpdCXDu47QUuJb"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 3.307702917s
-    - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_pTAtpi8GnpdCXDu47QUuJb"}]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 877.837584ms
+        duration: 170.9225ms
     - id: 13
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_pTAtpi8GnpdCXDu47QUuJb
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -498,33 +489,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_pTAtpi8GnpdCXDu47QUuJb","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:06.674Z","updated_at":"2023-12-19T13:33:06.674Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 958.817166ms
+        duration: 106.457917ms
     - id: 14
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_2rSgjw4zHnbvEFSYU7fuaF
         method: GET
       response:
         proto: HTTP/2.0
@@ -534,33 +524,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_pTAtpi8GnpdCXDu47QUuJb"}]}}}'
+        body: '{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:22.525Z","updated_at":"2024-08-08T21:38:22.525Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 692.316125ms
+        duration: 115.505875ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,33 +559,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_pTAtpi8GnpdCXDu47QUuJb"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.565868334s
+        duration: 120.477ms
     - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_pTAtpi8GnpdCXDu47QUuJb
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -606,33 +594,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_pTAtpi8GnpdCXDu47QUuJb","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:06.674Z","updated_at":"2023-12-19T13:33:06.674Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 712.993708ms
+        duration: 221.511208ms
     - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_2rSgjw4zHnbvEFSYU7fuaF
         method: GET
       response:
         proto: HTTP/2.0
@@ -642,33 +629,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_pTAtpi8GnpdCXDu47QUuJb"}]}}}'
+        body: '{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:22.525Z","updated_at":"2024-08-08T21:38:22.525Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 3.075307334s
+        duration: 109.666458ms
     - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -678,33 +664,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_pTAtpi8GnpdCXDu47QUuJb"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 692.518959ms
+        duration: 129.229959ms
     - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_pTAtpi8GnpdCXDu47QUuJb
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -714,33 +699,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_pTAtpi8GnpdCXDu47QUuJb","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:06.674Z","updated_at":"2023-12-19T13:33:06.674Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.127934125s
+        duration: 118.865ms
     - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_2rSgjw4zHnbvEFSYU7fuaF
         method: GET
       response:
         proto: HTTP/2.0
@@ -750,33 +734,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:22.525Z","updated_at":"2024-08-08T21:38:22.525Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 736.568958ms
+        duration: 107.653166ms
     - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials?include_totals=true&per_page=50
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -786,14 +769,49 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"cred_pTAtpi8GnpdCXDu47QUuJb","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:06.674Z","updated_at":"2023-12-19T13:33:06.674Z","expires_at":"2033-05-13T09:33:13.000Z"}]'
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.10779425s
+        duration: 126.464459ms
     - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"cred_2rSgjw4zHnbvEFSYU7fuaF","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:22.525Z","updated_at":"2024-08-08T21:38:22.525Z","expires_at":"2033-05-13T09:33:13.000Z"}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 109.475625ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -811,8 +829,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -822,14 +840,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 2.039958125s
-    - id: 23
+        duration: 126.526917ms
+    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -846,8 +864,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_pTAtpi8GnpdCXDu47QUuJb
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_2rSgjw4zHnbvEFSYU7fuaF
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -863,27 +881,26 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 994.081833ms
-    - id: 24
+        duration: 119.544667ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -893,14 +910,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 706.706458ms
-    - id: 25
+        duration: 114.228917ms
+    - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -918,8 +935,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials
         method: POST
       response:
         proto: HTTP/2.0
@@ -929,14 +946,14 @@ interactions:
         trailer: {}
         content_length: 284
         uncompressed: false
-        body: '{"id":"cred_qyRW9MoALpYMcLmGZmy1wv","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:28.899Z","updated_at":"2023-12-19T13:33:28.899Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_qifzsx1qZVFdiEoXpa71FP","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:25.388Z","updated_at":"2024-08-08T21:38:25.388Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 2.007449083s
-    - id: 26
+        duration: 123.486041ms
+    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -954,8 +971,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials
         method: POST
       response:
         proto: HTTP/2.0
@@ -965,14 +982,14 @@ interactions:
         trailer: {}
         content_length: 284
         uncompressed: false
-        body: '{"id":"cred_oLRodNDyFDMghGcQvf1m1a","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:33:32.372Z","updated_at":"2023-12-19T13:33:32.372Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_2owc7YazYLcCyHJCSam1R1","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:25.508Z","updated_at":"2024-08-08T21:38:25.508Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 3.474828875s
-    - id: 27
+        duration: 119.613083ms
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -984,14 +1001,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}},"token_endpoint_auth_method":null}
+            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}},"token_endpoint_auth_method":null}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1001,69 +1018,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.230917125s
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 1.068099708s
+        duration: 208.356084ms
     - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_qyRW9MoALpYMcLmGZmy1wv
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -1073,33 +1053,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_qyRW9MoALpYMcLmGZmy1wv","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:28.899Z","updated_at":"2023-12-19T13:33:28.899Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 880.312625ms
+        duration: 129.264125ms
     - id: 30
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_oLRodNDyFDMghGcQvf1m1a
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_qifzsx1qZVFdiEoXpa71FP
         method: GET
       response:
         proto: HTTP/2.0
@@ -1109,33 +1088,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_oLRodNDyFDMghGcQvf1m1a","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:33:32.372Z","updated_at":"2023-12-19T13:33:32.372Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_qifzsx1qZVFdiEoXpa71FP","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:25.388Z","updated_at":"2024-08-08T21:38:25.388Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 938.58925ms
+        duration: 137.603125ms
     - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_2owc7YazYLcCyHJCSam1R1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1145,33 +1123,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}}}'
+        body: '{"id":"cred_2owc7YazYLcCyHJCSam1R1","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:25.508Z","updated_at":"2024-08-08T21:38:25.508Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.562136875s
+        duration: 104.518833ms
     - id: 32
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -1181,33 +1158,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 848.886084ms
+        duration: 120.184208ms
     - id: 33
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_qyRW9MoALpYMcLmGZmy1wv
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -1217,33 +1193,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_qyRW9MoALpYMcLmGZmy1wv","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:28.899Z","updated_at":"2023-12-19T13:33:28.899Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 493.084125ms
+        duration: 118.573125ms
     - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_oLRodNDyFDMghGcQvf1m1a
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_qifzsx1qZVFdiEoXpa71FP
         method: GET
       response:
         proto: HTTP/2.0
@@ -1253,33 +1228,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_oLRodNDyFDMghGcQvf1m1a","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:33:32.372Z","updated_at":"2023-12-19T13:33:32.372Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_qifzsx1qZVFdiEoXpa71FP","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:25.388Z","updated_at":"2024-08-08T21:38:25.388Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.767241291s
+        duration: 104.257ms
     - id: 35
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_2owc7YazYLcCyHJCSam1R1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1289,33 +1263,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}}}'
+        body: '{"id":"cred_2owc7YazYLcCyHJCSam1R1","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:25.508Z","updated_at":"2024-08-08T21:38:25.508Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.178760125s
+        duration: 106.977458ms
     - id: 36
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -1325,33 +1298,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.312958334s
+        duration: 115.314375ms
     - id: 37
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_qyRW9MoALpYMcLmGZmy1wv
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -1361,33 +1333,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_qyRW9MoALpYMcLmGZmy1wv","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:28.899Z","updated_at":"2023-12-19T13:33:28.899Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.366791667s
+        duration: 150.765ms
     - id: 38
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_oLRodNDyFDMghGcQvf1m1a
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_qifzsx1qZVFdiEoXpa71FP
         method: GET
       response:
         proto: HTTP/2.0
@@ -1397,33 +1368,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_oLRodNDyFDMghGcQvf1m1a","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:33:32.372Z","updated_at":"2023-12-19T13:33:32.372Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_qifzsx1qZVFdiEoXpa71FP","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:25.388Z","updated_at":"2024-08-08T21:38:25.388Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 263.1965ms
+        duration: 105.053875ms
     - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_2owc7YazYLcCyHJCSam1R1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1433,14 +1403,49 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"id":"cred_2owc7YazYLcCyHJCSam1R1","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:25.508Z","updated_at":"2024-08-08T21:38:25.508Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 297.240584ms
+        duration: 111.355583ms
     - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 115.345333ms
+    - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1458,8 +1463,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_qyRW9MoALpYMcLmGZmy1wv
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_qifzsx1qZVFdiEoXpa71FP
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1469,69 +1474,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_qyRW9MoALpYMcLmGZmy1wv","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:28.899Z","updated_at":"2023-12-19T13:33:47.610Z","expires_at":"2050-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_qifzsx1qZVFdiEoXpa71FP","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:25.388Z","updated_at":"2024-08-08T21:38:28.409Z","expires_at":"2050-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 303.58725ms
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 1.005531125s
+        duration: 110.885625ms
     - id: 42
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_qyRW9MoALpYMcLmGZmy1wv
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -1541,33 +1509,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_qyRW9MoALpYMcLmGZmy1wv","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:28.899Z","updated_at":"2023-12-19T13:33:47.610Z","expires_at":"2050-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 448.260375ms
+        duration: 126.755542ms
     - id: 43
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_oLRodNDyFDMghGcQvf1m1a
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_qifzsx1qZVFdiEoXpa71FP
         method: GET
       response:
         proto: HTTP/2.0
@@ -1577,33 +1544,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_oLRodNDyFDMghGcQvf1m1a","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:33:32.372Z","updated_at":"2023-12-19T13:33:32.372Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_qifzsx1qZVFdiEoXpa71FP","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:25.388Z","updated_at":"2024-08-08T21:38:28.409Z","expires_at":"2050-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.365206417s
+        duration: 105.213417ms
     - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_2owc7YazYLcCyHJCSam1R1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1613,33 +1579,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}}}'
+        body: '{"id":"cred_2owc7YazYLcCyHJCSam1R1","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:25.508Z","updated_at":"2024-08-08T21:38:25.508Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 2.18279675s
+        duration: 102.332334ms
     - id: 45
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -1649,33 +1614,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 660.878333ms
+        duration: 109.04975ms
     - id: 46
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_qyRW9MoALpYMcLmGZmy1wv
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -1685,33 +1649,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_qyRW9MoALpYMcLmGZmy1wv","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:28.899Z","updated_at":"2023-12-19T13:33:47.610Z","expires_at":"2050-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.057784958s
+        duration: 118.408166ms
     - id: 47
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_oLRodNDyFDMghGcQvf1m1a
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_qifzsx1qZVFdiEoXpa71FP
         method: GET
       response:
         proto: HTTP/2.0
@@ -1721,33 +1684,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_oLRodNDyFDMghGcQvf1m1a","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:33:32.372Z","updated_at":"2023-12-19T13:33:32.372Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_qifzsx1qZVFdiEoXpa71FP","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:25.388Z","updated_at":"2024-08-08T21:38:28.409Z","expires_at":"2050-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.842193625s
+        duration: 107.577958ms
     - id: 48
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_2owc7YazYLcCyHJCSam1R1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1757,33 +1719,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}}}'
+        body: '{"id":"cred_2owc7YazYLcCyHJCSam1R1","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:25.508Z","updated_at":"2024-08-08T21:38:25.508Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.192388708s
+        duration: 110.076333ms
     - id: 49
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -1793,33 +1754,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qyRW9MoALpYMcLmGZmy1wv"},{"id":"cred_oLRodNDyFDMghGcQvf1m1a"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 720.593333ms
+        duration: 113.660291ms
     - id: 50
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_qyRW9MoALpYMcLmGZmy1wv
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -1829,33 +1789,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_qyRW9MoALpYMcLmGZmy1wv","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:28.899Z","updated_at":"2023-12-19T13:33:47.610Z","expires_at":"2050-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_qifzsx1qZVFdiEoXpa71FP"},{"id":"cred_2owc7YazYLcCyHJCSam1R1"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.152465666s
+        duration: 107.904667ms
     - id: 51
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_oLRodNDyFDMghGcQvf1m1a
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_qifzsx1qZVFdiEoXpa71FP
         method: GET
       response:
         proto: HTTP/2.0
@@ -1865,33 +1824,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_oLRodNDyFDMghGcQvf1m1a","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:33:32.372Z","updated_at":"2023-12-19T13:33:32.372Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_qifzsx1qZVFdiEoXpa71FP","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:25.388Z","updated_at":"2024-08-08T21:38:28.409Z","expires_at":"2050-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 944.453083ms
+        duration: 109.039833ms
     - id: 52
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_2owc7YazYLcCyHJCSam1R1
         method: GET
       response:
         proto: HTTP/2.0
@@ -1901,33 +1859,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"id":"cred_2owc7YazYLcCyHJCSam1R1","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:25.508Z","updated_at":"2024-08-08T21:38:25.508Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 909.293083ms
+        duration: 114.069291ms
     - id: 53
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials?include_totals=true&per_page=50
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -1937,14 +1894,49 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"cred_oLRodNDyFDMghGcQvf1m1a","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:33:32.372Z","updated_at":"2023-12-19T13:33:32.372Z","expires_at":"2025-05-13T09:33:13.000Z"},{"id":"cred_qyRW9MoALpYMcLmGZmy1wv","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2023-12-19T13:33:28.899Z","updated_at":"2023-12-19T13:33:47.610Z","expires_at":"2050-05-13T09:33:13.000Z"}]'
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.364168125s
+        duration: 118.572ms
     - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"cred_2owc7YazYLcCyHJCSam1R1","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:25.508Z","updated_at":"2024-08-08T21:38:25.508Z","expires_at":"2025-05-13T09:33:13.000Z"},{"id":"cred_qifzsx1qZVFdiEoXpa71FP","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2024-08-08T21:38:25.388Z","updated_at":"2024-08-08T21:38:28.409Z","expires_at":"2050-05-13T09:33:13.000Z"}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 142.607125ms
+    - id: 55
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1962,8 +1954,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -1973,48 +1965,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 685.265166ms
-    - id: 55
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_oLRodNDyFDMghGcQvf1m1a
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 708.2015ms
+        duration: 118.851791ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -2032,8 +1989,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_qyRW9MoALpYMcLmGZmy1wv
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_2owc7YazYLcCyHJCSam1R1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2049,27 +2006,61 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 874.161583ms
+        duration: 100.632ms
     - id: 57
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_qifzsx1qZVFdiEoXpa71FP
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 115.943875ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -2079,14 +2070,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.077711042s
-    - id: 58
+        duration: 115.26725ms
+    - id: 59
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2104,8 +2095,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials
         method: POST
       response:
         proto: HTTP/2.0
@@ -2115,14 +2106,14 @@ interactions:
         trailer: {}
         content_length: 284
         uncompressed: false
-        body: '{"id":"cred_2u7YAyH8mEUiujDENG9hLK","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:34:08.438Z","updated_at":"2023-12-19T13:34:08.438Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_v9ULccKC5xXbA9srEZbk5x","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:31.611Z","updated_at":"2024-08-08T21:38:31.611Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 948.225833ms
-    - id: 59
+        duration: 155.750792ms
+    - id: 60
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2134,14 +2125,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2u7YAyH8mEUiujDENG9hLK"}]}},"token_endpoint_auth_method":null}
+            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_v9ULccKC5xXbA9srEZbk5x"}]}},"token_endpoint_auth_method":null}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2151,69 +2142,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2u7YAyH8mEUiujDENG9hLK"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_v9ULccKC5xXbA9srEZbk5x"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 937.543667ms
-    - id: 60
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2u7YAyH8mEUiujDENG9hLK"}]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 859.229625ms
+        duration: 120.565334ms
     - id: 61
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_2u7YAyH8mEUiujDENG9hLK
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -2223,33 +2177,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_2u7YAyH8mEUiujDENG9hLK","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:34:08.438Z","updated_at":"2023-12-19T13:34:08.438Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_v9ULccKC5xXbA9srEZbk5x"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.779517375s
+        duration: 119.919666ms
     - id: 62
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_v9ULccKC5xXbA9srEZbk5x
         method: GET
       response:
         proto: HTTP/2.0
@@ -2259,33 +2212,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2u7YAyH8mEUiujDENG9hLK"}]}}}'
+        body: '{"id":"cred_v9ULccKC5xXbA9srEZbk5x","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:31.611Z","updated_at":"2024-08-08T21:38:31.611Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 2.317801167s
+        duration: 120.483ms
     - id: 63
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -2295,33 +2247,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2u7YAyH8mEUiujDENG9hLK"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_v9ULccKC5xXbA9srEZbk5x"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.404478167s
+        duration: 136.075125ms
     - id: 64
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_2u7YAyH8mEUiujDENG9hLK
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -2331,33 +2282,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_2u7YAyH8mEUiujDENG9hLK","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:34:08.438Z","updated_at":"2023-12-19T13:34:08.438Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_v9ULccKC5xXbA9srEZbk5x"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.147184667s
+        duration: 116.412833ms
     - id: 65
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_v9ULccKC5xXbA9srEZbk5x
         method: GET
       response:
         proto: HTTP/2.0
@@ -2367,33 +2317,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2u7YAyH8mEUiujDENG9hLK"}]}}}'
+        body: '{"id":"cred_v9ULccKC5xXbA9srEZbk5x","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:31.611Z","updated_at":"2024-08-08T21:38:31.611Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 4.225012416s
+        duration: 123.80675ms
     - id: 66
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -2403,33 +2352,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_2u7YAyH8mEUiujDENG9hLK"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_v9ULccKC5xXbA9srEZbk5x"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 4.054737291s
+        duration: 111.983541ms
     - id: 67
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_2u7YAyH8mEUiujDENG9hLK
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -2439,33 +2387,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_2u7YAyH8mEUiujDENG9hLK","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:34:08.438Z","updated_at":"2023-12-19T13:34:08.438Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_v9ULccKC5xXbA9srEZbk5x"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 482.315667ms
+        duration: 107.134625ms
     - id: 68
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_v9ULccKC5xXbA9srEZbk5x
         method: GET
       response:
         proto: HTTP/2.0
@@ -2475,33 +2422,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"id":"cred_v9ULccKC5xXbA9srEZbk5x","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:31.611Z","updated_at":"2024-08-08T21:38:31.611Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 2.565711125s
+        duration: 155.788375ms
     - id: 69
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials?include_totals=true&per_page=50
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -2511,14 +2457,49 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"cred_2u7YAyH8mEUiujDENG9hLK","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:34:08.438Z","updated_at":"2023-12-19T13:34:08.438Z","expires_at":"2025-05-13T09:33:13.000Z"}]'
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 713.773542ms
+        duration: 111.467167ms
     - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"cred_v9ULccKC5xXbA9srEZbk5x","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:31.611Z","updated_at":"2024-08-08T21:38:31.611Z","expires_at":"2025-05-13T09:33:13.000Z"}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 99.824292ms
+    - id: 71
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2536,8 +2517,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2547,14 +2528,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 4.585292834s
-    - id: 71
+        duration: 128.837666ms
+    - id: 72
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2571,8 +2552,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_2u7YAyH8mEUiujDENG9hLK
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_v9ULccKC5xXbA9srEZbk5x
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2588,27 +2569,26 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 1.830089583s
-    - id: 72
+        duration: 108.11775ms
+    - id: 73
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -2618,14 +2598,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.663701541s
-    - id: 73
+        duration: 104.337875ms
+    - id: 74
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2643,8 +2623,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2654,69 +2634,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.528344709s
-    - id: 74
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 1.118804209s
+        duration: 125.068375ms
     - id: 75
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -2726,33 +2669,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 955.192ms
+        duration: 112.803625ms
     - id: 76
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -2762,33 +2704,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 2.244583375s
+        duration: 125.477292ms
     - id: 77
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -2798,33 +2739,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 950.323333ms
+        duration: 110.731125ms
     - id: 78
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -2834,33 +2774,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 702.924083ms
+        duration: 116.644709ms
     - id: 79
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -2870,14 +2809,49 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.318837667s
+        duration: 113.937292ms
     - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id%2Capp_type&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 136.026542ms
+    - id: 81
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2895,8 +2869,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2906,33 +2880,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.548110292s
-    - id: 81
+        duration: 120.995792ms
+    - id: 82
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -2942,14 +2915,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.955985416s
-    - id: 82
+        duration: 135.707667ms
+    - id: 83
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2967,8 +2940,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials
         method: POST
       response:
         proto: HTTP/2.0
@@ -2978,14 +2951,14 @@ interactions:
         trailer: {}
         content_length: 284
         uncompressed: false
-        body: '{"id":"cred_jajddCZxz1cEDqM4ZGdy2h","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:34:55.017Z","updated_at":"2023-12-19T13:34:55.017Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_9P76CwqxM5jVWzHBSDep59","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:36.627Z","updated_at":"2024-08-08T21:38:36.627Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 2.208141541s
-    - id: 83
+        duration: 147.726375ms
+    - id: 84
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2997,14 +2970,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_jajddCZxz1cEDqM4ZGdy2h"}]}},"token_endpoint_auth_method":null}
+            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_9P76CwqxM5jVWzHBSDep59"}]}},"token_endpoint_auth_method":null}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -3014,69 +2987,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_jajddCZxz1cEDqM4ZGdy2h"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_9P76CwqxM5jVWzHBSDep59"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.766901916s
-    - id: 84
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_jajddCZxz1cEDqM4ZGdy2h"}]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 1.187578041s
+        duration: 120.373583ms
     - id: 85
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_jajddCZxz1cEDqM4ZGdy2h
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -3086,33 +3022,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_jajddCZxz1cEDqM4ZGdy2h","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:34:55.017Z","updated_at":"2023-12-19T13:34:55.017Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_9P76CwqxM5jVWzHBSDep59"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.06915525s
+        duration: 105.423375ms
     - id: 86
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_9P76CwqxM5jVWzHBSDep59
         method: GET
       response:
         proto: HTTP/2.0
@@ -3122,33 +3057,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_jajddCZxz1cEDqM4ZGdy2h"}]}}}'
+        body: '{"id":"cred_9P76CwqxM5jVWzHBSDep59","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:36.627Z","updated_at":"2024-08-08T21:38:36.627Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.223425959s
+        duration: 107.655125ms
     - id: 87
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -3158,33 +3092,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_jajddCZxz1cEDqM4ZGdy2h"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_9P76CwqxM5jVWzHBSDep59"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.675563875s
+        duration: 111.650833ms
     - id: 88
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_jajddCZxz1cEDqM4ZGdy2h
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -3194,33 +3127,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_jajddCZxz1cEDqM4ZGdy2h","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:34:55.017Z","updated_at":"2023-12-19T13:34:55.017Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_9P76CwqxM5jVWzHBSDep59"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 732.819292ms
+        duration: 109.4085ms
     - id: 89
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_9P76CwqxM5jVWzHBSDep59
         method: GET
       response:
         proto: HTTP/2.0
@@ -3230,33 +3162,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_jajddCZxz1cEDqM4ZGdy2h"}]}}}'
+        body: '{"id":"cred_9P76CwqxM5jVWzHBSDep59","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:36.627Z","updated_at":"2024-08-08T21:38:36.627Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 899.459334ms
+        duration: 104.444458ms
     - id: 90
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -3266,33 +3197,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_jajddCZxz1cEDqM4ZGdy2h"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_9P76CwqxM5jVWzHBSDep59"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 937.298ms
+        duration: 116.888125ms
     - id: 91
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_jajddCZxz1cEDqM4ZGdy2h
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -3302,33 +3232,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_jajddCZxz1cEDqM4ZGdy2h","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:34:55.017Z","updated_at":"2023-12-19T13:34:55.017Z","expires_at":"2025-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_9P76CwqxM5jVWzHBSDep59"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 503.8935ms
+        duration: 123.267ms
     - id: 92
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_9P76CwqxM5jVWzHBSDep59
         method: GET
       response:
         proto: HTTP/2.0
@@ -3338,33 +3267,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"id":"cred_9P76CwqxM5jVWzHBSDep59","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:36.627Z","updated_at":"2024-08-08T21:38:36.627Z","expires_at":"2025-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.674042375s
+        duration: 115.021459ms
     - id: 93
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials?include_totals=true&per_page=50
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -3374,14 +3302,49 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"cred_jajddCZxz1cEDqM4ZGdy2h","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2023-12-19T13:34:55.017Z","updated_at":"2023-12-19T13:34:55.017Z","expires_at":"2025-05-13T09:33:13.000Z"}]'
+        body: '{"client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.929952375s
+        duration: 108.314042ms
     - id: 94
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"cred_9P76CwqxM5jVWzHBSDep59","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2024-08-08T21:38:36.627Z","updated_at":"2024-08-08T21:38:36.627Z","expires_at":"2025-05-13T09:33:13.000Z"}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 106.421709ms
+    - id: 95
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3399,8 +3362,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -3410,14 +3373,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 517.565875ms
-    - id: 95
+        duration: 149.624167ms
+    - id: 96
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3434,8 +3397,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz/credentials/cred_jajddCZxz1cEDqM4ZGdy2h
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj/credentials/cred_9P76CwqxM5jVWzHBSDep59
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3451,63 +3414,26 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 735.796125ms
-    - id: 96
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 2.838378584s
+        duration: 115.906417ms
     - id: 97
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -3517,33 +3443,32 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 484.440834ms
+        duration: 110.338083ms
     - id: 98
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 5
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            null
+        body: ""
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: GET
       response:
         proto: HTTP/2.0
@@ -3553,13 +3478,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 473.508ms
+        duration: 113.57675ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -3577,8 +3502,43 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.4.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/a8V51fh8QmZSN11Veb9tc1vrvzsHn7nz
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethods","client_id":"X79whknVHCNK2sN6gehJtKAz0mUjlotj","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 138.701209ms
+    - id: 100
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/X79whknVHCNK2sN6gehJtKAz0mUjlotj
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3594,4 +3554,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 385.536292ms
+        duration: 184.808041ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrEmail.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrEmail.yaml
@@ -28,12 +28,292 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 111
+        content_length: 596
         uncompressed: false
-        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        body: '{"id":"con_Czze8lJ9J8dZtzMc","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"email":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}}},"strategy_version":2},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmail","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmail"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 400 Bad Request
-        code: 400
-        duration: 340.601833ms
+        status: 201 Created
+        code: 201
+        duration: 177.413667ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Czze8lJ9J8dZtzMc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_Czze8lJ9J8dZtzMc","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"identifier":{"active":true},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmail","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmail"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 110.053666ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Czze8lJ9J8dZtzMc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_Czze8lJ9J8dZtzMc","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"identifier":{"active":true},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmail","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmail"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 105.755125ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 110.01925ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Czze8lJ9J8dZtzMc
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_Czze8lJ9J8dZtzMc","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"identifier":{"active":true},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmail","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmail"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 228.355583ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_Czze8lJ9J8dZtzMc
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2024-08-02T14:35:09.559Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 115.069875ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 103.986625ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 108.784709ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections?include_totals=true&page=0&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"total":3,"start":0,"limit":50,"connections":[{"id":"con_NgUj1aAYUvMI1smy","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"craig-test-okta-connection","is_domain_connection":false,"show_as_button":false,"display_name":"Craig Test Okta Workforce Connection","realms":["craig-test-okta-connection"],"enabled_clients":[]},{"id":"con_nxtsVa2XBrGFWqrj","options":{"email":true,"scope":["email","profile"],"profile":true},"strategy":"google-oauth2","name":"google-oauth2","is_domain_connection":false,"realms":["google-oauth2"],"enabled_clients":["i4LnBZLIAarAMmWvIJdXwFhwDGs9wlEW","CD7KYYaQgl5CKjfoV5NMVljTPxJlOFs9"]},{"id":"con_cerN9Nsm83juEPcC","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Username-Password-Authentication","is_domain_connection":false,"realms":["Username-Password-Authentication"],"enabled_clients":["i4LnBZLIAarAMmWvIJdXwFhwDGs9wlEW","CD7KYYaQgl5CKjfoV5NMVljTPxJlOFs9"]}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 121.299833ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrEmail.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrEmail.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 377
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmail","strategy":"auth0","is_domain_connection":true,"options":{"brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"email":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 111
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 340.601833ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrInactiveSignUpNegative.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrInactiveSignUpNegative.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 401
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrInactiveSignUpNegative","strategy":"auth0","is_domain_connection":true,"options":{"brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"phone_number":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"inactive","verification":{"active":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 111
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 434.574708ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrInactiveSignUpNegative.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrInactiveSignUpNegative.yaml
@@ -28,12 +28,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 111
+        content_length: 134
         uncompressed: false
-        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        body: '{"statusCode":400,"error":"Bad Request","message":"attribute phone_number must also be required on signup","errorCode":"invalid_body"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 400 Bad Request
         code: 400
-        duration: 434.574708ms
+        duration: 104.971792ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrNoActiveNegative.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrNoActiveNegative.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 621
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrNoActiveNegative","strategy":"auth0","is_domain_connection":true,"options":{"brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"email":{"identifier":{"active":false},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}},"username":{"identifier":{"active":false},"profile_required":true,"signup":{"status":"required"}},"phone_number":{"identifier":{"active":false},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 111
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 355.003125ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrNoActiveNegative.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrNoActiveNegative.yaml
@@ -28,12 +28,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 111
+        content_length: 125
         uncompressed: false
-        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        body: '{"statusCode":400,"error":"Bad Request","message":"attributes must contain one active identifier","errorCode":"invalid_body"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 400 Bad Request
         code: 400
-        duration: 355.003125ms
+        duration: 112.985208ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrPhoneNumber.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrPhoneNumber.yaml
@@ -28,12 +28,292 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 111
+        content_length: 615
         uncompressed: false
-        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        body: '{"id":"con_24Q5zz6L4jldiLbH","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"phone_number":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}}},"strategy_version":2},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrPhoneNumber","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrPhoneNumber"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 400 Bad Request
-        code: 400
-        duration: 473.253584ms
+        status: 201 Created
+        code: 201
+        duration: 352.258042ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_24Q5zz6L4jldiLbH
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_24Q5zz6L4jldiLbH","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"phone_number":{"signup":{"status":"required","verification":{"active":false}},"identifier":{"active":true},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrPhoneNumber","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrPhoneNumber"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 244.282917ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_24Q5zz6L4jldiLbH
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_24Q5zz6L4jldiLbH","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"phone_number":{"signup":{"status":"required","verification":{"active":false}},"identifier":{"active":true},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrPhoneNumber","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrPhoneNumber"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 117.041375ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 97.546ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_24Q5zz6L4jldiLbH
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_24Q5zz6L4jldiLbH","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"phone_number":{"signup":{"status":"required","verification":{"active":false}},"identifier":{"active":true},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrPhoneNumber","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrPhoneNumber"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 117.415417ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_24Q5zz6L4jldiLbH
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2024-08-02T14:35:00.537Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 124.417584ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 114.812459ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 107.395417ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections?include_totals=true&page=0&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"total":3,"start":0,"limit":50,"connections":[{"id":"con_NgUj1aAYUvMI1smy","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"craig-test-okta-connection","is_domain_connection":false,"show_as_button":false,"display_name":"Craig Test Okta Workforce Connection","realms":["craig-test-okta-connection"],"enabled_clients":[]},{"id":"con_nxtsVa2XBrGFWqrj","options":{"email":true,"scope":["email","profile"],"profile":true},"strategy":"google-oauth2","name":"google-oauth2","is_domain_connection":false,"realms":["google-oauth2"],"enabled_clients":["i4LnBZLIAarAMmWvIJdXwFhwDGs9wlEW","CD7KYYaQgl5CKjfoV5NMVljTPxJlOFs9"]},{"id":"con_cerN9Nsm83juEPcC","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Username-Password-Authentication","is_domain_connection":false,"realms":["Username-Password-Authentication"],"enabled_clients":["i4LnBZLIAarAMmWvIJdXwFhwDGs9wlEW","CD7KYYaQgl5CKjfoV5NMVljTPxJlOFs9"]}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 117.693917ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrPhoneNumber.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrPhoneNumber.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 390
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrPhoneNumber","strategy":"auth0","is_domain_connection":true,"options":{"brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"phone_number":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 111
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 473.253584ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrSetValidationNegative.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrSetValidationNegative.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 535
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrSetValidationNegative","strategy":"auth0","is_domain_connection":true,"options":{"validation":{"username":{"max":5,"min":1}},"brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"email":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required","verification":{"active":false}}},"username":{"identifier":{"active":false},"profile_required":true,"signup":{"status":"required"}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 111
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 354.733834ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrSetValidationNegative.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrSetValidationNegative.yaml
@@ -28,12 +28,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 111
+        content_length: 137
         uncompressed: false
-        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        body: '{"statusCode":400,"error":"Bad Request","message":"Cannot set both options.attributes and options.validation","errorCode":"invalid_body"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 400 Bad Request
         code: 400
-        duration: 354.733834ms
+        duration: 108.277625ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrUserName.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrUserName.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 351
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","strategy":"auth0","is_domain_connection":true,"options":{"brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 111
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 366.9095ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrUserName.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrUserName.yaml
@@ -28,12 +28,292 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 111
+        content_length: 672
         uncompressed: false
-        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        body: '{"id":"con_MYsOwStYgIqJigRH","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":1,"max_length":15,"allowed_types":{"email":false,"phone_number":false}}}},"strategy_version":2},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 400 Bad Request
-        code: 400
-        duration: 366.9095ms
+        status: 201 Created
+        code: 201
+        duration: 145.098042ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_MYsOwStYgIqJigRH
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_MYsOwStYgIqJigRH","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":15,"min_length":1,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 116.613875ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_MYsOwStYgIqJigRH
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_MYsOwStYgIqJigRH","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":15,"min_length":1,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 107.340125ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 97.291458ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_MYsOwStYgIqJigRH
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_MYsOwStYgIqJigRH","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":15,"min_length":1,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 113.205208ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_MYsOwStYgIqJigRH
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2024-08-02T14:35:05.649Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 128.449875ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 105.051209ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 104.141708ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections?include_totals=true&page=0&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"total":3,"start":0,"limit":50,"connections":[{"id":"con_NgUj1aAYUvMI1smy","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"craig-test-okta-connection","is_domain_connection":false,"show_as_button":false,"display_name":"Craig Test Okta Workforce Connection","realms":["craig-test-okta-connection"],"enabled_clients":[]},{"id":"con_nxtsVa2XBrGFWqrj","options":{"email":true,"scope":["email","profile"],"profile":true},"strategy":"google-oauth2","name":"google-oauth2","is_domain_connection":false,"realms":["google-oauth2"],"enabled_clients":["i4LnBZLIAarAMmWvIJdXwFhwDGs9wlEW","CD7KYYaQgl5CKjfoV5NMVljTPxJlOFs9"]},{"id":"con_cerN9Nsm83juEPcC","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Username-Password-Authentication","is_domain_connection":false,"realms":["Username-Password-Authentication"],"enabled_clients":["i4LnBZLIAarAMmWvIJdXwFhwDGs9wlEW","CD7KYYaQgl5CKjfoV5NMVljTPxJlOFs9"]}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 110.767959ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrUserName.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrUserName.yaml
@@ -6,14 +6,14 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 351
+        content_length: 448
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","strategy":"auth0","is_domain_connection":true,"options":{"brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"}}}}}
+            {"name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","strategy":"auth0","is_domain_connection":true,"options":{"brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":1,"max_length":3,"allowed_types":{"email":true,"phone_number":false}}}}}}
         form: {}
         headers:
             Content-Type:
@@ -28,15 +28,15 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 672
+        content_length: 670
         uncompressed: false
-        body: '{"id":"con_MYsOwStYgIqJigRH","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":1,"max_length":15,"allowed_types":{"email":false,"phone_number":false}}}},"strategy_version":2},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
+        body: '{"id":"con_TviTez7iKu4Ld7EB","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","brute_force_protection":true,"requires_username":false,"precedence":["username","email","phone_number"],"attributes":{"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":1,"max_length":3,"allowed_types":{"email":true,"phone_number":false}}}},"strategy_version":2},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 145.098042ms
+        duration: 427.324416ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,7 +55,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_MYsOwStYgIqJigRH
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_TviTez7iKu4Ld7EB
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,13 +65,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_MYsOwStYgIqJigRH","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":15,"min_length":1,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
+        body: '{"id":"con_TviTez7iKu4Ld7EB","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":3,"min_length":1,"allowed_types":{"email":true,"phone_number":false}},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 116.613875ms
+        duration: 331.701166ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -90,7 +90,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_MYsOwStYgIqJigRH
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_TviTez7iKu4Ld7EB
         method: GET
       response:
         proto: HTTP/2.0
@@ -100,14 +100,49 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_MYsOwStYgIqJigRH","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":15,"min_length":1,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
+        body: '{"id":"con_TviTez7iKu4Ld7EB","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":3,"min_length":1,"allowed_types":{"email":true,"phone_number":false}},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 107.340125ms
+        duration: 321.037458ms
     - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_TviTez7iKu4Ld7EB
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_TviTez7iKu4Ld7EB","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":3,"min_length":1,"allowed_types":{"email":true,"phone_number":false}},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 301.52575ms
+    - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -135,48 +170,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        body: '{"allowed_logout_urls":["https://app.com/logout","http://localhost/logout"],"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"friendly_name":"My Example Tenant","idle_session_lifetime":720,"picture_url":"https://example.com/logo.png","sandbox_version":"18","session_lifetime":1080,"support_email":"support@example.com","support_url":"https://support.example.com","sessions":{"oidc_logout_prompt_enabled":false},"oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"session_cookie":{"mode":"non-persistent"},"sandbox_versions_available":["18","16"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 97.291458ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_MYsOwStYgIqJigRH
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_MYsOwStYgIqJigRH","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":15,"min_length":1,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"precedence":["username","email","phone_number"],"passwordPolicy":"good","strategy_version":2,"requires_username":false,"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName","is_domain_connection":true,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserName"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 113.205208ms
+        duration: 309.866042ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -195,7 +195,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.8.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_MYsOwStYgIqJigRH
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_TviTez7iKu4Ld7EB
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -205,13 +205,13 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2024-08-02T14:35:05.649Z"}'
+        body: '{"deleted_at":"2024-08-07T08:37:14.190Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 128.449875ms
+        duration: 327.426042ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -240,13 +240,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        body: '{"allowed_logout_urls":["https://app.com/logout","http://localhost/logout"],"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"friendly_name":"My Example Tenant","idle_session_lifetime":720,"picture_url":"https://example.com/logo.png","sandbox_version":"18","session_lifetime":1080,"support_email":"support@example.com","support_url":"https://support.example.com","sessions":{"oidc_logout_prompt_enabled":false},"oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"session_cookie":{"mode":"non-persistent"},"sandbox_versions_available":["18","16"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 105.051209ms
+        duration: 321.340916ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -275,13 +275,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"picture_url":"https://example.com/logo.png","sandbox_version":"16","universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"sandbox_versions_available":["18","16"]}'
+        body: '{"allowed_logout_urls":["https://app.com/logout","http://localhost/logout"],"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"universal_login":true,"revoke_refresh_token_grant":false,"dashboard_new_onboarding":true,"disable_clickjack_protection_headers":false},"friendly_name":"My Example Tenant","idle_session_lifetime":720,"picture_url":"https://example.com/logo.png","sandbox_version":"18","session_lifetime":1080,"support_email":"support@example.com","support_url":"https://support.example.com","sessions":{"oidc_logout_prompt_enabled":false},"oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"colors":{"page_background":"#FF4F40","primary":"#2A2E35"}},"session_cookie":{"mode":"non-persistent"},"sandbox_versions_available":["18","16"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 104.141708ms
+        duration: 317.61075ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -310,10 +310,10 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"total":3,"start":0,"limit":50,"connections":[{"id":"con_NgUj1aAYUvMI1smy","options":{"type":"back_channel","issuer":"https://example.okta.com","jwks_uri":"https://example.okta.com/oauth2/v1/keys","client_id":"1234567","attribute_map":{"mapping_mode":"basic_profile"},"client_secret":"1234567","schema_version":"oidc-V4","token_endpoint":"https://example.okta.com/oauth2/v1/token","userinfo_endpoint":null,"connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://example.okta.com/oauth2/v1/authorize"},"strategy":"okta","name":"craig-test-okta-connection","is_domain_connection":false,"show_as_button":false,"display_name":"Craig Test Okta Workforce Connection","realms":["craig-test-okta-connection"],"enabled_clients":[]},{"id":"con_nxtsVa2XBrGFWqrj","options":{"email":true,"scope":["email","profile"],"profile":true},"strategy":"google-oauth2","name":"google-oauth2","is_domain_connection":false,"realms":["google-oauth2"],"enabled_clients":["i4LnBZLIAarAMmWvIJdXwFhwDGs9wlEW","CD7KYYaQgl5CKjfoV5NMVljTPxJlOFs9"]},{"id":"con_cerN9Nsm83juEPcC","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"Username-Password-Authentication","is_domain_connection":false,"realms":["Username-Password-Authentication"],"enabled_clients":["i4LnBZLIAarAMmWvIJdXwFhwDGs9wlEW","CD7KYYaQgl5CKjfoV5NMVljTPxJlOFs9"]}]}'
+        body: '{"total":1,"start":0,"limit":50,"connections":[{"id":"con_NwYK1fgcPuPaFAgr","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":3,"min_length":1,"allowed_types":{"email":true,"phone_number":false}},"profile_required":true}},"passwordPolicy":"good","strategy_version":2,"brute_force_protection":true},"strategy":"auth0","name":"string","is_domain_connection":false,"display_name":"string","realms":["string"],"enabled_clients":[]}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 110.767959ms
+        duration: 358.918291ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrUserNameNegative.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrUserNameNegative.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 358
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrUserNameNegative","strategy":"auth0","is_domain_connection":true,"options":{"brute_force_protection":true,"requires_username":true,"precedence":["username","email","phone_number"],"attributes":{"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.8.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 111
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 358.071958ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrUserNameNegative.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrUserNameNegative.yaml
@@ -28,12 +28,12 @@ interactions:
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 111
+        content_length: 144
         uncompressed: false
-        body: '{"statusCode":400,"error":"Bad Request","message":"Bad HTTP authentication header format","errorCode":"Bearer"}'
+        body: '{"statusCode":400,"error":"Bad Request","message":"Cannot set both options.attributes and options.requires_username","errorCode":"invalid_body"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 400 Bad Request
         code: 400
-        duration: 358.071958ms
+        duration: 108.3045ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

1. Added schema updates to ```ConnectionOptions``` and included ```attributes``` and ```precedence```
2. Added corresponding expand and flatten logic.
3. Added relevant test cases to expand and flatten nested structs.


<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

Required changes have been made in line with the [documentation here](https://oktawiki.atlassian.net/wiki/spaces/DXSDK/pages/3009480856/Implementation+of+Phone+Number+as+Identifiers+on+SDK+-+GO-auth0)

[Create a connection with attributes](https://auth0.com/docs/api/management/v2/connections/post-connections)
Body Params: options-> attributes 


<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

```make test FILTER= TestAccConnectionOptionsAttr```

Relevant test cases and their recordings have been added to ensure changes as described above.
All created resources are cleaned up after the assertions are completed.

**- Auth0ConnectionTestCase**
- Added a set of test cases to test various combinations of ConnectionOptions:
- Auth0 Connection with PhoneNumber as Identifier
- Auth0 Connection with Email as Identifier
- Auth0 Connection with Username as Identifier
- Auth0 Connection Cannot set both requires_username and attributes together
- Auth0 Connection With No attribute is active
- Auth0 Connection Cannot set both validation and attributes together
- Auth0 Connection need PhoneNumber on signup but set to inactive on verification



<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
