### PR TITLE
Add changelog for v1.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v1.37.0
+
+FEATURES:
+- `resource/auth0_connection_directory` – Add support for creating and managing Directory Provisioning configurations for Google Workspace connections ([#1440](https://github.com/auth0/terraform-provider-auth0/pull/1440))
+- `data-source/auth0_connection_directory` – Add support for retrieving Directory Provisioning configurations by connection ID ([#1440](https://github.com/auth0/terraform-provider-auth0/pull/1440))
+- `data-source/auth0_connection_directory_default_mapping` – Add support for retrieving default Directory Provisioning attribute mappings ([#1440](https://github.com/auth0/terraform-provider-auth0/pull/1440))
+- `resource/auth0_branding_phone_notification_template` – Add support for creating and managing Branding Phone Notification Templates ([#1430](https://github.com/auth0/terraform-provider-auth0/pull/1430))
+- `data-source/auth0_branding_phone_notification_template` – Add support for retrieving Branding Phone Notification Templates ([#1430](https://github.com/auth0/terraform-provider-auth0/pull/1430))
+
+## BUG FIXES:
+- `resource/auth0_connection_scim_token` – Read SCIM token from schema and correctly persist it in state  ([#1425](https://github.com/auth0/terraform-provider-auth0/pull/1425))
+- Remove unnecessary nullable attribute patch during Create ([#1434](https://github.com/auth0/terraform-provider-auth0/pull/1434))
+
 ## v1.36.0
 
 FEATURES:


### PR DESCRIPTION
FEATURES:
- `resource/auth0_connection_directory` – Add support for creating and managing Directory Provisioning configurations for Google Workspace connections ([#1440](https://github.com/auth0/terraform-provider-auth0/pull/1440))
- `data-source/auth0_connection_directory` – Add support for retrieving Directory Provisioning configurations by connection ID ([#1440](https://github.com/auth0/terraform-provider-auth0/pull/1440))
- `data-source/auth0_connection_directory_default_mapping` – Add support for retrieving default Directory Provisioning attribute mappings ([#1440](https://github.com/auth0/terraform-provider-auth0/pull/1440))
- `resource/auth0_branding_phone_notification_template` – Add support for creating and managing Branding Phone Notification Templates ([#1430](https://github.com/auth0/terraform-provider-auth0/pull/1430))
- `data-source/auth0_branding_phone_notification_template` – Add support for retrieving Branding Phone Notification Templates ([#1430](https://github.com/auth0/terraform-provider-auth0/pull/1430))

## BUG FIXES:
- `resource/auth0_connection_scim_token` – Read SCIM token from schema and correctly persist it in state  ([#1425](https://github.com/auth0/terraform-provider-auth0/pull/1425))
- Remove unnecessary nullable attribute patch during Create ([#1434](https://github.com/auth0/terraform-provider-auth0/pull/1434))
