### PR TITLE
Add trigger id 'custom-token-exchange'

### DIFF
--- a/docs/resources/trigger_action.md
+++ b/docs/resources/trigger_action.md
@@ -45,7 +45,7 @@ resource "auth0_trigger_action" "post_login_alert_action" {
 ### Required
 
 - `action_id` (String) The ID of the action to bind to the trigger.
-- `trigger` (String) The ID of the trigger to bind with. Available options: `post-login`, `credentials-exchange`, `pre-user-registration`, `post-user-registration`, `post-change-password`, `send-phone-message`, `password-reset-post-challenge`, `custom-email-provider`, `custom-phone-provider`.
+- `trigger` (String) The ID of the trigger to bind with. Available options: `post-login`, `credentials-exchange`, `pre-user-registration`, `post-user-registration`, `post-change-password`, `send-phone-message`, `password-reset-post-challenge`, `custom-email-provider`, `custom-phone-provider`, `custom-token-exchange`.
 
 ### Optional
 

--- a/docs/resources/trigger_actions.md
+++ b/docs/resources/trigger_actions.md
@@ -69,7 +69,7 @@ resource "auth0_trigger_actions" "login_flow" {
 ### Required
 
 - `actions` (Block List, Min: 1) The list of actions bound to this trigger. (see [below for nested schema](#nestedblock--actions))
-- `trigger` (String) The ID of the trigger to bind with. Options include: `post-login`, `credentials-exchange`, `pre-user-registration`, `post-user-registration`, `post-change-password`, `send-phone-message`, `password-reset-post-challenge`, `custom-email-provider`, `custom-phone-provider`.
+- `trigger` (String) The ID of the trigger to bind with. Options include: `post-login`, `credentials-exchange`, `pre-user-registration`, `post-user-registration`, `post-change-password`, `send-phone-message`, `password-reset-post-challenge`, `custom-email-provider`, `custom-phone-provider`, `custom-token-exchange`.
 
 ### Read-Only
 

--- a/internal/auth0/action/resource_trigger_action.go
+++ b/internal/auth0/action/resource_trigger_action.go
@@ -40,8 +40,9 @@ func NewTriggerActionResource() *schema.Resource {
 					"password-reset-post-challenge",
 					"custom-email-provider",
 					"custom-phone-provider",
+					"custom-token-exchange",
 				}, false),
-				Description: "The ID of the trigger to bind with. Available options: `post-login`, `credentials-exchange`, `pre-user-registration`, `post-user-registration`, `post-change-password`, `send-phone-message`, `password-reset-post-challenge`, `custom-email-provider`, `custom-phone-provider`.",
+				Description: "The ID of the trigger to bind with. Available options: `post-login`, `credentials-exchange`, `pre-user-registration`, `post-user-registration`, `post-change-password`, `send-phone-message`, `password-reset-post-challenge`, `custom-email-provider`, `custom-phone-provider`, `custom-token-exchange`.",
 			},
 			"action_id": {
 				Type:        schema.TypeString,

--- a/internal/auth0/action/resource_trigger_actions.go
+++ b/internal/auth0/action/resource_trigger_actions.go
@@ -41,10 +41,11 @@ func NewTriggerActionsResource() *schema.Resource {
 					"password-reset-post-challenge",
 					"custom-email-provider",
 					"custom-phone-provider",
+					"custom-token-exchange",
 				}, false),
 				Description: "The ID of the trigger to bind with. Options include: `post-login`, `credentials-exchange`, " +
 					"`pre-user-registration`, `post-user-registration`, `post-change-password`, `send-phone-message`, " +
-					"`password-reset-post-challenge`, `custom-email-provider`, `custom-phone-provider`.",
+					"`password-reset-post-challenge`, `custom-email-provider`, `custom-phone-provider`, `custom-token-exchange`.",
 			},
 			"actions": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/token_exchange_profile suggests that it should be possible to use triggers of id "custom-token-exchange", but it's not the case. This pull requests adds the missing ID enum.
