### PR TITLE
Fix: Allow setting `organization_discovery_methods` as null

### DIFF
--- a/internal/auth0/client/expand.go
+++ b/internal/auth0/client/expand.go
@@ -1090,7 +1090,7 @@ func fetchNullableFields(data *schema.ResourceData, client *management.Client) m
 		},
 		"token_quota": commons.IsTokenQuotaNull,
 		"skip_non_verifiable_callback_uri_confirmation_prompt": isSkipNonVerifiableCallbackURIConfirmationPromptNull,
-		"organization_discovery_methods": isOrganizationDiscoveryMethodsNull,
+		"organization_discovery_methods":                       isOrganizationDiscoveryMethodsNull,
 	}
 
 	nullableMap := make(map[string]interface{})
@@ -1198,27 +1198,14 @@ func isSkipNonVerifiableCallbackURIConfirmationPromptNull(data *schema.ResourceD
 	if !data.IsNewResource() && !data.HasChange("skip_non_verifiable_callback_uri_confirmation_prompt") {
 		return false
 	}
-
-	rawConfig := data.GetRawConfig()
-	if rawConfig.IsNull() {
-		return true
-	}
-
-	return rawConfig.GetAttr("skip_non_verifiable_callback_uri_confirmation_prompt").IsNull()
+	return data.GetRawConfig().IsNull() || data.GetRawConfig().GetAttr("skip_non_verifiable_callback_uri_confirmation_prompt").IsNull()
 }
 
 func isOrganizationDiscoveryMethodsNull(data *schema.ResourceData) bool {
 	if !data.IsNewResource() && !data.HasChange("organization_discovery_methods") {
 		return false
 	}
-
-	rawConfig := data.GetRawConfig()
-	if rawConfig.IsNull() {
-		return true
-	}
-
-	attr := rawConfig.GetAttr("organization_discovery_methods")
-	return attr.IsNull()
+	return data.GetRawConfig().IsNull() || data.GetRawConfig().GetAttr("organization_discovery_methods").IsNull()
 }
 
 func expandExpressConfiguration(data *schema.ResourceData) *management.ExpressConfiguration {


### PR DESCRIPTION
### 🔧 Changes
`auth0_client`: Allow setting `organization_discovery_methods` as `null` since that is a support value. 

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References
Closes #1416 

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
