### PR TITLE
Added explicit check for handling missing env variables for login

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,7 +66,7 @@ func ConfigureProvider(terraformVersion *string) schema.ConfigureContextFunc {
 			return nil, diag.Diagnostics{
 				{
 					Severity: diag.Error,
-					Summary:  fmt.Sprintf("Missing environment variables"),
+					Summary:  "Missing environment variables",
 					Detail: fmt.Sprintf("Either AUTH0_API_TOKEN or AUTH0_DOMAIN:AUTH0_CLIENT_ID:AUTH0_CLIENT_SECRET must be configured. " +
 						"Ref: https://registry.terraform.io/providers/auth0/auth0/latest/docs"),
 				},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,17 @@ func ConfigureProvider(terraformVersion *string) schema.ConfigureContextFunc {
 		audience := data.Get("audience").(string)
 		debug := data.Get("debug").(bool)
 
+		if apiToken == "" && (clientID == "" || clientSecret == "" || domain == "") {
+			return nil, diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  fmt.Sprintf("Missing environment variables"),
+					Detail: fmt.Sprintf("Either AUTH0_API_TOKEN or AUTH0_DOMAIN:AUTH0_CLIENT_ID:AUTH0_CLIENT_SECRET must be configured. " +
+						"Ref: https://registry.terraform.io/providers/auth0/auth0/latest/docs"),
+				},
+			}
+		}
+
 		apiClient, err := management.New(domain,
 			authenticationOption(clientID, clientSecret, apiToken, audience),
 			management.WithDebug(debug),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -56,7 +56,8 @@ func TestConfigureProvider(t *testing.T) {
 			expectedDiagnostics: diag.Diagnostics{
 				diag.Diagnostic{
 					Severity: diag.Error,
-					Summary:  "parse \"https://example.com:path\": invalid port \":path\" after host",
+					Summary:  "Missing environment variables",
+					Detail:   "Either AUTH0_API_TOKEN or AUTH0_DOMAIN:AUTH0_CLIENT_ID:AUTH0_CLIENT_SECRET must be configured. Ref: https://registry.terraform.io/providers/auth0/auth0/latest/docs",
 				},
 			},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -56,7 +56,7 @@ func TestConfigureProvider(t *testing.T) {
 			expectedDiagnostics: diag.Diagnostics{
 				diag.Diagnostic{
 					Severity: diag.Error,
-					Summary:  "parse \"https://example.com:path\": invalid port \":path\" after host",
+					Summary:  "Missing environment variables",
 				},
 			},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -56,7 +56,7 @@ func TestConfigureProvider(t *testing.T) {
 			expectedDiagnostics: diag.Diagnostics{
 				diag.Diagnostic{
 					Severity: diag.Error,
-					Summary:  "Missing environment variables",
+					Summary:  "parse \"https://example.com:path\": invalid port \":path\" after host",
 				},
 			},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,7 +25,7 @@ func TestConfigureProvider(t *testing.T) {
 			name: "it can configure a provider with client credentials",
 			givenTerraformConfig: map[string]interface{}{
 				"domain":        "example.auth0.com",
-				"clientID":      "1234567",
+				"client_id":     "1234567",
 				"client_secret": "secret",
 			},
 			expectedDiagnostics: nil,
@@ -34,7 +34,7 @@ func TestConfigureProvider(t *testing.T) {
 			name: "it can configure a provider with client credentials and audience",
 			givenTerraformConfig: map[string]interface{}{
 				"domain":        "example.auth0.com",
-				"clientID":      "1234567",
+				"client_id":     "1234567",
 				"client_secret": "secret",
 				"audience":      "myaudience",
 			},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,11 +1,7 @@
 package provider
 
 import (
-	"context"
-	"fmt"
 	"os"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/auth0/terraform-provider-auth0/internal/auth0/flow"
 
@@ -176,29 +172,7 @@ func New() *schema.Provider {
 		},
 	}
 
-	provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-		var diags diag.Diagnostics
-
-		// Check required environment variables.
-		requiredEnvVars := []string{"AUTH0_DOMAIN", "AUTH0_CLIENT_ID", "AUTH0_CLIENT_SECRET"}
-		for _, varName := range requiredEnvVars {
-			value, exists := os.LookupEnv(varName)
-			if !exists || value == "" {
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Error,
-					Summary:  fmt.Sprintf("Missing environment variable: %s", varName),
-					Detail:   fmt.Sprintf("The environment variable %s must be set and cannot be empty.", varName),
-				})
-			}
-		}
-
-		if len(diags) > 0 {
-			return nil, diags
-		}
-
-		// Call the original configuration function if no errors.
-		return config.ConfigureProvider(&provider.TerraformVersion)(ctx, d)
-	}
+	provider.ConfigureContextFunc = config.ConfigureProvider(&provider.TerraformVersion)
 
 	return provider
 }


### PR DESCRIPTION
Moved checking required env variables from ConfigureContextFunc to when the provider actually get configured in `ConfigureProvider` during the planning step.

This allows picking variable which might be declared in the tf file itself 
```tf
provider "auth0" {
  domain        = "<domain>"
  client_id     = "<client-id>"
  client_secret = "<client-secret>"
  debug         = "<debug>"
}
```
The above is not recommended and use of env variables is advised. 




<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
