### PR TITLE
fix: Retrieve all clients for a connection via Pagination query

### DIFF
--- a/internal/auth0/connection/data_source.go
+++ b/internal/auth0/connection/data_source.go
@@ -135,5 +135,4 @@ func GetAllEnabledClients(ctx context.Context, api *management.Management, conne
 	return &management.ConnectionEnabledClientList{
 		Clients: &allClients,
 	}, nil
-
 }

--- a/internal/auth0/connection/data_source.go
+++ b/internal/auth0/connection/data_source.go
@@ -62,8 +62,7 @@ func readConnectionForDataSource(ctx context.Context, data *schema.ResourceData,
 			return diag.FromErr(err)
 		}
 
-		return flattenConnectionForDataSource(data, connection, &management.ConnectionEnabledClientList{
-			Clients: &existingClients})
+		return flattenConnectionForDataSource(data, connection, existingClients)
 	}
 
 	name := data.Get("name").(string)
@@ -91,8 +90,7 @@ func readConnectionForDataSource(ctx context.Context, data *schema.ResourceData,
 					return diag.FromErr(err)
 				}
 
-				return flattenConnectionForDataSource(data, connection, &management.ConnectionEnabledClientList{
-					Clients: &existingClients})
+				return flattenConnectionForDataSource(data, connection, existingClients)
 			}
 		}
 
@@ -108,7 +106,7 @@ func readConnectionForDataSource(ctx context.Context, data *schema.ResourceData,
 
 // GetAllEnabledClients fetches all enabled clients for a given connectionID
 // and handles pagination internally.
-func GetAllEnabledClients(ctx context.Context, api *management.Management, connectionID string) ([]management.ConnectionEnabledClient, error) {
+func GetAllEnabledClients(ctx context.Context, api *management.Management, connectionID string) (*management.ConnectionEnabledClientList, error) {
 	var allClients []management.ConnectionEnabledClient
 	var next string
 
@@ -134,5 +132,8 @@ func GetAllEnabledClients(ctx context.Context, api *management.Management, conne
 		next = enabledClientsResp.Next
 	}
 
-	return allClients, nil
+	return &management.ConnectionEnabledClientList{
+		Clients: &allClients,
+	}, nil
+
 }

--- a/internal/auth0/connection/resource_client.go
+++ b/internal/auth0/connection/resource_client.go
@@ -87,7 +87,7 @@ func readConnectionClient(ctx context.Context, data *schema.ResourceData, meta i
 	}
 
 	found := false
-	for _, c := range allClients {
+	for _, c := range allClients.GetClients() {
 		if c.GetClientID() == clientID {
 			found = true
 			break

--- a/internal/auth0/connection/resource_client.go
+++ b/internal/auth0/connection/resource_client.go
@@ -81,30 +81,9 @@ func readConnectionClient(ctx context.Context, data *schema.ResourceData, meta i
 	connectionID := data.Get("connection_id").(string)
 	clientID := data.Get("client_id").(string)
 
-	// Implement pagination using the Next token.
-	var allClients []management.ConnectionEnabledClient
-	var next string
-
-	for {
-		var enabledClientsResp *management.ConnectionEnabledClientList
-		var err error
-
-		if next == "" {
-			enabledClientsResp, err = api.Connection.ReadEnabledClients(ctx, connectionID)
-		} else {
-			enabledClientsResp, err = api.Connection.ReadEnabledClients(ctx, connectionID, management.From(next))
-		}
-
-		if err != nil {
-			return diag.FromErr(internalError.HandleAPIError(data, err))
-		}
-
-		allClients = append(allClients, enabledClientsResp.GetClients()...)
-
-		if !enabledClientsResp.HasNext() {
-			break
-		}
-		next = enabledClientsResp.Next
+	allClients, err := GetAllEnabledClients(ctx, api, connectionID)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	found := false

--- a/internal/auth0/connection/resource_clients.go
+++ b/internal/auth0/connection/resource_clients.go
@@ -67,7 +67,7 @@ func createConnectionClients(ctx context.Context, data *schema.ResourceData, met
 	}
 
 	var existingEnabledClientIDs []string
-	for _, c := range existingClients {
+	for _, c := range existingClients.GetClients() {
 		existingEnabledClientIDs = append(existingEnabledClientIDs, c.GetClientID())
 	}
 
@@ -112,9 +112,7 @@ func readConnectionClients(ctx context.Context, data *schema.ResourceData, meta 
 		return diag.FromErr(internalError.HandleAPIError(data, err))
 	}
 
-	return diag.FromErr(flattenConnectionClients(data, connection, &management.ConnectionEnabledClientList{
-		Clients: &allClients,
-	}))
+	return diag.FromErr(flattenConnectionClients(data, connection, allClients))
 }
 
 func updateConnectionClients(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/auth0/connection/resource_clients.go
+++ b/internal/auth0/connection/resource_clients.go
@@ -101,9 +101,9 @@ func readConnectionClients(ctx context.Context, data *schema.ResourceData, meta 
 	api := meta.(*config.Config).GetAPI()
 	connectionID := data.Id()
 
-	enabledClientsResp, err := api.Connection.ReadEnabledClients(ctx, connectionID)
+	allClients, err := GetAllEnabledClients(ctx, api, connectionID)
 	if err != nil {
-		return diag.FromErr(internalError.HandleAPIError(data, err))
+		return diag.FromErr(err)
 	}
 
 	requestOption := management.IncludeFields("strategy", "name")
@@ -112,7 +112,9 @@ func readConnectionClients(ctx context.Context, data *schema.ResourceData, meta 
 		return diag.FromErr(internalError.HandleAPIError(data, err))
 	}
 
-	return diag.FromErr(flattenConnectionClients(data, connection, enabledClientsResp))
+	return diag.FromErr(flattenConnectionClients(data, connection, &management.ConnectionEnabledClientList{
+		Clients: &allClients,
+	}))
 }
 
 func updateConnectionClients(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/auth0/connection/resource_clients.go
+++ b/internal/auth0/connection/resource_clients.go
@@ -61,13 +61,13 @@ func createConnectionClients(ctx context.Context, data *schema.ResourceData, met
 	rawEnabledClients := value.Strings(data.GetRawConfig().GetAttr("enabled_clients"))
 
 	// Fetch existing enabled clients from the new API.
-	existingClientsResp, err := api.Connection.ReadEnabledClients(ctx, connectionID)
+	existingClients, err := GetAllEnabledClients(ctx, api, connectionID)
 	if err != nil {
-		return diag.FromErr(internalError.HandleAPIError(data, err))
+		return diag.FromErr(err)
 	}
 
 	var existingEnabledClientIDs []string
-	for _, c := range existingClientsResp.GetClients() {
+	for _, c := range existingClients {
 		existingEnabledClientIDs = append(existingEnabledClientIDs, c.GetClientID())
 	}
 


### PR DESCRIPTION

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
The present implementation was missing Pagination and hence for higher number of client, it'd only fetch the initial defaults.
Added required updates to the data source.


<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing
Tested with test suite and recordings.
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
