### PR TITLE
Add changelog for v1.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ BUG FIXES:
 
 - `resource/auth0_user` - Add support for passing `custom_domain_header` ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
 - `data_source/auth0_user` - Add support for passing `custom_domain_header` ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
-- Add support for globally configure `custom_domain_header` ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
+- Add support to globally configure `custom_domain_header` ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
 
 ## v1.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 BUG FIXES:
 
-- `resource/auth0_custom_domain` - Add support for passing `custom_domain_header` via resource and global config ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
-- `data_source/auth0_custom_domain` - Add support for passing `custom_domain_header` via resource and global config ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
+- `resource/auth0_user` - Add support for passing `custom_domain_header` ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
+- `data_source/auth0_user` - Add support for passing `custom_domain_header` ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
+- Add support for globally configure `custom_domain_header` ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
 
 ## v1.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.24.1
+
+BUG FIXES:
+
+- `resource/auth0_custom_domain` - Add support for passing `custom_domain_header` via resource and global config ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
+- `data_source/auth0_custom_domain` - Add support for passing `custom_domain_header` via resource and global config ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
+
 ## v1.24.0
 
 ENHANCEMENTS:


### PR DESCRIPTION
BUG FIXES:

- `resource/auth0_user` - Add support for passing `custom_domain_header` ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
- `data_source/auth0_user` - Add support for passing `custom_domain_header` ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
- Add support to globally configure `custom_domain_header` ([#1316](https://github.com/auth0/terraform-provider-auth0/pull/1316))
