### PR TITLE
Deprecate phone MFA configuration in auth0_guardian if PhoneConsolidatedExperience is enabled

### DIFF
--- a/docs/resources/guardian.md
+++ b/docs/resources/guardian.md
@@ -77,7 +77,7 @@ resource "auth0_guardian" "my_guardian" {
 - `duo` (Block List, Max: 1) Configuration settings for the Duo MFA. If this block is present, Duo MFA will be enabled, and disabled otherwise. (see [below for nested schema](#nestedblock--duo))
 - `email` (Boolean) Indicates whether email MFA is enabled.
 - `otp` (Boolean) Indicates whether one time password MFA is enabled.
-- `phone` (Block List, Max: 1) Configuration settings for the phone MFA. If this block is present, Phone MFA will be enabled, and disabled otherwise. (see [below for nested schema](#nestedblock--phone))
+- `phone` (Block List, Max: 1, Deprecated) Configuration settings for the phone MFA. If this block is present, Phone MFA will be enabled, and disabled otherwise. (see [below for nested schema](#nestedblock--phone))
 - `push` (Block List, Max: 1) Configuration settings for the Push MFA. If this block is present, Push MFA will be enabled, and disabled otherwise. (see [below for nested schema](#nestedblock--push))
 - `recovery_code` (Boolean) Indicates whether recovery code MFA is enabled.
 - `webauthn_platform` (Block List, Max: 1) Configuration settings for the WebAuthn with FIDO Device Biometrics MFA. If this block is present, WebAuthn with FIDO Device Biometrics MFA will be enabled, and disabled otherwise. (see [below for nested schema](#nestedblock--webauthn_platform))

--- a/internal/auth0/guardian/resource.go
+++ b/internal/auth0/guardian/resource.go
@@ -123,6 +123,8 @@ func NewResource() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				MaxItems: 1,
+				Deprecated: "If `phone_consolidated_experience` is enabled on the tenant, " +
+					"use the `auth0_phone_provider` resource instead.",
 				Description: "Configuration settings for the phone MFA. If this block is present, " +
 					"Phone MFA will be enabled, and disabled otherwise.",
 				Elem: &schema.Resource{
@@ -430,6 +432,11 @@ func readGuardian(ctx context.Context, data *schema.ResourceData, meta interface
 		return diag.FromErr(err)
 	}
 
+	phoneConsolidated, err := isPhoneConsolidatedExperience(ctx, api)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	for _, factor := range multiFactorList {
 		switch factor.GetName() {
 		case "email":
@@ -439,6 +446,12 @@ func readGuardian(ctx context.Context, data *schema.ResourceData, meta interface
 		case "recovery-code":
 			result = multierror.Append(result, data.Set("recovery_code", factor.GetEnabled()))
 		case "sms":
+			if phoneConsolidated {
+				// Skip reading phone config via deprecated Guardian APIs.
+				// Phone is now managed by the auth0_phone_provider resource.
+				break
+			}
+
 			phone, err := flattenPhone(ctx, factor.GetEnabled(), api)
 			if err != nil {
 				return diag.FromErr(err)
@@ -503,9 +516,13 @@ func updateGuardian(ctx context.Context, data *schema.ResourceData, meta interfa
 func deleteGuardian(ctx context.Context, _ *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*config.Config).GetAPI()
 
+	phoneConsolidated, err := isPhoneConsolidatedExperience(ctx, api)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	result := multierror.Append(
 		api.Guardian.MultiFactor.UpdatePolicy(ctx, &management.MultiFactorPolicies{}),
-		api.Guardian.MultiFactor.Phone.Enable(ctx, false),
 		api.Guardian.MultiFactor.Email.Enable(ctx, false),
 		api.Guardian.MultiFactor.OTP.Enable(ctx, false),
 		api.Guardian.MultiFactor.RecoveryCode.Enable(ctx, false),
@@ -515,5 +532,21 @@ func deleteGuardian(ctx context.Context, _ *schema.ResourceData, meta interface{
 		api.Guardian.MultiFactor.Push.Enable(ctx, false),
 	)
 
+	if !phoneConsolidated {
+		// Only disable phone via deprecated Guardian API if the tenant
+		// has not migrated. Otherwise phone is managed by auth0_phone_provider.
+		result = multierror.Append(result, api.Guardian.MultiFactor.Phone.Enable(ctx, false))
+	}
+
 	return diag.FromErr(result.ErrorOrNil())
+}
+
+// isPhoneConsolidatedExperience returns true if Unified Phone Experience is enabled for the tenant.
+func isPhoneConsolidatedExperience(ctx context.Context, api *management.Management) (bool, error) {
+	tenant, err := api.Tenant.Read(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	return tenant.GetPhoneConsolidatedExperience(), nil
 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Deprecates the `phone` block in the `auth0_guardian` resource in favor of the `auth0_phone_provider` resource for tenants with Unified Phone Experience (UPE) enabled.

- Marks the `phone` block as deprecated with guidance to use `auth0_phone_provider` instead.
- Skips reading phone configuration via deprecated Guardian APIs when `phone_consolidated_experience` is enabled on the tenant.
- Conditionally disables phone MFA on resource deletion only when the tenant has **not** migrated to UPE, preventing conflicts with the new `auth0_phone_provider` resource.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🔬 Testing

- Verified that tenants with `phone_consolidated_experience` enabled skip deprecated Guardian phone API calls during read and delete.
- Verified that tenants without UPE continue to use the existing phone MFA flow unchanged.
- Confirmed deprecation warning surfaces in `terraform plan` output when the `phone` block is present.

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
