### PR TITLE
fix:  make `filters` computed for auth0_log_stream

### DIFF
--- a/internal/auth0/logstream/flatten.go
+++ b/internal/auth0/logstream/flatten.go
@@ -12,9 +12,10 @@ func flattenLogStream(data *schema.ResourceData, logStream *management.LogStream
 		data.Set("status", logStream.GetStatus()),
 		data.Set("is_priority", logStream.GetIsPriority()),
 		data.Set("type", logStream.GetType()),
-		data.Set("filters", logStream.Filters),
+		data.Set("filters", logStream.GetFilters()),
 		data.Set("sink", flattenLogStreamSink(data, logStream.Sink)),
 	)
+
 	return result.ErrorOrNil()
 }
 

--- a/internal/auth0/logstream/resource.go
+++ b/internal/auth0/logstream/resource.go
@@ -69,6 +69,7 @@ func NewResource() *schema.Resource {
 			"filters": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Description: "Only logs events matching these filters will be delivered by the stream." +
 					" If omitted or empty, all events will be delivered. " +
 					"Filters available: `auth.ancillary.fail`, `auth.ancillary.success`, `auth.login.fail`, " +

--- a/internal/auth0/logstream/resource.go
+++ b/internal/auth0/logstream/resource.go
@@ -352,7 +352,9 @@ func createLogStream(ctx context.Context, data *schema.ResourceData, meta interf
 	// we perform an additional operation to modify it.
 	if status := data.Get("status").(string); status != "" && status != logStream.GetStatus() {
 		logStreamWithStatus := &management.LogStream{Status: &status}
-		return diag.FromErr(api.LogStream.Update(ctx, logStream.GetID(), logStreamWithStatus))
+		if err := api.LogStream.Update(ctx, logStream.GetID(), logStreamWithStatus); err != nil {
+			return diag.FromErr(internalError.HandleAPIError(data, err))
+		}
 	}
 
 	return readLogStream(ctx, data, meta)


### PR DESCRIPTION
At times, the API returns a computed value for `filters` on `auth0_log_stream` resource. An example case is when setting the value for `is_priority`.
Hence updated the schema to meet this requirement

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

Closes #1296 
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
