### PR TITLE
PATCH: Add graceful error handling for `auth0_organization` data source when using client grants

### DIFF
--- a/internal/auth0/organization/data_source.go
+++ b/internal/auth0/organization/data_source.go
@@ -2,6 +2,7 @@ package organization
 
 import (
 	"context"
+	"strings"
 
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -195,6 +196,9 @@ func fetchAllOrganizationClientGrants(
 ) ([]*management.ClientGrant, error) {
 	clientGrantList, err := api.Organization.ClientGrants(ctx, organizationID)
 	if err != nil {
+		if strings.Contains(err.Error(), "Insufficient scope") {
+			return []*management.ClientGrant{}, nil
+		}
 		return nil, err
 	}
 

--- a/internal/auth0/organization/data_source_test.go
+++ b/internal/auth0/organization/data_source_test.go
@@ -129,7 +129,7 @@ func TestAccDataSourceOrganizationInsufficientScope(t *testing.T) {
 				//	_ = os.Setenv("AUTH0_DOMAIN", "some-domain-name")
 				//	_ = os.Setenv("AUTH0_CLIENT_ID", "some-client-id")
 				//	_ = os.Setenv("AUTH0_CLIENT_SECRET", "some-client-secret")
-				//},.
+				// },.
 				Config: `data "auth0_organization" "test" {
 					organization_id = "org_P0nITxTkwnKQvD22"
 				}`,

--- a/internal/auth0/organization/data_source_test.go
+++ b/internal/auth0/organization/data_source_test.go
@@ -2,6 +2,7 @@ package organization_test
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -113,6 +114,38 @@ func TestAccDataSourceOrganization(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.auth0_organization.test", "connections.0.connection_id"),
 					resource.TestCheckResourceAttr("data.auth0_organization.test", "members.#", "1"),
 				),
+			},
+			{
+				PreConfig: func() {
+					_ = os.Setenv("AUTH0_DOMAIN", "duedares.us.auth0.com")
+					_ = os.Setenv("AUTH0_CLIENT_ID", "DCglqGHelY62aZieE2d7TrvZ2Wwwmjfy")
+					_ = os.Setenv("AUTH0_CLIENT_SECRET", "bOTTvO1lq2_0VDvXidBN58A3tPIrHRSKw5xkAGmPbZy3i8DMjveVYkx5mxQosYNX")
+				},
+				Config: `data "auth0_organization" "test" {
+					organization_id = "org_P2TMimgtov7fsPI6"
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.auth0_organization.test", "grant_ids.#", "0")),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceOrganizationInsufficientScope(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					_ = os.Setenv("AUTH0_DOMAIN", "duedares.us.auth0.com")
+					_ = os.Setenv("AUTH0_CLIENT_ID", "DCglqGHelY62aZieE2d7TrvZ2Wwwmjfy")
+					_ = os.Setenv("AUTH0_CLIENT_SECRET", "bOTTvO1lq2_0VDvXidBN58A3tPIrHRSKw5xkAGmPbZy3i8DMjveVYkx5mxQosYNX")
+				},
+				Config: `data "auth0_organization" "test" {
+					organization_id = "org_P0nITxTkwnKQvD22"
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.auth0_organization.test", "grant_ids.#", "0")),
 			},
 		},
 	})

--- a/internal/auth0/organization/data_source_test.go
+++ b/internal/auth0/organization/data_source_test.go
@@ -136,12 +136,13 @@ func TestAccDataSourceOrganizationInsufficientScope(t *testing.T) {
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() {
-					// Add your env variables here
-					_ = os.Setenv("AUTH0_DOMAIN", "some-domain-name")
-					_ = os.Setenv("AUTH0_CLIENT_ID", "some-client-id")
-					_ = os.Setenv("AUTH0_CLIENT_SECRET", "some-client-secret")
-				},
+				// Uncomment the below code to test functionality against a non enabled tenants and record it.
+				//PreConfig: func() {
+				//	// Add your env variables here.
+				//	_ = os.Setenv("AUTH0_DOMAIN", "some-domain-name")
+				//	_ = os.Setenv("AUTH0_CLIENT_ID", "some-client-id")
+				//	_ = os.Setenv("AUTH0_CLIENT_SECRET", "some-client-secret")
+				//},
 				Config: `data "auth0_organization" "test" {
 					organization_id = "org_P0nITxTkwnKQvD22"
 				}`,

--- a/internal/auth0/organization/data_source_test.go
+++ b/internal/auth0/organization/data_source_test.go
@@ -2,7 +2,6 @@ package organization_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -114,18 +113,6 @@ func TestAccDataSourceOrganization(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.auth0_organization.test", "connections.0.connection_id"),
 					resource.TestCheckResourceAttr("data.auth0_organization.test", "members.#", "1"),
 				),
-			},
-			{
-				PreConfig: func() {
-					_ = os.Setenv("AUTH0_DOMAIN", "duedares.us.auth0.com")
-					_ = os.Setenv("AUTH0_CLIENT_ID", "DCglqGHelY62aZieE2d7TrvZ2Wwwmjfy")
-					_ = os.Setenv("AUTH0_CLIENT_SECRET", "bOTTvO1lq2_0VDvXidBN58A3tPIrHRSKw5xkAGmPbZy3i8DMjveVYkx5mxQosYNX")
-				},
-				Config: `data "auth0_organization" "test" {
-					organization_id = "org_P2TMimgtov7fsPI6"
-				}`,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.auth0_organization.test", "grant_ids.#", "0")),
 			},
 		},
 	})

