### PR TITLE
chore: Updated list of allowed regions for auth0_log_stream

### DIFF
--- a/internal/auth0/logstream/resource.go
+++ b/internal/auth0/logstream/resource.go
@@ -114,6 +114,7 @@ func NewResource() *schema.Resource {
 								"cn-north-1",
 								"cn-northwest-1",
 								"eu-central-1",
+								"eu-central-2",
 								"eu-north-1",
 								"eu-west-1",
 								"eu-west-2",


### PR DESCRIPTION
`eu-central-2` is a valid region which was missing from list of support regions for `sink.0.aws_region` in auth0_log_stream resource. Added the same

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

Closes #1439 

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
