### PR TITLE
Fix: Updated enabled_clients for connection logic

### DIFF
--- a/internal/auth0/connection/resource_clients.go
+++ b/internal/auth0/connection/resource_clients.go
@@ -119,20 +119,22 @@ func updateConnectionClients(ctx context.Context, data *schema.ResourceData, met
 	api := meta.(*config.Config).GetAPI()
 	connectionID := data.Id()
 
-	oldSet, newSet := data.GetChange("enabled_clients")
+	oldRaw, newRaw := data.GetChange("enabled_clients")
+	oldSet := oldRaw.(*schema.Set)
+	newSet := newRaw.(*schema.Set)
+
+	added := newSet.Difference(oldSet).List()
+	removed := oldSet.Difference(newSet).List()
 
 	var payload []management.ConnectionEnabledClient
 
-	add := newSet.(*schema.Set).List()
-	remove := oldSet.(*schema.Set).List()
-
-	for _, clientID := range add {
+	for _, clientID := range added {
 		payload = append(payload, management.ConnectionEnabledClient{
 			ClientID: auth0.String(clientID.(string)),
 			Status:   auth0.Bool(true),
 		})
 	}
-	for _, clientID := range remove {
+	for _, clientID := range removed {
 		payload = append(payload, management.ConnectionEnabledClient{
 			ClientID: auth0.String(clientID.(string)),
 			Status:   auth0.Bool(false),

--- a/test/data/recordings/TestAccConnectionClients.yaml
+++ b/test/data/recordings/TestAccConnectionClients.yaml
@@ -3,1537 +3,1933 @@ version: 2
 interactions:
     - id: 0
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 82
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"name":"Acceptance-Test-Connection-TestAccConnectionClients","strategy":"auth0"}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
-        method: POST
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 82
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: |
+              {"name":"Acceptance-Test-Connection-TestAccConnectionClients","strategy":"auth0"}
+          form: {}
+          headers:
+              Content-Type:
+                  - application/json
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+          method: POST
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 558
-        uncompressed: false
-        body: '{"id":"con_pIPfyhZmuesWcIny","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 201 Created
-        code: 201
-        duration: 364.927125ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 558
+          uncompressed: false
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","strategy_version":2,"authentication_methods":{"password":{"enabled":true},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 201 Created
+          code: 201
+          duration: 461.005667ms
     - id: 1
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 382.266083ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 513.456917ms
     - id: 2
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 14
-        uncompressed: false
-        body: '{"clients":[]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 354.863ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 14
+          uncompressed: false
+          body: '{"clients":[]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 503.312834ms
     - id: 3
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 14
-        uncompressed: false
-        body: '{"clients":[]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 345.670708ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 14
+          uncompressed: false
+          body: '{"clients":[]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 609.13725ms
     - id: 4
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny?fields=strategy%2Cname&include_fields=true
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 340.61725ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 520.358292ms
     - id: 5
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 366.437917ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 538.31725ms
     - id: 6
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 14
-        uncompressed: false
-        body: '{"clients":[]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 319.549917ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 14
+          uncompressed: false
+          body: '{"clients":[]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 460.277875ms
     - id: 7
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny?fields=strategy%2Cname&include_fields=true
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 331.648959ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 395.140208ms
     - id: 8
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 334.131625ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 503.891ms
     - id: 9
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 14
-        uncompressed: false
-        body: '{"clients":[]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 425.396208ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 14
+          uncompressed: false
+          body: '{"clients":[]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 562.970959ms
     - id: 10
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny?fields=strategy%2Cname&include_fields=true
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 952.708667ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 558.667667ms
     - id: 11
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 78
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"name":"Acceptance-Test-Client-1-TestAccConnectionClients","oidc_logout":{}}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients
-        method: POST
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 78
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: |
+              {"name":"Acceptance-Test-Client-1-TestAccConnectionClients","oidc_logout":{}}
+          form: {}
+          headers:
+              Content-Type:
+                  - application/json
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients
+          method: POST
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: false
-        body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 201 Created
-        code: 201
-        duration: 448.081709ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: false
+          body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 201 Created
+          code: 201
+          duration: 731.822083ms
     - id: 12
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/nYy1E8zO6kj15b4K91f5riCGavSkURan
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 337.871ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 507.480916ms
     - id: 13
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 65
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            [{"client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan","status":true}]
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: PATCH
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 65
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: |
+              [{"client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D","status":true}]
+          form: {}
+          headers:
+              Content-Type:
+                  - application/json
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: PATCH
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 348.583458ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 0
+          uncompressed: false
+          body: ""
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 204 No Content
+          code: 204
+          duration: 494.10225ms
     - id: 14
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"clients":[{"client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 376.471708ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"clients":[{"client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D"}]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 500.978166ms
     - id: 15
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny?fields=strategy%2Cname&include_fields=true
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 342.802625ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 386.883208ms
     - id: 16
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":["nYy1E8zO6kj15b4K91f5riCGavSkURan"],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 352.57225ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":["dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D"],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 464.069333ms
     - id: 17
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/nYy1E8zO6kj15b4K91f5riCGavSkURan
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 357.133875ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 485.027708ms
     - id: 18
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"clients":[{"client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 308.174584ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"clients":[{"client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D"}]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 546.324125ms
     - id: 19
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny?fields=strategy%2Cname&include_fields=true
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 357.66525ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 576.2015ms
     - id: 20
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":["nYy1E8zO6kj15b4K91f5riCGavSkURan"],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 350.148875ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":["dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D"],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 391.038375ms
     - id: 21
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/nYy1E8zO6kj15b4K91f5riCGavSkURan
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 330.237667ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 540.302583ms
     - id: 22
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"clients":[{"client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 345.05175ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"clients":[{"client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D"}]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 504.863458ms
     - id: 23
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny?fields=strategy%2Cname&include_fields=true
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 334.78275ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 568.7925ms
     - id: 24
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 78
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"name":"Acceptance-Test-Client-1-TestAccConnectionClients","oidc_logout":{}}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients
-        method: POST
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 78
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: |
+              {"name":"Acceptance-Test-Client-2-TestAccConnectionClients","oidc_logout":{}}
+          form: {}
+          headers:
+              Content-Type:
+                  - application/json
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients
+          method: POST
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: false
-        body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 201 Created
-        code: 201
-        duration: 480.597875ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: false
+          body: '{"name":"Acceptance-Test-Client-2-TestAccConnectionClients","client_id":"6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 201 Created
+          code: 201
+          duration: 622.788708ms
     - id: 25
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 333.273917ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-2-TestAccConnectionClients","client_id":"6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 450.075875ms
     - id: 26
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 128
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            [{"client_id":"WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3","status":true},{"client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan","status":true}]
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: PATCH
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 65
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: |
+              [{"client_id":"6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn","status":true}]
+          form: {}
+          headers:
+              Content-Type:
+                  - application/json
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: PATCH
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 369.226333ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 0
+          uncompressed: false
+          body: ""
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 204 No Content
+          code: 204
+          duration: 471.111959ms
     - id: 27
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"clients":[{"client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan"},{"client_id":"WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 358.395375ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"clients":[{"client_id":"6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn"},{"client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D"}]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 515.617ms
     - id: 28
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny?fields=strategy%2Cname&include_fields=true
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 331.030083ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 383.051417ms
     - id: 29
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":["WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3","nYy1E8zO6kj15b4K91f5riCGavSkURan"],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 348.2435ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":["6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn","dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D"],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 397.695958ms
     - id: 30
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/nYy1E8zO6kj15b4K91f5riCGavSkURan
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 346.237291ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 502.773292ms
     - id: 31
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 390.403458ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-2-TestAccConnectionClients","client_id":"6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 477.503208ms
     - id: 32
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"clients":[{"client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan"},{"client_id":"WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 365.61125ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"clients":[{"client_id":"6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn"},{"client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D"}]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 721.524125ms
     - id: 33
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny?fields=strategy%2Cname&include_fields=true
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 360.991542ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 767.802792ms
     - id: 34
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 346.557916ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":["6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn","dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D"],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 542.129041ms
     - id: 35
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/nYy1E8zO6kj15b4K91f5riCGavSkURan
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 346.631417ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 434.614833ms
     - id: 36
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"clients":[{"client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan"},{"client_id":"WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 512.667375ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-2-TestAccConnectionClients","client_id":"6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 522.859916ms
     - id: 37
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny?fields=strategy%2Cname&include_fields=true
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 353.650583ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"clients":[{"client_id":"6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn"},{"client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D"}]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 1.272171458s
     - id: 38
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":["WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3","nYy1E8zO6kj15b4K91f5riCGavSkURan"],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 912.516375ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 498.729916ms
     - id: 39
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 130
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            [{"client_id":"WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3","status":false},{"client_id":"nYy1E8zO6kj15b4K91f5riCGavSkURan","status":false}]
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny/clients
-        method: PATCH
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 130
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: |
+              [{"client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D","status":false},{"client_id":"6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn","status":false}]
+          form: {}
+          headers:
+              Content-Type:
+                  - application/json
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: PATCH
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 383.796917ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 0
+          uncompressed: false
+          body: ""
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 204 No Content
+          code: 204
+          duration: 412.156542ms
     - id: 40
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/WnujI4mp8vy2XpqV79FWHgH6XCYPnaG3
-        method: DELETE
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 391.660709ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 14
+          uncompressed: false
+          body: '{"clients":[]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 476.776542ms
     - id: 41
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/nYy1E8zO6kj15b4K91f5riCGavSkURan
-        method: DELETE
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 416.740458ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 385.565541ms
     - id: 42
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 385.766ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 652.435459ms
     - id: 43
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 352.95175ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 498.017584ms
     - id: 44
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny
-        method: GET
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_pIPfyhZmuesWcIny","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 344.882875ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-2-TestAccConnectionClients","client_id":"6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 473.842167ms
     - id: 45
       request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.22.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_pIPfyhZmuesWcIny
-        method: DELETE
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
       response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 41
-        uncompressed: false
-        body: '{"deleted_at":"2025-06-09T06:17:03.206Z"}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 202 Accepted
-        code: 202
-        duration: 348.134ms
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 14
+          uncompressed: false
+          body: '{"clients":[]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 526.052917ms
+    - id: 46
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 491.397625ms
+    - id: 47
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr/clients
+          method: GET
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 14
+          uncompressed: false
+          body: '{"clients":[]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 467.635834ms
+    - id: 48
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn
+          method: GET
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-2-TestAccConnectionClients","client_id":"6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 482.027917ms
+    - id: 49
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 514.605708ms
+    - id: 50
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D
+          method: GET
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"name":"Acceptance-Test-Client-1-TestAccConnectionClients","client_id":"dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D","client_secret":"[REDACTED]","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"oidc_backchannel_logout":{},"oidc_logout":{"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 651.415417ms
+    - id: 51
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr?fields=strategy%2Cname&include_fields=true
+          method: GET
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 468.878458ms
+    - id: 52
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/6Iyz4wEeUxyyuFBf0BfgZaZNb9WEBijn
+          method: DELETE
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 0
+          uncompressed: false
+          body: ""
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 204 No Content
+          code: 204
+          duration: 482.508375ms
+    - id: 53
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/dIu601Fa38aPX9imEIQQJ7Y0yIQzfG0D
+          method: DELETE
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 0
+          uncompressed: false
+          body: ""
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 204 No Content
+          code: 204
+          duration: 567.919708ms
+    - id: 54
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 529.521125ms
+    - id: 55
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 438.290291ms
+    - id: 56
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: GET
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: -1
+          uncompressed: true
+          body: '{"id":"con_lkGguil7xCdCWvGr","options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"good","passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionClients","is_domain_connection":false,"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionClients"]}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 200 OK
+          code: 200
+          duration: 539.790208ms
+    - id: 57
+      request:
+          proto: HTTP/1.1
+          proto_major: 1
+          proto_minor: 1
+          content_length: 0
+          transfer_encoding: []
+          trailer: {}
+          host: terraform-provider-auth0-dev.eu.auth0.com
+          remote_addr: ""
+          request_uri: ""
+          body: ""
+          form: {}
+          headers:
+              User-Agent:
+                  - Go-Auth0/1.24.0
+          url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_lkGguil7xCdCWvGr
+          method: DELETE
+      response:
+          proto: HTTP/2.0
+          proto_major: 2
+          proto_minor: 0
+          transfer_encoding: []
+          trailer: {}
+          content_length: 41
+          uncompressed: false
+          body: '{"deleted_at":"2025-07-03T20:14:07.922Z"}'
+          headers:
+              Content-Type:
+                  - application/json; charset=utf-8
+          status: 202 Accepted
+          code: 202
+          duration: 493.543666ms


### PR DESCRIPTION
The present logic did not cater to removal of clients associated with a connection during an Update call. The new logic ensure a diff is taken and both cases: `newly added clients` and `removal of previously existing clients` are taken care of.

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

`auth0_connection_clients` update handling has been changed
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
