### PR TITLE
Updated examples and docs for `auth0_resource_server`

### DIFF
--- a/docs/resources/resource_server_scope.md
+++ b/docs/resources/resource_server_scope.md
@@ -18,13 +18,6 @@ conjunction with the `auth0_resource_server_scopes` resource when managing scope
 resource "auth0_resource_server" "resource_server" {
   name       = "Example Resource Server (Managed by Terraform)"
   identifier = "https://api.example.com"
-
-  # Until we remove the ability to operate changes on
-  # the scopes field it is important to have this
-  # block in the config, to avoid diffing issues.
-  lifecycle {
-    ignore_changes = [scopes]
-  }
 }
 
 resource "auth0_resource_server_scope" "read_posts" {

--- a/docs/resources/resource_server_scopes.md
+++ b/docs/resources/resource_server_scopes.md
@@ -19,13 +19,6 @@ server id.
 resource "auth0_resource_server" "my_api" {
   name       = "Example Resource Server (Managed by Terraform)"
   identifier = "https://api.example.com"
-
-  # Until we remove the ability to operate changes on
-  # the scopes field it is important to have this
-  # block in the config, to avoid diffing issues.
-  lifecycle {
-    ignore_changes = [scopes]
-  }
 }
 
 resource "auth0_resource_server_scopes" "my_api_scopes" {

--- a/examples/resources/auth0_resource_server_scope/resource.tf
+++ b/examples/resources/auth0_resource_server_scope/resource.tf
@@ -1,13 +1,6 @@
 resource "auth0_resource_server" "resource_server" {
   name       = "Example Resource Server (Managed by Terraform)"
   identifier = "https://api.example.com"
-
-  # Until we remove the ability to operate changes on
-  # the scopes field it is important to have this
-  # block in the config, to avoid diffing issues.
-  lifecycle {
-    ignore_changes = [scopes]
-  }
 }
 
 resource "auth0_resource_server_scope" "read_posts" {

--- a/examples/resources/auth0_resource_server_scopes/resource.tf
+++ b/examples/resources/auth0_resource_server_scopes/resource.tf
@@ -1,13 +1,6 @@
 resource "auth0_resource_server" "my_api" {
   name       = "Example Resource Server (Managed by Terraform)"
   identifier = "https://api.example.com"
-
-  # Until we remove the ability to operate changes on
-  # the scopes field it is important to have this
-  # block in the config, to avoid diffing issues.
-  lifecycle {
-    ignore_changes = [scopes]
-  }
 }
 
 resource "auth0_resource_server_scopes" "my_api_scopes" {


### PR DESCRIPTION

### 🔧 Changes

Until the migration we had to put the `ignore_changes = [scopes]` block on the `auth0_resource_server` 
Updated the docs to remove it from examples.

Closes #994 
