### PR TITLE
Update example of auth0_prompt_screen_renderer

### DIFF
--- a/docs/resources/prompt_screen_renderer.md
+++ b/docs/resources/prompt_screen_renderer.md
@@ -33,8 +33,7 @@ resource "auth0_prompt_screen_renderer" "prompt_screen_renderer" {
     "untrusted_data.authorization_params.login_hint",
     "untrusted_data.authorization_params.screen_hint",
     "untrusted_data.authorization_params.ui_locales",
-    "untrusted_data.authorization_params.ext-.key",
-    "transaction.connection.metadata.key"
+    "untrusted_data.authorization_params.ext-key",
   ]
   head_tags = jsonencode([
     {

--- a/examples/resources/auth0_prompt_screen_renderer/resource.tf
+++ b/examples/resources/auth0_prompt_screen_renderer/resource.tf
@@ -20,8 +20,7 @@ resource "auth0_prompt_screen_renderer" "prompt_screen_renderer" {
     "untrusted_data.authorization_params.login_hint",
     "untrusted_data.authorization_params.screen_hint",
     "untrusted_data.authorization_params.ui_locales",
-    "untrusted_data.authorization_params.ext-.key",
-    "transaction.connection.metadata.key"
+    "untrusted_data.authorization_params.ext-key",
   ]
   head_tags = jsonencode([
     {


### PR DESCRIPTION
- Removed the unsupported context_configuration `transaction.connection.metadata`
- Updated the format for suffixing the `untrusted_data.authorization_params.ext-` field in context_configuration