--- a/internal/auth0/organization/data_source_test.go
+++ b/internal/auth0/organization/data_source_test.go
@@ -129,7 +129,7 @@ func TestAccDataSourceOrganizationInsufficientScope(t *testing.T) {
 				//	_ = os.Setenv("AUTH0_DOMAIN", "some-domain-name")
 				//	_ = os.Setenv("AUTH0_CLIENT_ID", "some-client-id")
 				//	_ = os.Setenv("AUTH0_CLIENT_SECRET", "some-client-secret")
-				//},
+				//},.
 				Config: `data "auth0_organization" "test" {
 					organization_id = "org_P0nITxTkwnKQvD22"
 				}`,

--- a/internal/auth0/organization/data_source_test.go
+++ b/internal/auth0/organization/data_source_test.go
@@ -137,9 +137,10 @@ func TestAccDataSourceOrganizationInsufficientScope(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					_ = os.Setenv("AUTH0_DOMAIN", "duedares.us.auth0.com")
-					_ = os.Setenv("AUTH0_CLIENT_ID", "DCglqGHelY62aZieE2d7TrvZ2Wwwmjfy")
-					_ = os.Setenv("AUTH0_CLIENT_SECRET", "bOTTvO1lq2_0VDvXidBN58A3tPIrHRSKw5xkAGmPbZy3i8DMjveVYkx5mxQosYNX")
+					// Add your env variables here
+					_ = os.Setenv("AUTH0_DOMAIN", "some-domain-name")
+					_ = os.Setenv("AUTH0_CLIENT_ID", "some-client-id")
+					_ = os.Setenv("AUTH0_CLIENT_SECRET", "some-client-secret")
 				},
 				Config: `data "auth0_organization" "test" {
 					organization_id = "org_P0nITxTkwnKQvD22"

--- a/test/data/recordings/TestAccDataSourceOrganizationInsufficientScope.yaml
+++ b/test/data/recordings/TestAccDataSourceOrganizationInsufficientScope.yaml
@@ -1,0 +1,423 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_P0nITxTkwnKQvD22","name":"integration-test-org-better","display_name":"Integration Test Updated Organization","branding":{"logo_url":"https://example.com/logo.png","colors":{"page_background":"#AA1166","primary":"#00FFAA"}},"metadata":{"FOO":"bar"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 342.892042ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22/enabled_connections?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 350.456292ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"members":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 353.623125ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22/client-grants?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 312.830666ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_P0nITxTkwnKQvD22","name":"integration-test-org-better","display_name":"Integration Test Updated Organization","branding":{"logo_url":"https://example.com/logo.png","colors":{"page_background":"#AA1166","primary":"#00FFAA"}},"metadata":{"FOO":"bar"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 447.941834ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22/enabled_connections?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 383.67775ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"members":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 366.776834ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22/client-grants?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 325.221ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_P0nITxTkwnKQvD22","name":"integration-test-org-better","display_name":"Integration Test Updated Organization","branding":{"logo_url":"https://example.com/logo.png","colors":{"page_background":"#AA1166","primary":"#00FFAA"}},"metadata":{"FOO":"bar"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 361.434708ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22/enabled_connections?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_connections":[],"start":0,"limit":0,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 353.844583ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"members":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 357.018083ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.11.1
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_P0nITxTkwnKQvD22/client-grants?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Insufficient scope, expected any of: read:organization_client_grants","errorCode":"insufficient_scope"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 331.718458ms


### PR DESCRIPTION
The `auth0_organization` data source retrieves a list of connections, members, and client grants for a given organization. However, the client grants and organization association feature is only available to limited users. As a result, an empty slice of client grants is returned for tenants that do not have access to this feature.

---

### 🔧 Changes

- Implemented graceful handling for tenants that do not have access to the client grants feature.
- When the `auth0_organization` data source is queried by such tenants, an empty slice is returned for the client grants, ensuring that the data source works without errors for all users, even those without this feature.

### 📚 References

N/A

### 🔬 Testing

- Added a negative test case that runs against a tenant with insufficient scopes or access to the client grants feature.
- Verified that the data source returns an empty slice for client grants without causing errors, ensuring smooth operation for tenants without this feature.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests.
- [x] I have added documentation for all new/changed functionality (if applicable).