### PR TITLE
feat(FND-1279): Add Email Extensibility Provider Option

### DIFF
--- a/docs/resources/email_provider.md
+++ b/docs/resources/email_provider.md
@@ -51,7 +51,7 @@ resource "auth0_email_provider" "sendgrid_email_provider" {
 
 
 # This is an example on how to set up the email provider with Azure CS.
-resource "auth0_email_provider" "smtp_email_provider" {
+resource "auth0_email_provider" "azure_cs_email_provider" {
   name                 = "azure_cs"
   enabled              = true
   default_from_address = "accounts@example.com"
@@ -63,7 +63,7 @@ resource "auth0_email_provider" "smtp_email_provider" {
 
 
 # This is an example on how to set up the email provider with MS365.
-resource "auth0_email_provider" "smtp_email_provider" {
+resource "auth0_email_provider" "ms365_email_provider" {
   name                 = "ms365"
   enabled              = true
   default_from_address = "accounts@example.com"
@@ -72,6 +72,44 @@ resource "auth0_email_provider" "smtp_email_provider" {
     ms365_tenant_id     = "ms365_tenant_id"
     ms365_client_id     = "ms365_client_id"
     ms365_client_secret = "ms365_client_secret"
+  }
+}
+
+
+# This is an example on how to set up the email provider with a Custom Action.
+resource "auth0_email_provider" "custom_email_provider" {
+  name                 = "custom"
+  enabled              = true
+
+  credentials {
+  }
+}
+
+resource "auth0_action" "my_action" {
+  name    = "Custom Email Provider"
+  runtime = "node18"
+  deploy  = true
+  code    = <<-EOT
+  /**
+  * Handler to be executed while sending an email notification
+  * @param {Event} event - Details about the user and the context in which they are logging in.
+  * @param {CustomEmailProviderAPI} api - Methods and utilities to help change the behavior of sending a email notification.
+  */
+  exports.onExecuteCustomEmailProvider = async (event, api) => {
+    // Code goes here
+    return;
+  };
+  EOT
+
+  supported_triggers {
+    id      = "custom-email-provider"
+    version = "v1"
+  }
+
+  dependencies {
+  }
+
+  secrets {
   }
 }
 ```
@@ -83,7 +121,7 @@ resource "auth0_email_provider" "smtp_email_provider" {
 
 - `credentials` (Block List, Min: 1, Max: 1) Configuration settings for the credentials for the email provider. (see [below for nested schema](#nestedblock--credentials))
 - `default_from_address` (String) Email address to use as the sender when no other "from" address is specified.
-- `name` (String) Name of the email provider. Options include `azure_cs`, `mailgun`, `mandrill`, `ms365`, `sendgrid`, `ses`, `smtp` and `sparkpost`.
+- `name` (String) Name of the email provider. Options include `azure_cs`, `custom`, `mailgun`, `mandrill`, `ms365`, `sendgrid`, `ses`, `smtp` and `sparkpost`.
 
 ### Optional
 

--- a/examples/resources/auth0_email_provider/resource.tf
+++ b/examples/resources/auth0_email_provider/resource.tf
@@ -61,3 +61,13 @@ resource "auth0_email_provider" "smtp_email_provider" {
     ms365_client_secret = "ms365_client_secret"
   }
 }
+
+
+# This is an example on how to set up the email provider with a custom action.
+resource "auth0_email_provider" "smtp_email_provider" {
+  name                 = "custom"
+  enabled              = true
+
+  credentials {
+  }
+}

--- a/internal/auth0/email/expand.go
+++ b/internal/auth0/email/expand.go
@@ -31,6 +31,8 @@ func expandEmailProvider(config cty.Value) *management.EmailProvider {
 		expandEmailProviderAzureCS(config, emailProvider)
 	case management.EmailProviderMS365:
 		expandEmailProviderMS365(config, emailProvider)
+	case management.EmailProviderCustom:
+		expandEmailProviderCustom(config, emailProvider)
 	}
 
 	return emailProvider
@@ -151,6 +153,13 @@ func expandEmailProviderMS365(config cty.Value, emailProvider *management.EmailP
 			ClientID:     value.String(credentials.GetAttr("ms365_client_id")),
 			ClientSecret: value.String(credentials.GetAttr("ms365_client_secret")),
 		}
+		return stop
+	})
+}
+
+func expandEmailProviderCustom(config cty.Value, emailProvider *management.EmailProvider) {
+	config.GetAttr("credentials").ForEachElement(func(_ cty.Value, credentials cty.Value) (stop bool) {
+		emailProvider.Credentials = &management.EmailProviderCredentialsMS365{}
 		return stop
 	})
 }

--- a/internal/auth0/email/flatten.go
+++ b/internal/auth0/email/flatten.go
@@ -2,7 +2,6 @@ package email
 
 import (
 	"github.com/auth0/go-auth0/management"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -67,6 +66,8 @@ func flattenEmailProviderCredentials(data *schema.ResourceData, emailProvider *m
 			"ms365_client_id":     data.Get("credentials.0.ms365_client_id").(string),
 			"ms365_client_secret": data.Get("credentials.0.ms365_client_secret").(string),
 		}
+	case *management.EmailProviderCredentialsCustom:
+		credentials = map[string]interface{}{}
 	}
 
 	return []interface{}{credentials}

--- a/internal/auth0/email/resource.go
+++ b/internal/auth0/email/resource.go
@@ -33,11 +33,11 @@ func NewResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice(
-					[]string{"azure_cs", "mailgun", "mandrill", "ms365", "sendgrid", "ses", "smtp", "sparkpost"},
+					[]string{"azure_cs", "custom", "mailgun", "mandrill", "ms365", "sendgrid", "ses", "smtp", "sparkpost"},
 					false,
 				),
 				Description: "Name of the email provider. " +
-					"Options include `azure_cs`, `mailgun`, `mandrill`, `ms365`, `sendgrid`, `ses`, `smtp` and `sparkpost`.",
+					"Options include `azure_cs`, `custom`, `mailgun`, `mandrill`, `ms365`, `sendgrid`, `ses`, `smtp` and `sparkpost`.",
 			},
 			"enabled": {
 				Type:        schema.TypeBool,

--- a/internal/auth0/email/resource_test.go
+++ b/internal/auth0/email/resource_test.go
@@ -174,6 +174,24 @@ resource "auth0_email_provider" "my_email_provider" {
 }
 `
 
+const testAccCreateCustomEmailProvider = `
+resource "auth0_email_provider" "my_email_provider" {
+	name = "custom"
+	enabled = true
+	credentials {
+	}
+}
+`
+
+const testAccUpdateCustomEmailProvider = `
+resource "auth0_email_provider" "my_email_provider" {
+	name = "custom"
+	enabled = false
+	credentials {
+	}
+}
+`
+
 const testAccAlreadyConfiguredEmailProviderWillNotConflict = `
 resource "auth0_email_provider" "my_email_provider" {
 	name = "mailgun"
@@ -341,6 +359,20 @@ func TestAccEmail(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_email_provider.my_email_provider", "credentials.0.ms365_tenant_id", "ms365_updated_tenant_id"),
 					resource.TestCheckResourceAttr("auth0_email_provider.my_email_provider", "credentials.0.ms365_client_id", "ms365_updated_client_id"),
 					resource.TestCheckResourceAttr("auth0_email_provider.my_email_provider", "credentials.0.ms365_client_secret", "ms365_updated_client_secret"),
+				),
+			},
+			{
+				Config: testAccCreateCustomEmailProvider,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_email_provider.my_email_provider", "name", "custom"),
+					resource.TestCheckResourceAttr("auth0_email_provider.my_email_provider", "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccUpdateCustomEmailProvider,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_email_provider.my_email_provider", "name", "custom"),
+					resource.TestCheckResourceAttr("auth0_email_provider.my_email_provider", "enabled", "false"),
 				),
 			},
 			{


### PR DESCRIPTION
### 🔧 Changes
This change is to add the Custom provider option to the Email Provider to enable the new Email Extensibility feature utilizing Auth0 Actions.

### 📚 References


### 🔬 Testing


### 📝 Checklist
