### PR TITLE
Add support for release 5 ACUL screens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	gopkg.in/dnaeon/go-vcr.v3 v3.2.0
 )
 
+replace github.com/auth0/go-auth0 v1.19.0 => ../go-auth0
+
 require (
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/Kunde21/markdownfmt/v3 v3.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/auth0/go-auth0 v1.19.0 h1:LZAVZCiZsENm0wX/PvRwN+mLbyCb4PPCfyKww8b7KR4=
-github.com/auth0/go-auth0 v1.19.0/go.mod h1:6g0NRYWA+rzTLG5AohwCJ0YCEqbzphKcdjt+PWrgcPk=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/internal/auth0/client/expand.go
+++ b/internal/auth0/client/expand.go
@@ -52,6 +52,7 @@ func expandClient(data *schema.ResourceData) (*management.Client, error) {
 		DefaultOrganization:                expandDefaultOrganization(data),
 		TokenExchange:                      expandTokenExchange(data),
 		RequireProofOfPossession:           value.Bool(config.GetAttr("require_proof_of_possession")),
+		SessionTransfer:                    expandSessionTransfer(data),
 		ComplianceLevel:                    value.String(config.GetAttr("compliance_level")),
 	}
 
@@ -1014,4 +1015,26 @@ func expandClientGrant(data *schema.ResourceData) *management.ClientGrant {
 	}
 
 	return clientGrant
+}
+
+func expandSessionTransfer(data *schema.ResourceData) *management.SessionTransfer {
+	if !data.IsNewResource() && !data.HasChange("session_transfer") {
+		return nil
+	}
+
+	sessionTransferConfig := data.GetRawConfig().GetAttr("session_transfer")
+	if sessionTransferConfig.IsNull() {
+		return nil
+	}
+
+	var sessionTransfer management.SessionTransfer
+
+	sessionTransferConfig.ForEachElement(func(_ cty.Value, config cty.Value) (stop bool) {
+		sessionTransfer.CanCreateSessionTransferToken = value.Bool(config.GetAttr("can_create_session_transfer_token"))
+		sessionTransfer.AllowedAuthenticationMethods = value.Strings(config.GetAttr("allowed_authentication_methods"))
+		sessionTransfer.EnforceDeviceBinding = value.String(config.GetAttr("enforce_device_binding"))
+		return stop
+	})
+
+	return &sessionTransfer
 }

--- a/internal/auth0/client/flatten.go
+++ b/internal/auth0/client/flatten.go
@@ -615,8 +615,25 @@ func flattenClient(data *schema.ResourceData, client *management.Client) error {
 		data.Set("token_exchange", flattenTokenExchange(client.GetTokenExchange())),
 		data.Set("require_proof_of_possession", client.GetRequireProofOfPossession()),
 		data.Set("compliance_level", client.GetComplianceLevel()),
+		data.Set("session_transfer", flattenSessionTransfer(client.GetSessionTransfer())),
 	)
 	return result.ErrorOrNil()
+}
+
+func flattenSessionTransfer(sessionTransfer *management.SessionTransfer) []interface{} {
+	if sessionTransfer == nil {
+		return nil
+	}
+
+	t := map[string]interface{}{
+		"can_create_session_transfer_token": sessionTransfer.GetCanCreateSessionTransferToken(),
+		"allowed_authentication_methods":    sessionTransfer.GetAllowedAuthenticationMethods(),
+		"enforce_device_binding":            sessionTransfer.GetEnforceDeviceBinding(),
+	}
+
+	return []interface{}{
+		t,
+	}
 }
 
 func flattenClientGrant(data *schema.ResourceData, clientGrant *management.ClientGrant) error {

--- a/internal/auth0/client/resource_test.go
+++ b/internal/auth0/client/resource_test.go
@@ -2543,3 +2543,106 @@ func TestAccClientOIDCLogout(t *testing.T) {
 		},
 	})
 }
