### PR TITLE
fix: Added missing expand for name field in Resource Server

### DIFF
--- a/internal/auth0/resourceserver/expand.go
+++ b/internal/auth0/resourceserver/expand.go
@@ -30,6 +30,8 @@ func expandResourceServer(data *schema.ResourceData) *management.ResourceServer 
 	if !resourceServerIsAuth0ManagementAPI(data.GetRawState()) {
 		if resourceServerIsAuth0MyAccountAPI(data.GetRawState()) {
 			resourceServer.Name = auth0.String(auth0MyAccountAPIName)
+		} else {
+			resourceServer.Name = value.String(cfg.GetAttr("name"))
 		}
 		resourceServer.SigningAlgorithm = value.String(cfg.GetAttr("signing_alg"))
 		resourceServer.SigningSecret = value.String(cfg.GetAttr("signing_secret"))


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes
Changes pertaining to ACR in https://github.com/auth0/terraform-provider-auth0/pull/1545 missed the else notation for setting the `name` field when Resource server is not ManagementAPI or MyAccountAPI.

Added `name` field in expand function.


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
