### PR TITLE
PATCH: update `setup` attribute schema for `auth0_flow_vault_connection`

### DIFF
--- a/docs/resources/flow_vault_connection.md
+++ b/docs/resources/flow_vault_connection.md
@@ -37,12 +37,12 @@ resource "auth0_flow_vault_connection" "my_connection" {
 - `account_name` (String) Custom account name of the vault connection.
 - `environment` (String) Environment of the vault connection.
 - `fingerprint` (String) Fingerprint of the vault connection.
-- `ready` (Boolean) Indicates if the vault connection is configured.
 - `setup` (Map of String, Sensitive) Configuration of the vault connection. (Mapping information must be provided as key/value pairs)
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `ready` (Boolean) Indicates if the vault connection is configured.
 
 ## Import
 

--- a/internal/auth0/flow/expand.go
+++ b/internal/auth0/flow/expand.go
@@ -48,10 +48,6 @@ func expandVaultConnection(data *schema.ResourceData) (*management.FlowVaultConn
 		vaultConnection.AccountName = value.String(cfg.GetAttr("account_name"))
 	}
 
-	if data.HasChange("ready") {
-		vaultConnection.Ready = value.Bool(cfg.GetAttr("ready"))
-	}
-
 	return vaultConnection, nil
 }
 

--- a/internal/auth0/flow/flatten.go
+++ b/internal/auth0/flow/flatten.go
@@ -34,7 +34,6 @@ func flattenVaultConnection(data *schema.ResourceData, vaultConnection *manageme
 		data.Set("name", vaultConnection.GetName()),
 		data.Set("app_id", vaultConnection.GetAppID()),
 		data.Set("environment", vaultConnection.GetEnvironment()),
-		data.Set("setup", vaultConnection.GetSetup()),
 		data.Set("account_name", vaultConnection.GetAccountName()),
 		data.Set("ready", vaultConnection.GetReady()),
 		data.Set("fingerprint", vaultConnection.GetFingerprint()),

--- a/internal/auth0/flow/resource_vault_connection.go
+++ b/internal/auth0/flow/resource_vault_connection.go
@@ -68,9 +68,7 @@ func NewVaultConnectionResource() *schema.Resource {
 				Optional:    true,
 				Description: "Configuration of the vault connection. (Mapping information must be provided as key/value pairs)",
 				Sensitive:   true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        schema.TypeString,
 			},
 			"account_name": {
 				Type:        schema.TypeString,
@@ -79,7 +77,7 @@ func NewVaultConnectionResource() *schema.Resource {
 			},
 			"ready": {
 				Type:        schema.TypeBool,
-				Optional:    true,
+				Computed:    true,
 				Description: "Indicates if the vault connection is configured.",
 			},
 			"fingerprint": {


### PR DESCRIPTION
The `setup` attribute in `auth0_flow_vault_connection` is a write-only field and is not returned as part of Vault.GetConnection. Hence updated the expand/flatten to handle the same.

Also, `ready` attribute is a read-only field so update the schema and marked it as a `Computed` field.

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References
https://github.com/auth0/terraform-provider-auth0/issues/1098

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