+
+const testAccCreateClientWithSessionTransfer = `
+resource "auth0_client" "my_client" {
+	name      = "Acceptance Test - Session Transfer - {{.testName}}"
+	app_type  = "native"
+	session_transfer {
+
+	}
+}`
+
+const testAccUpdateClientWithSessionTransfer = `
+resource "auth0_client" "my_client" {
+	name      = "Acceptance Test - Session Transfer - {{.testName}}"
+	app_type  = "native"
+	session_transfer {
+		can_create_session_transfer_token = true
+		allowed_authentication_methods = ["cookie", "query"]
+		enforce_device_binding = "asn"
+	}
+}`
+
+const testAccUpdateClientWithSessionTransfer1 = `
+resource "auth0_client" "my_client" {
+	name      = "Acceptance Test - Session Transfer - {{.testName}}"
+	app_type  = "native"
+	session_transfer {
+		can_create_session_transfer_token = false
+		enforce_device_binding = "none"
+		allowed_authentication_methods = []
+	}
+}`
+
+const testAccUpdateClientWithSessionTransfer2 = `
+resource "auth0_client" "my_client" {
+	name      = "Acceptance Test - Session Transfer - {{.testName}}"
+	app_type  = "native"
+	session_transfer {
+		can_create_session_transfer_token = true
+		enforce_device_binding = "ip"
+		allowed_authentication_methods = ["query"]
+	}
+}`
+
+const testAccUpdateClientWithSessionTransfer3 = `
+resource "auth0_client" "my_client" {
+	name      = "Acceptance Test - Session Transfer - {{.testName}}"
+	app_type  = "native"
+}`
+
+func TestAccClientSessionTransfer(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseTestName(testAccCreateClientWithSessionTransfer, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Session Transfer - %s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "app_type", "native"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.can_create_session_transfer_token", "false"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.allowed_authentication_methods.#", "0"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.enforce_device_binding", "ip"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccUpdateClientWithSessionTransfer, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Session Transfer - %s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "app_type", "native"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.can_create_session_transfer_token", "true"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.allowed_authentication_methods.#", "2"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.enforce_device_binding", "asn"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccUpdateClientWithSessionTransfer1, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Session Transfer - %s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "app_type", "native"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.can_create_session_transfer_token", "false"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.enforce_device_binding", "none"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.allowed_authentication_methods.#", "0"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccUpdateClientWithSessionTransfer2, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Session Transfer - %s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "app_type", "native"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.can_create_session_transfer_token", "true"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.enforce_device_binding", "ip"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.allowed_authentication_methods.0", "query"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccUpdateClientWithSessionTransfer3, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Session Transfer - %s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "app_type", "native"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/internal/auth0/prompt/resource_screen_render.go
+++ b/internal/auth0/prompt/resource_screen_render.go
@@ -38,6 +38,11 @@ var (
 		string(management.PromptInvitation),
 		string(management.PromptOrganizations),
 		string(management.PromptMFAOTP),
+		string(management.PromptDeviceFlow),
+		string(management.PromptMFAPhone),
+		string(management.PromptMFAVoice),
+		string(management.PromptMFARecoveryCode),
+		string(management.PromptCommon),
 	}
 	allowedScreensSettingsRenderer = []string{
 		string(management.ScreenSignupID),
@@ -83,6 +88,21 @@ var (
 		string(management.ScreenMFAOTPChallenge),
 		string(management.ScreenMFAOTPEnrollmentCode),
 		string(management.ScreenMFAOTPEnrollmentQR),
+		string(management.ScreenDeviceCodeActivation),
+		string(management.ScreenDeviceCodeActivationAllowed),
+		string(management.ScreenDeviceCodeActivationDenied),
+		string(management.ScreenDeviceCodeConfirmation),
+		string(management.ScreenMFAPhoneChallenge),
+		string(management.ScreenMFAPhoneEnrollment),
+		string(management.ScreenMFAVoiceChallenge),
+		string(management.ScreenMFAVoiceEnrollment),
+		string(management.ScreenResetPasswordMFAPhoneChallenge),
+		string(management.ScreenResetPasswordMFAVoiceChallenge),
+		string(management.ScreenMFARecoveryCodeChallenge),
+		string(management.ScreenMFARecoveryCodeEnrollment),
+
+		string(management.ScreenResetPasswordMFARecoveryCodeChallenge),
+		string(management.ScreenRedeemTicket),
 	}
 
 	supportedRenderingModes = []string{string(management.RenderingModeStandard), string(management.RenderingModeAdvanced)}


### PR DESCRIPTION
Support new screens on ACUL as part of release-5:


Prompt-name | Screen-name
-- | --
device-flow | device-code-activation
device-flow | device-code-activation-allowed
device-flow | device-code-activation-denied
device-flow | device-code-confirmation
mfa-phone |  mfa-phone-challenge
mfa-phone |  mfa-phone-enrollment
mfa-voice | mfa-voice-challenge
mfa-voice | mfa-voice-enrollment
reset-password | reset-password-mfa-phone-challenge
reset-password | reset-password-mfa-voice-challenge
mfa-recovery-code | mfa-recovery-code-challenge
mfa-recovery-code | mfa-recovery-code-enrollment
reset-password | reset-password-mfa-recovery-code-challenge
common | redeem-ticket
