### PR TITLE
PATCH: Add sleep time after auth0_user create before trying to retrieve it

### DIFF
--- a/internal/auth0/organization/resource_member.go
+++ b/internal/auth0/organization/resource_member.go
@@ -2,6 +2,7 @@ package organization
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -49,6 +50,7 @@ func createOrganizationMember(ctx context.Context, data *schema.ResourceData, me
 	}
 
 	internalSchema.SetResourceGroupID(data, organizationID, userID)
+	time.Sleep(500 * time.Millisecond)
 
 	return readOrganizationMember(ctx, data, meta)
 }


### PR DESCRIPTION
Added a 500 millisecond sleep before a newly created user is retrieved through get call.
This change has been made to address: https://github.com/auth0/terraform-provider-auth0/issues/1007

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
