### PR TITLE
feat: added debug flag to the TF provider repo to be used with vscode…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,3 @@ override.tf.json
 # Environment
 .env
 .envrc
-
-# Go debug files ignored
-__debug_*

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
@@ -21,8 +22,9 @@ func main() {
 	schema.DescriptionKind = schema.StringMarkdown
 
 	debug := false
-	if v := os.Getenv("TF_PROVIDER_AUTH0_DEBUG"); v == "true" {
-		debug = true
+
+	if debugEnv, err := strconv.ParseBool(os.Getenv("TF_PROVIDER_AUTH0_DEBUG")); err == nil {
+		debug = debugEnv
 	}
 
 	plugin.Serve(&plugin.ServeOpts{


### PR DESCRIPTION
<!-- ❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket. By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md. -->

🔧 Changes
<!-- Describe both what is changing and why this is important. Include: - Types and methods added, deleted, deprecated, or changed - A summary of usage if this is a new feature or a change to a public API -->

This PR introduces the following changes:

Feature Addition: Added a debug flag to the Terraform provider repository to facilitate debugging with vscode launch.json.
Documentation Update: Updated the documentation to reflect the changes and provide clarity on the new debug flag.
These changes are important to ensure consistent behavior in user attribute profile sorting and to improve the developer experience with enhanced debugging capabilities.

### Debugging checklist

I have added the debugging hooks in the [main.go](https://github.com/auth0/terraform-provider-auth0/pull/1505/changes#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R24) and it should be used with 

launch.json

```
{
  "version": "0.2.0",
  "configurations": [
    {
      "name": "Debug main.go",
      "type": "go",
      "request": "launch",
      "mode": "debug",
      "program": "${workspaceFolder}/terraform-provider-auth0/main.go",
      "args": [
        "-debug" 
      ],
      "env": {
        "TF_PROVIDER_AUTH0_DEBUG": "true"
      },
      "buildFlags": ""
    }
  ]
}
```

Copy the TF_ATTACH_PROVIDER generated after the debug server starts, update the rettach env variable from 
`TF_REATTACH_PROVIDERS='{"provider":{"Protocol":"grpc","ProtocolVersion":5,"Pid":34101,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/__/jrmdx0sj0dncqly1l80bscww0000gn/T/plugin559730453"}}}'` to
`TF_REATTACH_PROVIDERS='{"registry.terraform.io/auth0/auth0":{"Protocol":"grpc","ProtocolVersion":5,"Pid":92130,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/__/jrmdx0sj0dncqly1l80bscww0000gn/T/plugin33786402"}}}'`

Replace `provider` with `registry.terraform.io/auth0/auth0`

📚 References
<!-- Add relevant links supporting this change, such as: - GitHub issue/PR number addressed or fixed - Auth0 Community post - StackOverflow answer - Related pull requests/issues from other repositories If there are no references, simply delete this section. -->


Related to ticket: ANEW-9742
GitHub issue: N/Aa

🔬 Testing
<!-- Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests. -->

Tested the debug flag functionality with vscode launch.json to ensure it works as expected.
Ensured that the updated documentation is accurate and complete.

📝 Checklist
 All new/changed/fixed functionality is covered by tests (or N/A)
 I have added documentation for all new/changed functionality (or N/A)
<!-- ❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed. -->