### PR TITLE
WIP: Support 'error_page' on the tenant settings

### DIFF
--- a/internal/auth0/tenant/resource.go
+++ b/internal/auth0/tenant/resource.go
@@ -376,6 +376,34 @@ func NewResource() *schema.Resource {
 					},
 				},
 			},
+			"error_page": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
+				Description: "Configuration for the error page",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"html": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Custom Error HTML (Liquid syntax is supported)",
+						},
+						"show_log_link": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: "Whether to show the link to log as part of the default error page (true, default) or not to show the link (false).",
+						},
+						"url": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "URL to redirect to when an error occurs instead of showing the default error page",
+						},
+					},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds 'error_page' block for the 'auth0_tenant' resource

### 📚 References

Closes #1162. [Management API reference](https://auth0.com/docs/api/management/v2/tenants/patch-settings)

### 🔬 Testing

Will add unit tests and help set up e2e acceptance tests

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)
