### PR TITLE
Add pagination to auth0_connection_client to avoid error on Create

### DIFF
--- a/internal/auth0/connection/resource_client.go
+++ b/internal/auth0/connection/resource_client.go
@@ -81,13 +81,34 @@ func readConnectionClient(ctx context.Context, data *schema.ResourceData, meta i
 	connectionID := data.Get("connection_id").(string)
 	clientID := data.Get("client_id").(string)
 
-	enabledClientsResp, err := api.Connection.ReadEnabledClients(ctx, connectionID)
-	if err != nil {
-		return diag.FromErr(internalError.HandleAPIError(data, err))
+	// Implement pagination using the Next token
+	var allClients []management.ConnectionEnabledClient
+	var next string
+
+	for {
+		var enabledClientsResp *management.ConnectionEnabledClientList
+		var err error
+
+		if next == "" {
+			enabledClientsResp, err = api.Connection.ReadEnabledClients(ctx, connectionID)
+		} else {
+			enabledClientsResp, err = api.Connection.ReadEnabledClients(ctx, connectionID, management.From(next))
+		}
+
+		if err != nil {
+			return diag.FromErr(internalError.HandleAPIError(data, err))
+		}
+
+		allClients = append(allClients, enabledClientsResp.GetClients()...)
+
+		if !enabledClientsResp.HasNext() {
+			break
+		}
+		next = enabledClientsResp.Next
 	}
 
 	found := false
-	for _, c := range enabledClientsResp.GetClients() {
+	for _, c := range allClients {
 		if c.GetClientID() == clientID {
 			found = true
 			break

--- a/internal/auth0/connection/resource_client.go
+++ b/internal/auth0/connection/resource_client.go
@@ -81,7 +81,7 @@ func readConnectionClient(ctx context.Context, data *schema.ResourceData, meta i
 	connectionID := data.Get("connection_id").(string)
 	clientID := data.Get("client_id").(string)
 
-	// Implement pagination using the Next token
+	// Implement pagination using the Next token.
 	var allClients []management.ConnectionEnabledClient
 	var next string
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

This pull request adds pagination via `management.ConnectionEnabledClientList.Next()` to `readConnectionClient` method so that all Clients are returned to read from.

### 📚 References

I believe this fixes #1321, or is at least adjacent.

This was first brought to our attention at Pulumi via https://github.com/pulumi/pulumi-auth0/issues/909, and we thought we'd bring the fix upstream to you.

### 🔬 Testing

Testing is difficult for this one, because it involves API calls. Our free-tier auth0 instance doesn't support creating more than 10 clients, and this is an error that shows up when the number of clients is greater than the default number of clients per page returned by the Auth0 API (which is 50 [per the docs](https://auth0.com/docs/api/management/v2/connections/get-connection-clients)).
I did build this provider with a `management.Take` of `2` and then tested against 5 clients, which caused Apply to fail.

### 📝 Checklist

- [x] N/A All new/changed/fixed functionality is covered by tests (or N/A)
- [x] N/A I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
