### PR TITLE
Added flatten/expand for token_exchange

### DIFF
--- a/internal/auth0/action/expand.go
+++ b/internal/auth0/action/expand.go
@@ -32,7 +32,7 @@ func expandAction(data *schema.ResourceData) *management.Action {
 		action.Secrets = expandActionSecrets(config.GetAttr("secrets"))
 	}
 
-	// TODO: Remove these soon as node18 reaches EOF.
+	// TODO: Remove this soon as node18 reaches EOL.
 	if action.GetRuntime() == "node18" && !isTokenExchangeInSupportedTriggers(action.SupportedTriggers) {
 		action.Runtime = auth0.String("node18-actions")
 	}

--- a/internal/auth0/action/expand.go
+++ b/internal/auth0/action/expand.go
@@ -40,6 +40,15 @@ func expandAction(data *schema.ResourceData) *management.Action {
 	return action
 }
 
+func isTokenExchangeInSupportedTriggers(actionTriggers []management.ActionTrigger) bool {
+	for _, actionTrigger := range actionTriggers {
+		if actionTrigger.GetID() == "custom-token-exchange" {
+			return true
+		}
+	}
+	return false
+}
+
 func expandActionTriggers(triggers cty.Value) []management.ActionTrigger {
 	if triggers.IsNull() {
 		return nil

--- a/internal/auth0/action/expand.go
+++ b/internal/auth0/action/expand.go
@@ -32,6 +32,7 @@ func expandAction(data *schema.ResourceData) *management.Action {
 		action.Secrets = expandActionSecrets(config.GetAttr("secrets"))
 	}
 
+	// TODO: Remove these soon as node18 reaches EOF.
 	if action.GetRuntime() == "node18" && !isTokenExchangeInSupportedTriggers(action.SupportedTriggers) {
 		action.Runtime = auth0.String("node18-actions")
 	}

--- a/internal/auth0/action/expand.go
+++ b/internal/auth0/action/expand.go
@@ -32,7 +32,7 @@ func expandAction(data *schema.ResourceData) *management.Action {
 		action.Secrets = expandActionSecrets(config.GetAttr("secrets"))
 	}
 
-	if action.GetRuntime() == "node18" {
+	if action.GetRuntime() == "node18" && !isTokenExchangeInSupportedTriggers(action.SupportedTriggers) {
 		action.Runtime = auth0.String("node18-actions")
 	}
 

--- a/internal/auth0/action/expand.go
+++ b/internal/auth0/action/expand.go
@@ -32,6 +32,9 @@ func expandAction(data *schema.ResourceData) *management.Action {
 		action.Secrets = expandActionSecrets(config.GetAttr("secrets"))
 	}
 
+	// If custom-token-exchange is part of SupportedTriggers for an action,
+	// we'd not manipulate it's runtime value.
+	// This is done, to support node18 as runtime.
 	// TODO: Remove this soon as node18 reaches EOL.
 	if action.GetRuntime() == "node18" && !isTokenExchangeInSupportedTriggers(action.SupportedTriggers) {
 		action.Runtime = auth0.String("node18-actions")

--- a/internal/auth0/action/flatten.go
+++ b/internal/auth0/action/flatten.go
@@ -15,7 +15,11 @@ func flattenAction(data *schema.ResourceData, action *management.Action) error {
 		data.Set("runtime", action.GetRuntime()),
 	)
 
-	if action.GetRuntime() == "node18-actions" {
+	// If custom-token-exchange is part of SupportedTriggers for an action,
+	// we'd not manipulate it's runtime value.
+	// This is done, to support node18-actions as runtime.
+
+	if action.GetRuntime() == "node18-actions" && !isTokenExchangeInSupportedTriggers(action.SupportedTriggers) {
 		result = multierror.Append(result, data.Set("runtime", "node18"))
 	}
 
@@ -26,6 +30,14 @@ func flattenAction(data *schema.ResourceData, action *management.Action) error {
 	return result.ErrorOrNil()
 }
 
+func isTokenExchangeInSupportedTriggers(actionTriggers []management.ActionTrigger) bool {
+	for _, actionTrigger := range actionTriggers {
+		if actionTrigger.GetID() == "custom-token-exchange" {
+			return true
+		}
+	}
+	return false
+}
 func flattenActionTriggers(triggers []management.ActionTrigger) []interface{} {
 	var result []interface{}
 

--- a/internal/auth0/action/flatten.go
+++ b/internal/auth0/action/flatten.go
@@ -20,7 +20,7 @@ func flattenAction(data *schema.ResourceData, action *management.Action) error {
 	// This is done, to support node18 as runtime.
 	// TODO: Remove this soon as node18 reaches EOL.
 
-	if action.GetRuntime() == "node18-actions" && !isTokenExchangeInSupportedTriggers(action.SupportedTriggers) {
+	if action.GetRuntime() == "node18-actions" {
 		result = multierror.Append(result, data.Set("runtime", "node18"))
 	}
 
@@ -31,14 +31,6 @@ func flattenAction(data *schema.ResourceData, action *management.Action) error {
 	return result.ErrorOrNil()
 }
 
-func isTokenExchangeInSupportedTriggers(actionTriggers []management.ActionTrigger) bool {
-	for _, actionTrigger := range actionTriggers {
-		if actionTrigger.GetID() == "custom-token-exchange" {
-			return true
-		}
-	}
-	return false
-}
 func flattenActionTriggers(triggers []management.ActionTrigger) []interface{} {
 	var result []interface{}
 

--- a/internal/auth0/action/flatten.go
+++ b/internal/auth0/action/flatten.go
@@ -18,7 +18,7 @@ func flattenAction(data *schema.ResourceData, action *management.Action) error {
 	// If custom-token-exchange is part of SupportedTriggers for an action,
 	// we'd not manipulate it's runtime value.
 	// This is done, to support node18 as runtime.
-	// TODO: Remove these soon as node18 reaches EOF.
+	// TODO: Remove this soon as node18 reaches EOL.
 
 	if action.GetRuntime() == "node18-actions" && !isTokenExchangeInSupportedTriggers(action.SupportedTriggers) {
 		result = multierror.Append(result, data.Set("runtime", "node18"))

--- a/internal/auth0/action/flatten.go
+++ b/internal/auth0/action/flatten.go
@@ -15,11 +15,6 @@ func flattenAction(data *schema.ResourceData, action *management.Action) error {
 		data.Set("runtime", action.GetRuntime()),
 	)
 
-	// If custom-token-exchange is part of SupportedTriggers for an action,
-	// we'd not manipulate it's runtime value.
-	// This is done, to support node18 as runtime.
-	// TODO: Remove this soon as node18 reaches EOL.
-
 	if action.GetRuntime() == "node18-actions" {
 		result = multierror.Append(result, data.Set("runtime", "node18"))
 	}

--- a/internal/auth0/action/flatten.go
+++ b/internal/auth0/action/flatten.go
@@ -17,7 +17,8 @@ func flattenAction(data *schema.ResourceData, action *management.Action) error {
 
 	// If custom-token-exchange is part of SupportedTriggers for an action,
 	// we'd not manipulate it's runtime value.
-	// This is done, to support node18-actions as runtime.
+	// This is done, to support node18 as runtime.
+	// TODO: Remove these soon as node18 reaches EOF.
 
 	if action.GetRuntime() == "node18-actions" && !isTokenExchangeInSupportedTriggers(action.SupportedTriggers) {
 		result = multierror.Append(result, data.Set("runtime", "node18"))

--- a/internal/auth0/client/expand.go
+++ b/internal/auth0/client/expand.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-cty/cty"
@@ -50,6 +49,7 @@ func expandClient(data *schema.ResourceData) (*management.Client, error) {
 		NativeSocialLogin:                  expandClientNativeSocialLogin(data),
 		Mobile:                             expandClientMobile(data),
 		DefaultOrganization:                expandDefaultOrganization(data),
+		TokenExchange:                      expandTokenExchange(data),
 		RequireProofOfPossession:           value.Bool(config.GetAttr("require_proof_of_possession")),
 		ComplianceLevel:                    value.String(config.GetAttr("compliance_level")),
 	}
@@ -109,6 +109,26 @@ func expandDefaultOrganization(data *schema.ResourceData) *management.ClientDefa
 	}
 
 	return &defaultOrg
+}
+
+func expandTokenExchange(data *schema.ResourceData) *management.ClientTokenExchange {
+	if !data.IsNewResource() && !data.HasChange("token_exchange") {
+		return nil
+	}
+	var tokenExchange management.ClientTokenExchange
+
+	config := data.GetRawConfig().GetAttr("token_exchange")
+	if config.IsNull() || config.ForEachElement(func(_ cty.Value, cfg cty.Value) (stop bool) {
+		tokenExchange.AllowAnyProfileOfType = value.Strings(cfg.GetAttr("allow_any_profile_of_type"))
+		return stop
+	}) {
+		return nil
+	}
+	if tokenExchange == (management.ClientTokenExchange{}) {
+		return nil
+	}
+
+	return &tokenExchange
 }
 
 func isDefaultOrgNull(data *schema.ResourceData) bool {

--- a/internal/auth0/client/expand.go
+++ b/internal/auth0/client/expand.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-cty/cty"

--- a/internal/auth0/client/flatten.go
+++ b/internal/auth0/client/flatten.go
@@ -559,13 +559,13 @@ func flattenDefaultOrganization(defaultOrganization *management.ClientDefaultOrg
 }
 
 func flattenTokenExchange(tokenExchange *management.ClientTokenExchange) []interface{} {
-	te := make(map[string]interface{})
-
-	if tokenExchange != nil {
-		te["allow_any_profile_of_type"] = tokenExchange.AllowAnyProfileOfType
+	if tokenExchange == nil {
+		return nil
 	}
-
-	return []interface{}{te}
+	t := map[string]interface{}{
+		"allow_any_profile_of_type": tokenExchange.AllowAnyProfileOfType,
+	}
+	return []interface{}{t}
 }
 
 func flattenClient(data *schema.ResourceData, client *management.Client) error {

--- a/internal/auth0/client/flatten.go
+++ b/internal/auth0/client/flatten.go
@@ -558,6 +558,16 @@ func flattenDefaultOrganization(defaultOrganization *management.ClientDefaultOrg
 	return []interface{}{do}
 }
 
+func flattenTokenExchange(tokenExchange *management.ClientTokenExchange) []interface{} {
+	te := make(map[string]interface{})
+
+	if tokenExchange != nil {
+		te["allow_any_profile_of_type"] = tokenExchange.AllowAnyProfileOfType
+	}
+
+	return []interface{}{te}
+}
+
 func flattenClient(data *schema.ResourceData, client *management.Client) error {
 	result := multierror.Append(
 		data.Set("client_id", client.GetClientID()),
@@ -597,6 +607,7 @@ func flattenClient(data *schema.ResourceData, client *management.Client) error {
 		data.Set("oidc_logout", flattenOIDCLogout(client.GetOIDCLogout())),
 		data.Set("require_pushed_authorization_requests", client.GetRequirePushedAuthorizationRequests()),
 		data.Set("default_organization", flattenDefaultOrganization(client.GetDefaultOrganization())),
+		data.Set("token_exchange", flattenTokenExchange(client.GetTokenExchange())),
 		data.Set("require_proof_of_possession", client.GetRequireProofOfPossession()),
 		data.Set("compliance_level", client.GetComplianceLevel()),
 	)

--- a/internal/auth0/client/resource_test.go
+++ b/internal/auth0/client/resource_test.go
@@ -58,7 +58,7 @@ const testAccCreateMobileClient = `
 resource "auth0_client" "my_client" {
 	name = "Acceptance Test - Mobile - {{.testName}}"
 	app_type = "native"
-
+	oidc_conformant = true
 	token_exchange {
 		allow_any_profile_of_type = ["custom_authentication"]
 	}
@@ -92,6 +92,11 @@ resource "auth0_client" "my_client" {
 	name = "Acceptance Test - Mobile - {{.testName}}"
 	app_type = "native"
 
+	oidc_conformant = true
+	token_exchange {
+		allow_any_profile_of_type = ["custom_authentication"]
+	}
+
 	mobile {
 		android {
 			app_package_name = "com.example"
@@ -121,6 +126,10 @@ resource "auth0_client" "my_client" {
 	name = "Acceptance Test - Mobile - {{.testName}}"
 	app_type = "native"
 
+	oidc_conformant = true
+	token_exchange {
+		allow_any_profile_of_type = ["custom_authentication"]
+	}
 	mobile {
 		android {
 			app_package_name = "com.example"
@@ -141,6 +150,10 @@ resource "auth0_client" "my_client" {
 	name = "Acceptance Test - Mobile - {{.testName}}"
 	app_type = "non_interactive"
 
+	oidc_conformant = true
+	token_exchange {
+		allow_any_profile_of_type = ["custom_authentication"]
+	}
 	native_social_login {
 		apple {
 			enabled = false
@@ -161,6 +174,7 @@ func TestAccClientMobile(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Mobile - %s", t.Name())),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "app_type", "native"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "oidc_conformant", "true"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "token_exchange.0.allow_any_profile_of_type.0", "custom_authentication"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "mobile.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "mobile.0.android.#", "1"),
@@ -181,6 +195,8 @@ func TestAccClientMobile(t *testing.T) {
 				Config: acctest.ParseTestName(testAccUpdateMobileClient, t.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Mobile - %s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "oidc_conformant", "true"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "token_exchange.0.allow_any_profile_of_type.0", "custom_authentication"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "app_type", "native"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "mobile.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "mobile.0.android.#", "1"),
@@ -202,6 +218,8 @@ func TestAccClientMobile(t *testing.T) {
 				Config: acctest.ParseTestName(testAccUpdateMobileClientAgainByRemovingSomeFields, t.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Mobile - %s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "oidc_conformant", "true"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "token_exchange.0.allow_any_profile_of_type.0", "custom_authentication"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "app_type", "native"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "mobile.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "mobile.0.android.#", "1"),
@@ -228,6 +246,8 @@ func TestAccClientMobile(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Mobile - %s", t.Name())),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "app_type", "non_interactive"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "oidc_conformant", "true"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "token_exchange.0.allow_any_profile_of_type.0", "custom_authentication"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "mobile.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "mobile.0.android.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "mobile.0.android.0.app_package_name", "com.example"),

--- a/internal/auth0/client/resource_test.go
+++ b/internal/auth0/client/resource_test.go
@@ -246,7 +246,6 @@ func TestAccClientMobile(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Mobile - %s", t.Name())),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "app_type", "non_interactive"),
-					resource.TestCheckResourceAttr("auth0_client.my_client", "oidc_conformant", "true"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "token_exchange.0.allow_any_profile_of_type.0", "custom_authentication"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "mobile.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "mobile.0.android.#", "1"),

--- a/test/data/recordings/TestAccClientMobile.yaml
+++ b/test/data/recordings/TestAccClientMobile.yaml
@@ -6,14 +6,14 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 382
+        content_length: 478
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Acceptance Test - Mobile - TestAccClientMobile","app_type":"native","token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF"]},"ios":{"team_id":"9JA89QQLNQ","app_bundle_identifier":"com.my.bundle.id"}},"native_social_login":{"apple":{"enabled":true},"facebook":{"enabled":false}},"oidc_logout":{}}
+            {"name":"Acceptance Test - Mobile - TestAccClientMobile","app_type":"native","oidc_conformant":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF"]},"ios":{"team_id":"9JA89QQLNQ","app_bundle_identifier":"com.my.bundle.id"}},"native_social_login":{"apple":{"enabled":true},"facebook":{"enabled":false}},"oidc_logout":{},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}
         form: {}
         headers:
             Content-Type:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF"]},"ios":{"team_id":"9JA89QQLNQ","app_bundle_identifier":"com.my.bundle.id"}},"native_social_login":{"apple":{"enabled":true},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF"]},"ios":{"team_id":"9JA89QQLNQ","app_bundle_identifier":"com.my.bundle.id"}},"native_social_login":{"apple":{"enabled":true},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 467.127875ms
+        duration: 482.056541ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -55,7 +55,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: GET
       response:
         proto: HTTP/2.0
@@ -65,13 +65,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF"]},"ios":{"team_id":"9JA89QQLNQ","app_bundle_identifier":"com.my.bundle.id"}},"native_social_login":{"apple":{"enabled":true},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF"]},"ios":{"team_id":"9JA89QQLNQ","app_bundle_identifier":"com.my.bundle.id"}},"native_social_login":{"apple":{"enabled":true},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.042417ms
+        duration: 368.2245ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -90,7 +90,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: GET
       response:
         proto: HTTP/2.0
@@ -100,13 +100,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF"]},"ios":{"team_id":"9JA89QQLNQ","app_bundle_identifier":"com.my.bundle.id"}},"native_social_login":{"apple":{"enabled":true},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF"]},"ios":{"team_id":"9JA89QQLNQ","app_bundle_identifier":"com.my.bundle.id"}},"native_social_login":{"apple":{"enabled":true},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 539.020958ms
+        duration: 360.043834ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -125,7 +125,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: GET
       response:
         proto: HTTP/2.0
@@ -135,33 +135,33 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF"]},"ios":{"team_id":"9JA89QQLNQ","app_bundle_identifier":"com.my.bundle.id"}},"native_social_login":{"apple":{"enabled":true},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF"]},"ios":{"team_id":"9JA89QQLNQ","app_bundle_identifier":"com.my.bundle.id"}},"native_social_login":{"apple":{"enabled":true},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 468.57625ms
+        duration: 352.010625ms
     - id: 4
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 363
+        content_length: 386
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Acceptance Test - Mobile - TestAccClientMobile","app_type":"native","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":true}},"oidc_logout":{}}
+            {"name":"Acceptance Test - Mobile - TestAccClientMobile","app_type":"native","oidc_conformant":true,"mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":true}},"oidc_logout":{}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -171,13 +171,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":true}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":true}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.8045ms
+        duration: 345.963083ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -196,7 +196,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: GET
       response:
         proto: HTTP/2.0
@@ -206,13 +206,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":true}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":true}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 370.05825ms
+        duration: 363.341542ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -231,7 +231,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: GET
       response:
         proto: HTTP/2.0
@@ -241,13 +241,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":true}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":true}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 381.755167ms
+        duration: 352.704166ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -266,7 +266,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: GET
       response:
         proto: HTTP/2.0
@@ -276,33 +276,33 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":true}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":true}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.437167ms
+        duration: 353.129208ms
     - id: 8
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 261
+        content_length: 284
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Acceptance Test - Mobile - TestAccClientMobile","app_type":"native","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]}},"native_social_login":{"facebook":{"enabled":false}},"oidc_logout":{}}
+            {"name":"Acceptance Test - Mobile - TestAccClientMobile","app_type":"native","oidc_conformant":true,"mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]}},"native_social_login":{"facebook":{"enabled":false}},"oidc_logout":{}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -312,13 +312,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.054958ms
+        duration: 371.820667ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -337,7 +337,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: GET
       response:
         proto: HTTP/2.0
@@ -347,13 +347,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 882.332792ms
+        duration: 369.016416ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -372,7 +372,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: GET
       response:
         proto: HTTP/2.0
@@ -382,13 +382,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 329.571834ms
+        duration: 362.47675ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -407,7 +407,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: GET
       response:
         proto: HTTP/2.0
@@ -417,33 +417,33 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 468.295875ms
+        duration: 366.8265ms
     - id: 12
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 183
+        content_length: 206
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Acceptance Test - Mobile - TestAccClientMobile","app_type":"non_interactive","native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"oidc_logout":{}}
+            {"name":"Acceptance Test - Mobile - TestAccClientMobile","app_type":"non_interactive","oidc_conformant":true,"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"oidc_logout":{}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -453,13 +453,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 357.563709ms
+        duration: 345.836333ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -478,7 +478,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: GET
       response:
         proto: HTTP/2.0
@@ -488,13 +488,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 373.037166ms
+        duration: 371.887875ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -513,7 +513,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: GET
       response:
         proto: HTTP/2.0
@@ -523,13 +523,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Mobile - TestAccClientMobile","client_id":"wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","mobile":{"android":{"app_package_name":"com.example","sha256_cert_fingerprints":["DE:AD:BE:EF","CA:DE:FF:AA"]},"ios":{"team_id":"1111111111","app_bundle_identifier":"com.my.auth0.bundle"}},"native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 363.084458ms
+        duration: 382.453834ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -548,7 +548,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.15.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7t1PS7dxCkLX8gFRvU5sYrRVUL5eUyfu
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/wPL56OZaYQFu3WHW8lk3NgNvj5doCsyC
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -564,4 +564,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 433.958834ms
+        duration: 413.086833ms

--- a/test/data/recordings/TestAccDataClientByName.yaml
+++ b/test/data/recordings/TestAccDataClientByName.yaml
@@ -6,20 +6,20 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 138
+        content_length: 205
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
         body: |
-            {"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","app_type":"non_interactive"}
+            {"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","app_type":"non_interactive","token_endpoint_auth_method":"client_secret_post","oidc_logout":{}}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.0.2
+                - Go-Auth0/1.15.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients
         method: POST
       response:
@@ -30,338 +30,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"pzZriljNXBNEaW9NSpRrborEYULX1dxK","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 450.056042ms
+        duration: 1.059188958s
     - id: 1
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.0.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/pzZriljNXBNEaW9NSpRrborEYULX1dxK
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"pzZriljNXBNEaW9NSpRrborEYULX1dxK","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 111.988ms
-    - id: 2
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.0.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/pzZriljNXBNEaW9NSpRrborEYULX1dxK
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"pzZriljNXBNEaW9NSpRrborEYULX1dxK","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 106.735084ms
-    - id: 3
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.0.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/pzZriljNXBNEaW9NSpRrborEYULX1dxK
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"pzZriljNXBNEaW9NSpRrborEYULX1dxK","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 155.92225ms
-    - id: 4
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.0.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients?include_totals=true&page=0&per_page=100
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"total":4,"start":0,"limit":100,"clients":[{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Default App","callbacks":["http://localhost:8484"],"is_first_party":true,"oidc_conformant":true,"sso_disabled":false,"cross_origin_auth":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"Kqoad1upS7U9WL0TSASFuPMguc2Ttegh","callback_url_template":false,"client_secret":"7HpycYdsGe_6N5--QL3i9J77bn-1WyA1Aqv-ZAGK7F7X63ZVlKleZpPiUfTpXL8y","jwt_configuration":{"alg":"RS256","lifetime_in_seconds":36000,"secret_encoded":false},"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Terraform Provider Auth0","is_first_party":true,"oidc_conformant":true,"sso_disabled":false,"cross_origin_auth":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":31557600,"idle_token_lifetime":2592000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"w1336KJwTZOudMX62U6xdeSTak3X2XpV","callback_url_template":false,"client_secret":"cw650tLZskdGmULHLcB2nLnRtOYifD7A1H2NEIhOO5Yc6H3H1oOMavufhVmSdfLV","jwt_configuration":{"alg":"RS256","lifetime_in_seconds":36000,"secret_encoded":false},"token_endpoint_auth_method":"client_secret_post","app_type":"non_interactive","grant_types":["client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","is_first_party":true,"sso_disabled":false,"cross_origin_auth":false,"oidc_conformant":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"pzZriljNXBNEaW9NSpRrborEYULX1dxK","callback_url_template":false,"client_secret":"QGaxvptDQpRn2OmZ2Xtn635mzbXFXwH0SxX6Wm-4pcPkXHSo2i9pw-z7pfFA6FlC","jwt_configuration":{"lifetime_in_seconds":36000,"secret_encoded":false},"app_type":"non_interactive","grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":true,"callbacks":[],"is_first_party":true,"name":"All Applications","refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"owners":["mr|google-oauth2|102002633619863830825","mr|samlp|okta|will.vedder@auth0.com"],"custom_login_page":"<html><body>My Custom Login Page</body></html>","signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"o9HBfRCcqYIQmDQpaRIZAAQHCaTKdb1a","client_secret":"DiF90gv-nRqVxUxWXHxWVlXEvF5af7cn2fI359bJeONym7jEPk7rwRw7xy7NN_FD","custom_login_page_on":false}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 105.392958ms
-    - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.0.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients?include_totals=true&page=0&per_page=100
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"total":4,"start":0,"limit":100,"clients":[{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Default App","callbacks":["http://localhost:8484"],"is_first_party":true,"oidc_conformant":true,"sso_disabled":false,"cross_origin_auth":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"Kqoad1upS7U9WL0TSASFuPMguc2Ttegh","callback_url_template":false,"client_secret":"7HpycYdsGe_6N5--QL3i9J77bn-1WyA1Aqv-ZAGK7F7X63ZVlKleZpPiUfTpXL8y","jwt_configuration":{"alg":"RS256","lifetime_in_seconds":36000,"secret_encoded":false},"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Terraform Provider Auth0","is_first_party":true,"oidc_conformant":true,"sso_disabled":false,"cross_origin_auth":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":31557600,"idle_token_lifetime":2592000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"w1336KJwTZOudMX62U6xdeSTak3X2XpV","callback_url_template":false,"client_secret":"cw650tLZskdGmULHLcB2nLnRtOYifD7A1H2NEIhOO5Yc6H3H1oOMavufhVmSdfLV","jwt_configuration":{"alg":"RS256","lifetime_in_seconds":36000,"secret_encoded":false},"token_endpoint_auth_method":"client_secret_post","app_type":"non_interactive","grant_types":["client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","is_first_party":true,"sso_disabled":false,"cross_origin_auth":false,"oidc_conformant":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"pzZriljNXBNEaW9NSpRrborEYULX1dxK","callback_url_template":false,"client_secret":"QGaxvptDQpRn2OmZ2Xtn635mzbXFXwH0SxX6Wm-4pcPkXHSo2i9pw-z7pfFA6FlC","jwt_configuration":{"lifetime_in_seconds":36000,"secret_encoded":false},"app_type":"non_interactive","grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":true,"callbacks":[],"is_first_party":true,"name":"All Applications","refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"owners":["mr|google-oauth2|102002633619863830825","mr|samlp|okta|will.vedder@auth0.com"],"custom_login_page":"<html><body>My Custom Login Page</body></html>","signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"o9HBfRCcqYIQmDQpaRIZAAQHCaTKdb1a","client_secret":"DiF90gv-nRqVxUxWXHxWVlXEvF5af7cn2fI359bJeONym7jEPk7rwRw7xy7NN_FD","custom_login_page_on":false}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 102.9585ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.0.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients?include_totals=true&page=0&per_page=100
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"total":4,"start":0,"limit":100,"clients":[{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Default App","callbacks":["http://localhost:8484"],"is_first_party":true,"oidc_conformant":true,"sso_disabled":false,"cross_origin_auth":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"Kqoad1upS7U9WL0TSASFuPMguc2Ttegh","callback_url_template":false,"client_secret":"7HpycYdsGe_6N5--QL3i9J77bn-1WyA1Aqv-ZAGK7F7X63ZVlKleZpPiUfTpXL8y","jwt_configuration":{"alg":"RS256","lifetime_in_seconds":36000,"secret_encoded":false},"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Terraform Provider Auth0","is_first_party":true,"oidc_conformant":true,"sso_disabled":false,"cross_origin_auth":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":31557600,"idle_token_lifetime":2592000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"w1336KJwTZOudMX62U6xdeSTak3X2XpV","callback_url_template":false,"client_secret":"cw650tLZskdGmULHLcB2nLnRtOYifD7A1H2NEIhOO5Yc6H3H1oOMavufhVmSdfLV","jwt_configuration":{"alg":"RS256","lifetime_in_seconds":36000,"secret_encoded":false},"token_endpoint_auth_method":"client_secret_post","app_type":"non_interactive","grant_types":["client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","is_first_party":true,"sso_disabled":false,"cross_origin_auth":false,"oidc_conformant":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"pzZriljNXBNEaW9NSpRrborEYULX1dxK","callback_url_template":false,"client_secret":"QGaxvptDQpRn2OmZ2Xtn635mzbXFXwH0SxX6Wm-4pcPkXHSo2i9pw-z7pfFA6FlC","jwt_configuration":{"lifetime_in_seconds":36000,"secret_encoded":false},"app_type":"non_interactive","grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":true,"callbacks":[],"is_first_party":true,"name":"All Applications","refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"owners":["mr|google-oauth2|102002633619863830825","mr|samlp|okta|will.vedder@auth0.com"],"custom_login_page":"<html><body>My Custom Login Page</body></html>","signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"o9HBfRCcqYIQmDQpaRIZAAQHCaTKdb1a","client_secret":"DiF90gv-nRqVxUxWXHxWVlXEvF5af7cn2fI359bJeONym7jEPk7rwRw7xy7NN_FD","custom_login_page_on":false}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 116.58375ms
-    - id: 7
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.0.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/pzZriljNXBNEaW9NSpRrborEYULX1dxK
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"pzZriljNXBNEaW9NSpRrborEYULX1dxK","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 113.528167ms
-    - id: 8
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.0.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients?include_totals=true&page=0&per_page=100
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"total":4,"start":0,"limit":100,"clients":[{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Default App","callbacks":["http://localhost:8484"],"is_first_party":true,"oidc_conformant":true,"sso_disabled":false,"cross_origin_auth":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"Kqoad1upS7U9WL0TSASFuPMguc2Ttegh","callback_url_template":false,"client_secret":"7HpycYdsGe_6N5--QL3i9J77bn-1WyA1Aqv-ZAGK7F7X63ZVlKleZpPiUfTpXL8y","jwt_configuration":{"alg":"RS256","lifetime_in_seconds":36000,"secret_encoded":false},"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Terraform Provider Auth0","is_first_party":true,"oidc_conformant":true,"sso_disabled":false,"cross_origin_auth":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":31557600,"idle_token_lifetime":2592000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"w1336KJwTZOudMX62U6xdeSTak3X2XpV","callback_url_template":false,"client_secret":"cw650tLZskdGmULHLcB2nLnRtOYifD7A1H2NEIhOO5Yc6H3H1oOMavufhVmSdfLV","jwt_configuration":{"alg":"RS256","lifetime_in_seconds":36000,"secret_encoded":false},"token_endpoint_auth_method":"client_secret_post","app_type":"non_interactive","grant_types":["client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","is_first_party":true,"sso_disabled":false,"cross_origin_auth":false,"oidc_conformant":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"pzZriljNXBNEaW9NSpRrborEYULX1dxK","callback_url_template":false,"client_secret":"QGaxvptDQpRn2OmZ2Xtn635mzbXFXwH0SxX6Wm-4pcPkXHSo2i9pw-z7pfFA6FlC","jwt_configuration":{"lifetime_in_seconds":36000,"secret_encoded":false},"app_type":"non_interactive","grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":true,"callbacks":[],"is_first_party":true,"name":"All Applications","refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"owners":["mr|google-oauth2|102002633619863830825","mr|samlp|okta|will.vedder@auth0.com"],"custom_login_page":"<html><body>My Custom Login Page</body></html>","signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"o9HBfRCcqYIQmDQpaRIZAAQHCaTKdb1a","client_secret":"DiF90gv-nRqVxUxWXHxWVlXEvF5af7cn2fI359bJeONym7jEPk7rwRw7xy7NN_FD","custom_login_page_on":false}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 112.319834ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 5
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            null
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.0.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients?include_totals=true&page=0&per_page=100
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"total":4,"start":0,"limit":100,"clients":[{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Default App","callbacks":["http://localhost:8484"],"is_first_party":true,"oidc_conformant":true,"sso_disabled":false,"cross_origin_auth":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"Kqoad1upS7U9WL0TSASFuPMguc2Ttegh","callback_url_template":false,"client_secret":"7HpycYdsGe_6N5--QL3i9J77bn-1WyA1Aqv-ZAGK7F7X63ZVlKleZpPiUfTpXL8y","jwt_configuration":{"alg":"RS256","lifetime_in_seconds":36000,"secret_encoded":false},"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Terraform Provider Auth0","is_first_party":true,"oidc_conformant":true,"sso_disabled":false,"cross_origin_auth":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":31557600,"idle_token_lifetime":2592000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"w1336KJwTZOudMX62U6xdeSTak3X2XpV","callback_url_template":false,"client_secret":"cw650tLZskdGmULHLcB2nLnRtOYifD7A1H2NEIhOO5Yc6H3H1oOMavufhVmSdfLV","jwt_configuration":{"alg":"RS256","lifetime_in_seconds":36000,"secret_encoded":false},"token_endpoint_auth_method":"client_secret_post","app_type":"non_interactive","grant_types":["client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":false,"is_token_endpoint_ip_header_trusted":false,"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","is_first_party":true,"sso_disabled":false,"cross_origin_auth":false,"oidc_conformant":false,"refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"pzZriljNXBNEaW9NSpRrborEYULX1dxK","callback_url_template":false,"client_secret":"QGaxvptDQpRn2OmZ2Xtn635mzbXFXwH0SxX6Wm-4pcPkXHSo2i9pw-z7pfFA6FlC","jwt_configuration":{"lifetime_in_seconds":36000,"secret_encoded":false},"app_type":"non_interactive","grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true},{"tenant":"terraform-provider-auth0-dev","global":true,"callbacks":[],"is_first_party":true,"name":"All Applications","refresh_token":{"expiration_type":"non-expiring","leeway":0,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"token_lifetime":2592000,"idle_token_lifetime":1296000,"rotation_type":"non-rotating"},"owners":["mr|google-oauth2|102002633619863830825","mr|samlp|okta|will.vedder@auth0.com"],"custom_login_page":"<html><body>My Custom Login Page</body></html>","signing_keys":[{"cert":"-----BEGIN CERTIFICATE-----\r\nMIIDOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNV\r\nBAMTL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAu\r\nY29tMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMv\r\ndGVycmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20w\r\nggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1\r\njRX+qmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+\r\nWqS1F+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJ\r\no2Fwzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0K\r\nmFhw1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv\r\n/qLxKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCen\r\nAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq\r\n1eNX7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7\r\npOEYJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qc\r\ngyr4YaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPkn\r\nPJ6GL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4\r\nXxjtjA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d\r\n03TE9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YI\r\nM3F9PniaChrQ1vBAZg==\r\n-----END CERTIFICATE-----","pkcs7":"-----BEGIN PKCS7-----\r\nMIIDaAYJKoZIhvcNAQcCoIIDWTCCA1UCAQExADALBgkqhkiG9w0BBwGgggM9MIID\r\nOTCCAiGgAwIBAgIJXhd78QwsLiPkMA0GCSqGSIb3DQEBCwUAMDoxODA2BgNVBAMT\r\nL3RlcnJhZm9ybS1wcm92aWRlci1hdXRoMC1lMmUtdGVzdHMuZXUuYXV0aDAuY29t\r\nMB4XDTIzMDYxNTEwMjAyOFoXDTM3MDIyMTEwMjAyOFowOjE4MDYGA1UEAxMvdGVy\r\ncmFmb3JtLXByb3ZpZGVyLWF1dGgwLWUyZS10ZXN0cy5ldS5hdXRoMC5jb20wggEi\r\nMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIDz7FwcVudBg6L1fWZun1jRX+\r\nqmzb53asskZE3HpI2PiVneNLSuMVmW8ciStiOHsPfCkFTStKXWRTA/6TN3i+WqS1\r\nF+7Ixuvsu2zGzdzgwEXb+nzWe7Q5+u3C/tDA9HX9rcef6S0hoRWyMY/4ObOJo2Fw\r\nzq7x/IKRaUy5R6/pTyRPUnFm+SqvJWSfu+5ah+aSuj/mxaGmugW8ueWxFS0KmFhw\r\n1DmhsjHKIo4Jrb3b5Ohqr2xbKG/zLdJfkHYZowhutReRfdzCjRd/t/cud+Iv/qLx\r\nKR0CluxvpjAmyw1bYtNP4OxVry3iXEq/Yh4gqnSpx/uVmmSLYh9Ks37rUCenAgMB\r\nAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFOAcj8ZDWthLndbq1eNX\r\n7sEvZ9ycMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAAxj7pOEY\r\nJdJrd5DPnF7W6/4XA48AgxqIzReZbL6ykXqlqnxgKRWqIdsLA0Wf1N3aO7qcgyr4\r\nYaqS63P6X4Fmn00/PR6AiqLLbs+s0dIjItUu7KtkHB9EOHtMKoEw8jzRcPknPJ6G\r\nL0VcpzJTXGQasdXIxPl0gbvjfeAFKVmlVXQo6HhCAy0hblSCQop3R7hjZrB4Xxjt\r\njA8N3L7VlQMI781vTV1fhuATOSu3Nkg3UHBReMK9JtzybfTKZFHK7vwuJs6d03TE\r\n9Ll45Nyy5O+P+1HOb+R0tFpk17dC8PSBZukw0WWdN8gZxnnajZeDaiorN0YIM3F9\r\nPniaChrQ1vBAZjEA\r\n-----END PKCS7-----\r\n","subject":"deprecated"}],"client_id":"o9HBfRCcqYIQmDQpaRIZAAQHCaTKdb1a","client_secret":"DiF90gv-nRqVxUxWXHxWVlXEvF5af7cn2fI359bJeONym7jEPk7rwRw7xy7NN_FD","custom_login_page_on":false}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 137.54725ms
-    - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -378,8 +54,253 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.0.2
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/pzZriljNXBNEaW9NSpRrborEYULX1dxK
+                - Go-Auth0/1.15.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 431.166834ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.15.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 729.776792ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.15.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 509.105792ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.15.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"start":0,"limit":100,"length":0,"total":9,"next":"","clients":[{"name":"terraform-e2e-auth0","client_id":"Mt2OyVN7QphPhmFWgJMXtzzethEatko0","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"callbacks":[],"client_aliases":[],"allowed_clients":[],"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":true,"grant_types":["client_credentials","urn:openid:params:grant-type:ciba"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}},{"name":"API Explorer Application","client_id":"bpViNbMMF1X5J17kaB1jObShEVB81nol","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"callbacks":[],"client_aliases":[],"allowed_clients":[],"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":true,"grant_types":["client_credentials","urn:openid:params:grant-type:ciba"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"organization_usage":"allow"},{"name":"CTE Demo","client_id":"5Ra4gVS4JuTFjuJYkhwIcRcfZIAIT2N0","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}},{"name":"test-client","client_id":"xl774jhA7nyg0mlNYb6RFdybfgDFULKD","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}},{"name":"test-client-223","client_id":"tEQ9i0TSqyblOJAb0LD8WvpgxnGf4Kn1","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}},{"name":"test-client-223","client_id":"VfXAisN0UNJalKZNSWEtUd5nE3NhqnYT","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}},{"name":"test-client","description":"hello","client_id":"VkLpDwBPhbZO0rS8WgwPQUv5rsL4cqZy","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}},{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}},{"name":"All Applications","client_id":"B28zWMhmmwnIIG4Sfgnupe8BtKcOaA8D","client_secret":"[REDACTED]","is_first_party":true,"callbacks":[],"signing_keys":[{"cert":"[REDACTED]"}],"cross_origin_authentication":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.036616125s
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.15.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"start":0,"limit":100,"length":0,"total":9,"next":"","clients":[{"name":"terraform-e2e-auth0","client_id":"Mt2OyVN7QphPhmFWgJMXtzzethEatko0","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"callbacks":[],"client_aliases":[],"allowed_clients":[],"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":true,"grant_types":["client_credentials","urn:openid:params:grant-type:ciba"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}},{"name":"API Explorer Application","client_id":"bpViNbMMF1X5J17kaB1jObShEVB81nol","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"callbacks":[],"client_aliases":[],"allowed_clients":[],"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":true,"grant_types":["client_credentials","urn:openid:params:grant-type:ciba"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"organization_usage":"allow"},{"name":"CTE Demo","client_id":"5Ra4gVS4JuTFjuJYkhwIcRcfZIAIT2N0","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}},{"name":"test-client","client_id":"xl774jhA7nyg0mlNYb6RFdybfgDFULKD","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}},{"name":"test-client-223","client_id":"tEQ9i0TSqyblOJAb0LD8WvpgxnGf4Kn1","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}},{"name":"test-client-223","client_id":"VfXAisN0UNJalKZNSWEtUd5nE3NhqnYT","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}},{"name":"test-client","description":"hello","client_id":"VkLpDwBPhbZO0rS8WgwPQUv5rsL4cqZy","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}},{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}},{"name":"All Applications","client_id":"B28zWMhmmwnIIG4Sfgnupe8BtKcOaA8D","client_secret":"[REDACTED]","is_first_party":true,"callbacks":[],"signing_keys":[{"cert":"[REDACTED]"}],"cross_origin_authentication":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 896.186375ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.15.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 376.54ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.15.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients?include_totals=true&page=0&per_page=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"start":0,"limit":100,"length":0,"total":9,"next":"","clients":[{"name":"terraform-e2e-auth0","client_id":"Mt2OyVN7QphPhmFWgJMXtzzethEatko0","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"callbacks":[],"client_aliases":[],"allowed_clients":[],"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":true,"grant_types":["client_credentials","urn:openid:params:grant-type:ciba"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}},{"name":"API Explorer Application","client_id":"bpViNbMMF1X5J17kaB1jObShEVB81nol","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"callbacks":[],"client_aliases":[],"allowed_clients":[],"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":true,"grant_types":["client_credentials","urn:openid:params:grant-type:ciba"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","native_social_login":{"apple":{"enabled":false},"facebook":{"enabled":false}},"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"organization_usage":"allow"},{"name":"CTE Demo","client_id":"5Ra4gVS4JuTFjuJYkhwIcRcfZIAIT2N0","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}},{"name":"test-client","client_id":"xl774jhA7nyg0mlNYb6RFdybfgDFULKD","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}},{"name":"test-client-223","client_id":"tEQ9i0TSqyblOJAb0LD8WvpgxnGf4Kn1","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}},{"name":"test-client-223","client_id":"VfXAisN0UNJalKZNSWEtUd5nE3NhqnYT","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}},"token_exchange":{"allow_any_profile_of_type":["custom_authentication"]}},{"name":"test-client","description":"hello","client_id":"VkLpDwBPhbZO0rS8WgwPQUv5rsL4cqZy","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}},{"name":"Acceptance Test - TestAccDataClientByName","description":"Description for TestAccDataClientByName","client_id":"h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}},{"name":"All Applications","client_id":"B28zWMhmmwnIIG4Sfgnupe8BtKcOaA8D","client_secret":"[REDACTED]","is_first_party":true,"callbacks":[],"signing_keys":[{"cert":"[REDACTED]"}],"cross_origin_authentication":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 531.399625ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.15.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/h3CRWhAAu2qfA1z3bq12WKMxc9OiueC1
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -395,4 +316,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 236.649542ms
+        duration: 439.652584ms


### PR DESCRIPTION
1. `custom-token-exchange` trigger does not support node18-actions as runtime. It only supports node18 and node22. With the present terraform configuration which manipulated node18 input to node18-actions, it was practically impossible to create an action for this trigger with node18 as runtime. A required clause was added to support this and maintain the same functionality for other triggers.
2. Missing expand/flatten rules where added for auth0_client `token_exchange` param

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
