### PR TITLE
Fix docs for user_id_attribute for AzureAD connection options

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -319,7 +319,7 @@ resource "auth0_connection" "azure_ad" {
     client_id         = "123456"
     client_secret     = "123456"
     strategy_version  = 2
-    user_id_attribute = "userName"
+    user_id_attribute = "oid"
     app_id            = "app-id-123"
     tenant_domain     = "example.onmicrosoft.com"
     domain            = "example.onmicrosoft.com"

--- a/examples/resources/auth0_connection/resource_with_azure_ad.tf
+++ b/examples/resources/auth0_connection/resource_with_azure_ad.tf
@@ -7,7 +7,7 @@ resource "auth0_connection" "azure_ad" {
     client_id         = "123456"
     client_secret     = "123456"
     strategy_version  = 2
-    user_id_attribute = "userName"
+    user_id_attribute = "oid"
     app_id            = "app-id-123"
     tenant_domain     = "example.onmicrosoft.com"
     domain            = "example.onmicrosoft.com"

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -592,7 +592,7 @@ func TestAccConnectionAzureAD(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.client_id", "123456"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.client_secret", "123456"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.strategy_version", "2"),
-					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.user_id_attribute", "userName"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.user_id_attribute", "oid"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.tenant_domain", "example.onmicrosoft.com"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.domain", "example.onmicrosoft.com"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.domain_aliases.#", "2"),
@@ -616,7 +616,7 @@ func TestAccConnectionAzureAD(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.identity_api", "azure-active-directory-v1.0"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.client_id", "123456"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.client_secret", "123456"),
-					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.user_id_attribute", "email"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.user_id_attribute", "sub"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.tenant_domain", "example.onmicrosoft.com"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.domain", "example.onmicrosoft.com"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.domain_aliases.#", "2"),
@@ -654,7 +654,7 @@ resource "auth0_connection" "azure_ad" {
 		use_wsfed            = false
 		waad_protocol        = "openid-connect"
 		waad_common_endpoint = false
-		user_id_attribute    = "userName"
+		user_id_attribute    = "oid"
 		api_enable_users     = true
 		scopes               = [
 			"basic_profile",
@@ -690,7 +690,7 @@ resource "auth0_connection" "azure_ad" {
 		use_wsfed            = false
 		waad_protocol        = "openid-connect"
 		waad_common_endpoint = false
-		user_id_attribute    = "email"
+		user_id_attribute    = "sub"
 		api_enable_users     = true
 		scopes               = [
 			"basic_profile",

--- a/test/data/recordings/TestAccConnectionAzureAD.yaml
+++ b/test/data/recordings/TestAccConnectionAzureAD.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 672
+        content_length: 667
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","strategy":"waad","show_as_button":true,"options":{"client_id":"123456","client_secret":"123456","strategy_version":2,"tenant_domain":"example.onmicrosoft.com","domain":"example.onmicrosoft.com","domain_aliases":["api.example.com","example.com"],"identity_api":"azure-active-directory-v1.0","waad_protocol":"openid-connect","use_wsfed":false,"useCommonEndpoint":false,"api_enable_users":true,"basic_profile":true,"ext_profile":true,"ext_groups":true,"should_trust_email_verified_connection":"never_set_emails_as_verified","upstream_params":{"screen_name":{"alias":"login_hint"}},"user_id_attribute":"userName"}}
+            {"name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","strategy":"waad","show_as_button":true,"options":{"client_id":"123456","client_secret":"123456","strategy_version":2,"tenant_domain":"example.onmicrosoft.com","domain":"example.onmicrosoft.com","domain_aliases":["api.example.com","example.com"],"identity_api":"azure-active-directory-v1.0","waad_protocol":"openid-connect","use_wsfed":false,"useCommonEndpoint":false,"api_enable_users":true,"basic_profile":true,"ext_profile":true,"ext_groups":true,"should_trust_email_verified_connection":"never_set_emails_as_verified","upstream_params":{"screen_name":{"alias":"login_hint"}},"user_id_attribute":"oid"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
+                - Go-Auth0/1.11.1
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"id":"con_vC97x6M6uJ5I5k0D","options":{"client_id":"123456","client_secret":"123456","strategy_version":2,"tenant_domain":"example.onmicrosoft.com","domain":"example.onmicrosoft.com","domain_aliases":["api.example.com","example.com"],"identity_api":"azure-active-directory-v1.0","waad_protocol":"openid-connect","use_wsfed":false,"useCommonEndpoint":false,"api_enable_users":true,"basic_profile":true,"ext_profile":true,"ext_groups":true,"should_trust_email_verified_connection":"never_set_emails_as_verified","upstream_params":{"screen_name":{"alias":"login_hint"}},"user_id_attribute":"userName","thumbprints":["1fd9e3e40392b30329860d52171ee3695fa507dc","8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","824f47a0658299810b52ad51110d0290783e46c6"],"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","waad_common_endpoint":false,"userid_attribute":"oid"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/rJNVoCqy","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        body: '{"id":"con_ZiMbuMWAUGW3Xpkg","options":{"client_id":"123456","client_secret":"123456","strategy_version":2,"tenant_domain":"example.onmicrosoft.com","domain":"example.onmicrosoft.com","domain_aliases":["api.example.com","example.com"],"identity_api":"azure-active-directory-v1.0","waad_protocol":"openid-connect","use_wsfed":false,"useCommonEndpoint":false,"api_enable_users":true,"basic_profile":true,"ext_profile":true,"ext_groups":true,"should_trust_email_verified_connection":"never_set_emails_as_verified","upstream_params":{"screen_name":{"alias":"login_hint"}},"user_id_attribute":"oid","thumbprints":["8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","8b0d415d77326e4d3b926b4879e25e218a9ab35f","dcf68ae047f204d42edc2b6362c6b7626850e44d","f0f5d00dbe263a6a25bbf06d1b78c35f8a91db15"],"app_domain":"terraform-provider-auth0-dev.sus.auth0.com","waad_common_endpoint":false,"userid_attribute":"oid"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.sus.auth0.com/terraform-provider-auth0-dev/p/waad/Lu5q8dId","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 435.464042ms
+        duration: 592.206125ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -54,8 +54,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_vC97x6M6uJ5I5k0D
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZiMbuMWAUGW3Xpkg
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,13 +65,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_vC97x6M6uJ5I5k0D","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["1fd9e3e40392b30329860d52171ee3695fa507dc","8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","824f47a0658299810b52ad51110d0290783e46c6"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"strategy_version":2,"userid_attribute":"oid","useCommonEndpoint":false,"user_id_attribute":"userName","waad_common_endpoint":false,"should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/rJNVoCqy","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        body: '{"id":"con_ZiMbuMWAUGW3Xpkg","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.sus.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","8b0d415d77326e4d3b926b4879e25e218a9ab35f","dcf68ae047f204d42edc2b6362c6b7626850e44d","f0f5d00dbe263a6a25bbf06d1b78c35f8a91db15"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"strategy_version":2,"userid_attribute":"oid","useCommonEndpoint":false,"user_id_attribute":"oid","waad_common_endpoint":false,"should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.sus.auth0.com/terraform-provider-auth0-dev/p/waad/Lu5q8dId","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 158.795292ms
+        duration: 162.080834ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -89,8 +89,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_vC97x6M6uJ5I5k0D
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZiMbuMWAUGW3Xpkg
         method: GET
       response:
         proto: HTTP/2.0
@@ -100,13 +100,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_vC97x6M6uJ5I5k0D","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["1fd9e3e40392b30329860d52171ee3695fa507dc","8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","824f47a0658299810b52ad51110d0290783e46c6"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"strategy_version":2,"userid_attribute":"oid","useCommonEndpoint":false,"user_id_attribute":"userName","waad_common_endpoint":false,"should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/rJNVoCqy","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        body: '{"id":"con_ZiMbuMWAUGW3Xpkg","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.sus.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","8b0d415d77326e4d3b926b4879e25e218a9ab35f","dcf68ae047f204d42edc2b6362c6b7626850e44d","f0f5d00dbe263a6a25bbf06d1b78c35f8a91db15"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"strategy_version":2,"userid_attribute":"oid","useCommonEndpoint":false,"user_id_attribute":"oid","waad_common_endpoint":false,"should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.sus.auth0.com/terraform-provider-auth0-dev/p/waad/Lu5q8dId","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 155.665125ms
+        duration: 165.604583ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -124,8 +124,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_vC97x6M6uJ5I5k0D
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZiMbuMWAUGW3Xpkg
         method: GET
       response:
         proto: HTTP/2.0
@@ -135,13 +135,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_vC97x6M6uJ5I5k0D","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["1fd9e3e40392b30329860d52171ee3695fa507dc","8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","824f47a0658299810b52ad51110d0290783e46c6"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"strategy_version":2,"userid_attribute":"oid","useCommonEndpoint":false,"user_id_attribute":"userName","waad_common_endpoint":false,"should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/rJNVoCqy","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        body: '{"id":"con_ZiMbuMWAUGW3Xpkg","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.sus.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","8b0d415d77326e4d3b926b4879e25e218a9ab35f","dcf68ae047f204d42edc2b6362c6b7626850e44d","f0f5d00dbe263a6a25bbf06d1b78c35f8a91db15"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"strategy_version":2,"userid_attribute":"oid","useCommonEndpoint":false,"user_id_attribute":"oid","waad_common_endpoint":false,"should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.sus.auth0.com/terraform-provider-auth0-dev/p/waad/Lu5q8dId","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 212.03275ms
+        duration: 164.530791ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -159,8 +159,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_vC97x6M6uJ5I5k0D
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZiMbuMWAUGW3Xpkg
         method: GET
       response:
         proto: HTTP/2.0
@@ -170,33 +170,33 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_vC97x6M6uJ5I5k0D","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["1fd9e3e40392b30329860d52171ee3695fa507dc","8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","824f47a0658299810b52ad51110d0290783e46c6"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"strategy_version":2,"userid_attribute":"oid","useCommonEndpoint":false,"user_id_attribute":"userName","waad_common_endpoint":false,"should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/rJNVoCqy","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        body: '{"id":"con_ZiMbuMWAUGW3Xpkg","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.sus.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","8b0d415d77326e4d3b926b4879e25e218a9ab35f","dcf68ae047f204d42edc2b6362c6b7626850e44d","f0f5d00dbe263a6a25bbf06d1b78c35f8a91db15"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"strategy_version":2,"userid_attribute":"oid","useCommonEndpoint":false,"user_id_attribute":"oid","waad_common_endpoint":false,"should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.sus.auth0.com/terraform-provider-auth0-dev/p/waad/Lu5q8dId","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 158.75525ms
+        duration: 135.279083ms
     - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 841
+        content_length: 889
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"show_as_button":true,"options":{"client_id":"123456","client_secret":"123456","tenant_domain":"example.onmicrosoft.com","domain":"example.onmicrosoft.com","domain_aliases":["api.example.com","example.com"],"identity_api":"azure-active-directory-v1.0","waad_protocol":"openid-connect","use_wsfed":false,"useCommonEndpoint":false,"api_enable_users":true,"basic_profile":true,"ext_profile":true,"ext_groups":true,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified","upstream_params":{"screen_name":{"alias":"login_hint"}},"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","thumbprints":["1fd9e3e40392b30329860d52171ee3695fa507dc","8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","824f47a0658299810b52ad51110d0290783e46c6"],"user_id_attribute":"email"}}
+            {"show_as_button":true,"options":{"client_id":"123456","client_secret":"123456","tenant_domain":"example.onmicrosoft.com","domain":"example.onmicrosoft.com","domain_aliases":["api.example.com","example.com"],"identity_api":"azure-active-directory-v1.0","waad_protocol":"openid-connect","use_wsfed":false,"useCommonEndpoint":false,"api_enable_users":true,"basic_profile":true,"ext_profile":true,"ext_groups":true,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified","upstream_params":{"screen_name":{"alias":"login_hint"}},"app_domain":"terraform-provider-auth0-dev.sus.auth0.com","thumbprints":["8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","8b0d415d77326e4d3b926b4879e25e218a9ab35f","dcf68ae047f204d42edc2b6362c6b7626850e44d","f0f5d00dbe263a6a25bbf06d1b78c35f8a91db15"],"user_id_attribute":"sub"}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_vC97x6M6uJ5I5k0D
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZiMbuMWAUGW3Xpkg
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -206,13 +206,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_vC97x6M6uJ5I5k0D","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["1fd9e3e40392b30329860d52171ee3695fa507dc","8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","824f47a0658299810b52ad51110d0290783e46c6"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"userid_attribute":null,"useCommonEndpoint":false,"user_id_attribute":"email","waad_common_endpoint":false,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/rJNVoCqy","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        body: '{"id":"con_ZiMbuMWAUGW3Xpkg","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.sus.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","8b0d415d77326e4d3b926b4879e25e218a9ab35f","dcf68ae047f204d42edc2b6362c6b7626850e44d","f0f5d00dbe263a6a25bbf06d1b78c35f8a91db15"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"userid_attribute":null,"useCommonEndpoint":false,"user_id_attribute":"sub","waad_common_endpoint":false,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.sus.auth0.com/terraform-provider-auth0-dev/p/waad/Lu5q8dId","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 425.207125ms
+        duration: 530.512792ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -230,8 +230,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_vC97x6M6uJ5I5k0D
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZiMbuMWAUGW3Xpkg
         method: GET
       response:
         proto: HTTP/2.0
@@ -241,13 +241,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_vC97x6M6uJ5I5k0D","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["1fd9e3e40392b30329860d52171ee3695fa507dc","8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","824f47a0658299810b52ad51110d0290783e46c6"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"userid_attribute":null,"useCommonEndpoint":false,"user_id_attribute":"email","waad_common_endpoint":false,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/rJNVoCqy","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        body: '{"id":"con_ZiMbuMWAUGW3Xpkg","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.sus.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","8b0d415d77326e4d3b926b4879e25e218a9ab35f","dcf68ae047f204d42edc2b6362c6b7626850e44d","f0f5d00dbe263a6a25bbf06d1b78c35f8a91db15"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"userid_attribute":null,"useCommonEndpoint":false,"user_id_attribute":"sub","waad_common_endpoint":false,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.sus.auth0.com/terraform-provider-auth0-dev/p/waad/Lu5q8dId","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 150.204833ms
+        duration: 150.378667ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -265,8 +265,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_vC97x6M6uJ5I5k0D
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZiMbuMWAUGW3Xpkg
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,13 +276,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_vC97x6M6uJ5I5k0D","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.eu.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["1fd9e3e40392b30329860d52171ee3695fa507dc","8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","824f47a0658299810b52ad51110d0290783e46c6"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"userid_attribute":null,"useCommonEndpoint":false,"user_id_attribute":"email","waad_common_endpoint":false,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.eu.auth0.com/terraform-provider-auth0-dev/p/waad/rJNVoCqy","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
+        body: '{"id":"con_ZiMbuMWAUGW3Xpkg","options":{"domain":"example.onmicrosoft.com","client_id":"123456","use_wsfed":false,"app_domain":"terraform-provider-auth0-dev.sus.auth0.com","ext_groups":true,"ext_profile":true,"thumbprints":["8a48f046b8d93d1e7c6bfc10c54ce9cc6b94378b","31cee5dc8cfdde0eeec2035e1269b0fd66063e4a","8b0d415d77326e4d3b926b4879e25e218a9ab35f","dcf68ae047f204d42edc2b6362c6b7626850e44d","f0f5d00dbe263a6a25bbf06d1b78c35f8a91db15"],"identity_api":"azure-active-directory-v1.0","basic_profile":true,"client_secret":"123456","tenant_domain":"example.onmicrosoft.com","waad_protocol":"openid-connect","domain_aliases":["api.example.com","example.com"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"api_enable_users":true,"userid_attribute":null,"useCommonEndpoint":false,"user_id_attribute":"sub","waad_common_endpoint":false,"set_user_root_attributes":"on_first_login","should_trust_email_verified_connection":"never_set_emails_as_verified"},"strategy":"waad","name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","provisioning_ticket_url":"https://terraform-provider-auth0-dev.sus.auth0.com/terraform-provider-auth0-dev/p/waad/Lu5q8dId","is_domain_connection":false,"show_as_button":true,"display_name":"Acceptance-Test-Azure-AD-TestAccConnectionAzureAD","enabled_clients":[],"realms":["Acceptance-Test-Azure-AD-TestAccConnectionAzureAD"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 148.59025ms
+        duration: 115.988041ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -300,8 +300,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.10.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_vC97x6M6uJ5I5k0D
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ZiMbuMWAUGW3Xpkg
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -311,10 +311,10 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2024-09-19T17:48:55.628Z"}'
+        body: '{"deleted_at":"2024-10-09T14:00:41.943Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 163.399875ms
+        duration: 176.680833ms


### PR DESCRIPTION
The documentation and examples for Microsoft Azure AD connections gave an invalid value for `user_id_attribute`. The only valid values according to their documentation are `sub` and `oid`

### 🔧 Changes

Updated example for resource `auth0_connection` for AzureAD

### 📚 References

[https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference#use-claims-to-reliably-identify-a-user](https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference#use-claims-to-reliably-identify-a-user)


### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
