### PR TITLE
Patch: Removed MinItems validation for precedence on Connection Resource

### DIFF
--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -859,6 +859,7 @@ var optionsSchema = &schema.Schema{
 						"username",
 					}, true),
 				},
+				MaxItems: 3,
 				Optional: true,
 				Computed: false,
 				Description: "Order of attributes for precedence in identification." +

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -861,8 +861,6 @@ var optionsSchema = &schema.Schema{
 				},
 				Optional: true,
 				Computed: false,
-				MaxItems: 3,
-				MinItems: 3,
 				Description: "Order of attributes for precedence in identification." +
 					"Valid values: email, phone_number, username. " +
 					"If Precedence is set, it must contain all values (email, phone_number, username) in specific order",


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
The precedence field is a slice which can either have a length of 0 or 3. That means if specified all three of `email, phone_number, username` must be specified or none. 
Added this patch such that MinItems can be 0 also.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
