### PR TITLE
Add status field with enabled/disabled options in event_streams

### DIFF
--- a/docs/data-sources/event_stream.md
+++ b/docs/data-sources/event_stream.md
@@ -31,7 +31,7 @@ data "auth0_event_stream" "test" {
 - `destination_type` (String) The type of event stream destination. Possible values: `eventbridge`, `webhook`, or `action`.
 - `eventbridge_configuration` (List of Object) Configuration for the EventBridge destination. This block is only applicable when `destination_type` is set to `eventbridge`. EventBridge configurations **cannot** be updated after creation. Any change to this block will force the resource to be recreated. (see [below for nested schema](#nestedatt--eventbridge_configuration))
 - `name` (String) The name of the event stream.
-- `status` (String) The current status of the event stream.
+- `status` (String) The current status of the event stream. Can be `enabled` or `disabled`.
 - `subscriptions` (List of String) List of event types this stream is subscribed to.
 - `updated_at` (String) The ISO 8601 timestamp when the stream was last updated.
 - `webhook_configuration` (List of Object) Configuration for the Webhook destination. This block is only applicable when `destination_type` is set to `webhook`. Webhook configurations **can** be updated after creation, including the endpoint and authorization fields. (see [below for nested schema](#nestedatt--webhook_configuration))

--- a/docs/resources/event_stream.md
+++ b/docs/resources/event_stream.md
@@ -26,10 +26,11 @@ resource "auth0_event_stream" "my_event_stream_event_bridge" {
   }
 }
 
-# Creates an event stream of type webhook
+# Creates an event stream of type webhook in a disabled state
 resource "auth0_event_stream" "my_event_stream_webhook" {
   name             = "my-webhook"
   destination_type = "webhook"
+  status           = "disabled"
   subscriptions = [
     "user.created",
     "user.updated"
@@ -102,13 +103,13 @@ resource "auth0_event_stream" "my_event_stream_action" {
 
 - `action_configuration` (Block List, Max: 1) Configuration for the Action destination. This block is only applicable when `destination_type` is set to `action`. Action configurations **cannot** be updated after creation. Any change to this block will force the resource to be recreated. (see [below for nested schema](#nestedblock--action_configuration))
 - `eventbridge_configuration` (Block List, Max: 1) Configuration for the EventBridge destination. This block is only applicable when `destination_type` is set to `eventbridge`. EventBridge configurations **cannot** be updated after creation. Any change to this block will force the resource to be recreated. (see [below for nested schema](#nestedblock--eventbridge_configuration))
+- `status` (String) The current status of the event stream. Can be `enabled` or `disabled`.
 - `webhook_configuration` (Block List, Max: 1) Configuration for the Webhook destination. This block is only applicable when `destination_type` is set to `webhook`. Webhook configurations **can** be updated after creation, including the endpoint and authorization fields. (see [below for nested schema](#nestedblock--webhook_configuration))
 
 ### Read-Only
 
 - `created_at` (String) The ISO 8601 timestamp when the stream was created.
 - `id` (String) The ID of this resource.
-- `status` (String) The current status of the event stream.
 - `updated_at` (String) The ISO 8601 timestamp when the stream was last updated.
 
 <a id="nestedblock--action_configuration"></a>

--- a/examples/resources/auth0_event_stream/resource.tf
+++ b/examples/resources/auth0_event_stream/resource.tf
@@ -13,10 +13,11 @@ resource "auth0_event_stream" "my_event_stream_event_bridge" {
   }
 }
 
-# Creates an event stream of type webhook
+# Creates an event stream of type webhook in a disabled state
 resource "auth0_event_stream" "my_event_stream_webhook" {
   name             = "my-webhook"
   destination_type = "webhook"
+  status           = "disabled"
   subscriptions = [
     "user.created",
     "user.updated"

--- a/internal/auth0/eventstream/expand.go
+++ b/internal/auth0/eventstream/expand.go
@@ -17,6 +17,10 @@ func expandEventStream(data *schema.ResourceData) *management.EventStream {
 		Destination:   expandEventStreamDestination(data),
 	}
 
+	if status := cfg.GetAttr("status"); !status.IsNull() {
+		eventStream.Status = value.String(status)
+	}
+
 	return eventStream
 }
 

--- a/internal/auth0/eventstream/resource.go
+++ b/internal/auth0/eventstream/resource.go
@@ -161,9 +161,11 @@ func NewResource() *schema.Resource {
 				Description: "The name of the event stream.",
 			},
 			"status": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The current status of the event stream.",
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"enabled", "disabled"}, false),
+				Description:  "The current status of the event stream. Can be `enabled` or `disabled`.",
 			},
 			"subscriptions": {
 				Type:        schema.TypeList,

--- a/internal/auth0/eventstream/resource_test.go
+++ b/internal/auth0/eventstream/resource_test.go
@@ -86,6 +86,40 @@ resource "auth0_event_stream" "my_event_stream_webhook" {
 }
 `
 
+const testEventStreamCreateWebhookDisabled = `
+resource "auth0_event_stream" "my_event_stream_webhook" {
+  name              = "{{.testName}}-my-webhook-disabled"
+  destination_type  = "webhook"
+  status            = "disabled"
+  subscriptions     = ["user.created"]
+
+  webhook_configuration {
+    webhook_endpoint = "https://eof28wtn4v4506o.m.pipedream.net"
+    webhook_authorization {
+      method = "bearer"
+      token  = "123456789"
+    }
+  }
+}
+`
+
+const testEventStreamUpdateWebhookToEnabled = `
+resource "auth0_event_stream" "my_event_stream_webhook" {
+  name              = "{{.testName}}-my-webhook-disabled"
+  destination_type  = "webhook"
+  status            = "enabled"
+  subscriptions     = ["user.created"]
+
+  webhook_configuration {
+    webhook_endpoint = "https://eof28wtn4v4506o.m.pipedream.net"
+    webhook_authorization {
+      method = "bearer"
+      token  = "123456789"
+    }
+  }
+}
+`
+
 const actionConfig = `
 resource "auth0_action" "my_action" {
 	name    = "Test Action {{.testName}}"
@@ -195,6 +229,29 @@ func TestAccEventStream(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_webhook", "webhook_configuration.0.webhook_authorization.0.method", "bearer"),
 
 					resource.TestCheckNoResourceAttr("auth0_event_stream.my_event_stream_webhook", "webhook_configuration.0.webhook_authorization.0.token_wo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEventStreamStatus(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseTestName(testEventStreamCreateWebhookDisabled, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_webhook", "name", fmt.Sprintf("%s-my-webhook-disabled", t.Name())),
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_webhook", "destination_type", "webhook"),
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_webhook", "status", "disabled"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testEventStreamUpdateWebhookToEnabled, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_webhook", "name", fmt.Sprintf("%s-my-webhook-disabled", t.Name())),
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_webhook", "destination_type", "webhook"),
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_webhook", "status", "enabled"),
 				),
 			},
 		},

--- a/test/data/recordings/TestAccEventStreamStatus.yaml
+++ b/test/data/recordings/TestAccEventStreamStatus.yaml
@@ -1,0 +1,273 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 300
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"status":"disabled","name":"TestAccEventStreamStatus-my-webhook-disabled","subscriptions":[{"event_type":"user.created"}],"destination":{"type":"webhook","configuration":{"webhook_authorization":{"method":"bearer","token":"123456789"},"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 393
+        uncompressed: false
+        body: '{"id":"est_sQnKrCmhBUamEMn5CCD7Cd","status":"disabled","name":"TestAccEventStreamStatus-my-webhook-disabled","subscriptions":[{"event_type":"user.created"}],"created_at":"2026-05-07T06:39:02.044Z","updated_at":"2026-05-07T06:39:02.044Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"bearer"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 403.043042ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_sQnKrCmhBUamEMn5CCD7Cd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_sQnKrCmhBUamEMn5CCD7Cd","status":"disabled","name":"TestAccEventStreamStatus-my-webhook-disabled","subscriptions":[{"event_type":"user.created"}],"created_at":"2026-05-07T06:39:02.044Z","updated_at":"2026-05-07T06:39:02.044Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"bearer"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 944.770875ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_sQnKrCmhBUamEMn5CCD7Cd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_sQnKrCmhBUamEMn5CCD7Cd","status":"disabled","name":"TestAccEventStreamStatus-my-webhook-disabled","subscriptions":[{"event_type":"user.created"}],"created_at":"2026-05-07T06:39:02.044Z","updated_at":"2026-05-07T06:39:02.044Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"bearer"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 456.825ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_sQnKrCmhBUamEMn5CCD7Cd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_sQnKrCmhBUamEMn5CCD7Cd","status":"disabled","name":"TestAccEventStreamStatus-my-webhook-disabled","subscriptions":[{"event_type":"user.created"}],"created_at":"2026-05-07T06:39:02.044Z","updated_at":"2026-05-07T06:39:02.044Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"bearer"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 418.029666ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 299
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"status":"enabled","name":"TestAccEventStreamStatus-my-webhook-disabled","subscriptions":[{"event_type":"user.created"}],"destination":{"type":"webhook","configuration":{"webhook_authorization":{"method":"bearer","token":"123456789"},"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_sQnKrCmhBUamEMn5CCD7Cd
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_sQnKrCmhBUamEMn5CCD7Cd","status":"enabled","name":"TestAccEventStreamStatus-my-webhook-disabled","subscriptions":[{"event_type":"user.created"}],"created_at":"2026-05-07T06:39:02.044Z","updated_at":"2026-05-07T06:39:05.965Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"bearer"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 475.286041ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_sQnKrCmhBUamEMn5CCD7Cd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_sQnKrCmhBUamEMn5CCD7Cd","status":"enabled","name":"TestAccEventStreamStatus-my-webhook-disabled","subscriptions":[{"event_type":"user.created"}],"created_at":"2026-05-07T06:39:02.044Z","updated_at":"2026-05-07T06:39:05.965Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"bearer"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 505.237916ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_sQnKrCmhBUamEMn5CCD7Cd
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_sQnKrCmhBUamEMn5CCD7Cd","status":"enabled","name":"TestAccEventStreamStatus-my-webhook-disabled","subscriptions":[{"event_type":"user.created"}],"created_at":"2026-05-07T06:39:02.044Z","updated_at":"2026-05-07T06:39:05.965Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"bearer"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 502.706541ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_sQnKrCmhBUamEMn5CCD7Cd
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 422.33525ms


### PR DESCRIPTION
<!--
For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Promotes the `status` field on `auth0_event_stream` from read-only to user-configurable, allowing users to create event streams in a disabled state or toggle between `enabled` and `disabled` via Terraform.

- The `status` schema field is now `Optional + Computed` with validation restricting values to `enabled` or `disabled`
- `expandEventStream()` conditionally includes `status` in API requests when explicitly set in config
- When omitted, the API defaults it to `enabled`, fully backward compatible

**Usage:**

```hcl
resource "auth0_event_stream" "example" {
  name             = "my-webhook"
  destination_type = "webhook"
  status           = "disabled" # editable param: `enabled` or `disabled`
  subscriptions    = ["user.created"]

  webhook_configuration {
    webhook_endpoint = "https://example.com/webhook"
    webhook_authorization {
      method = "bearer"
      token  = "my-token"
    }
  }
}
```

### References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- Closes #1563
- API: https://auth0.com/docs/api/management/v2/event-streams/post-event-streams

### Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Added `TestAccEventStreamStatus` acceptance test covering:
  - Create with `status = "disabled"` — verifies stream is created in disabled state
  - Update to `status = "enabled"` — verifies status toggle works
- Existing `TestAccEventStream` and `TestAccEventStreamAction` tests continue to pass (no status specified, defaults to enabled)
- Test recording included at `test/data/recordings/TestAccEventStreamStatus.yaml`

**Run tests:**

```bash
TF_ACC=1 go test ./internal/auth0/eventstream/ -run TestAccEventStreamStatus -v
```

### Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
