### PR TITLE
fix(client_credentials): prevent unnecessary ForceNew for private_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,28 @@
-## v1.46.0 (Unreleased)
+## v1.47.0 (Unreleased)
 
 ENHANCEMENTS:
 - `resource/auth0_client_credentials` – `private_key_jwt` credentials now use an unordered set instead of an ordered list, preventing unnecessary resource recreation when removing or reordering credentials. Adding, removing, or rotating individual credentials no longer destroys the entire resource — only the affected credential is created/deleted. Updating `expires_at` on an existing credential is now handled via in-place PATCH (when `parse_expiry_from_cert` is not enabled). ([#XXXX](https://github.com/auth0/terraform-provider-auth0/pull/XXXX))
 
 NOTES:
 - `resource/auth0_client_credentials` – State schema upgraded from v0 to v1 for `private_key_jwt` credentials (TypeList → TypeSet). Existing state will be migrated automatically on the next `terraform plan` or `terraform apply`.
+
+## v1.46.0
+
+FEATURES:
+
+- `resource/auth0_event_stream` – Add support for configuring `status` field with `enabled`/`disabled` options ([#1568](https://github.com/auth0/terraform-provider-auth0/pull/1568))
+- `resource/auth0_client` – Add support for configuring `third_party_security_mode` and `redirection_policy` ([#1555](https://github.com/auth0/terraform-provider-auth0/pull/1555))
+- `resource/auth0_client_grant` – Add support for configuring `default_for` to specify default grants for third-party clients ([#1555](https://github.com/auth0/terraform-provider-auth0/pull/1555))
+- `resource/auth0_tenant` – Add support for configuring `dynamic_client_registration_security_mode` ([#1555](https://github.com/auth0/terraform-provider-auth0/pull/1555))
+- `resource/auth0_connection` – Add write support for `token_endpoint_jwtca_aud_format` for OIDC and Okta connections ([#1557](https://github.com/auth0/terraform-provider-auth0/pull/1557))
+- `resource/auth0_connection_directory` – Add support for configuring `synchronize_groups` for Inbound Groups Directory Provisioning in Google Workspaces (EA Only) ([#1561](https://github.com/auth0/terraform-provider-auth0/pull/1561))
+- `resource/auth0_connection_directory_synchronized_groups` – Add support for managing synchronized Google Workspace group IDs via directory provisioning (EA Only) ([#1561](https://github.com/auth0/terraform-provider-auth0/pull/1561))
+- `data-source/auth0_connection_directory_synchronized_groups` – Add support for retrieving synchronized group IDs for a connection's directory provisioning (EA Only) ([#1561](https://github.com/auth0/terraform-provider-auth0/pull/1561))
+- `resource/auth0_connection` – Add support for configuring `api_enable_groups` for Google Workspace connections (EA Only) ([#1561](https://github.com/auth0/terraform-provider-auth0/pull/1561))
+
+BUG FIXES:
+- `resource/auth0_resource_server` – Fix missing expand for `name` field ([#1566](https://github.com/auth0/terraform-provider-auth0/pull/1566))
+- `resource/auth0_tenant` – Fix default values for `ephemeral_session_lifetime`, `idle_ephemeral_session_lifetime`, `enable_pipeline2`, and `disable_management_api_sms_obfuscation` to align with API docs ([#1569](https://github.com/auth0/terraform-provider-auth0/pull/1569))
 
 ## v1.45.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.46.0 (Unreleased)
+
+ENHANCEMENTS:
+- `resource/auth0_client_credentials` – `private_key_jwt` credentials now use an unordered set instead of an ordered list, preventing unnecessary resource recreation when removing or reordering credentials. Adding, removing, or rotating individual credentials no longer destroys the entire resource — only the affected credential is created/deleted. Updating `expires_at` on an existing credential is now handled via in-place PATCH (when `parse_expiry_from_cert` is not enabled). ([#XXXX](https://github.com/auth0/terraform-provider-auth0/pull/XXXX))
+
+NOTES:
+- `resource/auth0_client_credentials` – State schema upgraded from v0 to v1 for `private_key_jwt` credentials (TypeList → TypeSet). Existing state will be migrated automatically on the next `terraform plan` or `terraform apply`.
+
 ## v1.45.0
 
 FEATURES:

--- a/docs/resources/client_credentials.md
+++ b/docs/resources/client_credentials.md
@@ -152,7 +152,7 @@ resource "auth0_client_credentials" "test" {
 
 Required:
 
-- `credentials` (Block List, Min: 1, Max: 2) Client credentials available for use when Private Key JWT is in use as the client authentication method. A maximum of 2 client credentials can be set. (see [below for nested schema](#nestedblock--private_key_jwt--credentials))
+- `credentials` (Block Set, Min: 1, Max: 2) Client credentials available for use when Private Key JWT is in use as the client authentication method. A maximum of 2 client credentials can be set. (see [below for nested schema](#nestedblock--private_key_jwt--credentials))
 
 <a id="nestedblock--private_key_jwt--credentials"></a>
 ### Nested Schema for `private_key_jwt.credentials`

--- a/internal/auth0/client/flatten.go
+++ b/internal/auth0/client/flatten.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const timeRFC3339WithMilliseconds = "2006-01-02T15:04:05.000Z07:00"
+
 func flattenCustomSocialConfiguration(customSocial *management.ClientNativeSocialLogin) []interface{} {
 	if customSocial == nil {
 		return nil
@@ -885,8 +887,6 @@ func flattenCredentials(
 		return nil, nil
 	}
 
-	const timeRFC3339WithMilliseconds = "2006-01-02T15:04:05.000Z07:00"
-
 	stateCredentials := make([]interface{}, 0)
 	for index, cred := range credentials {
 		credential, err := api.Client.GetCredential(ctx, data.Id(), cred.GetID())
@@ -909,8 +909,21 @@ func flattenCredentials(
 			stateCredential["algorithm"] = credential.GetAlgorithm()
 			stateCredential["key_id"] = credential.GetKeyID()
 
-			if isResource {
-				// These ones don't get read back, so we have to get them from the state.
+			if isResource && attribute == "private_key_jwt" {
+				statePEM, parseExpiry := findCredentialInState(data, attribute, credential.GetID())
+				if statePEM == "" {
+					statePEM, parseExpiry = findCredentialInStateByName(data, attribute, credential.GetName())
+				}
+				// Detect external key rotation: if the PEM in state no longer
+				// matches the API-returned key_id, clear it so Terraform sees drift.
+				if statePEM != "" && credential.GetKeyID() != "" {
+					if jwkThumbprint(statePEM) != credential.GetKeyID() {
+						statePEM = ""
+					}
+				}
+				stateCredential["pem"] = statePEM
+				stateCredential["parse_expiry_from_cert"] = parseExpiry
+			} else if isResource {
 				stateCredential["pem"] = data.Get(
 					fmt.Sprintf("%s.0.credentials.%d.pem", attribute, index),
 				)
@@ -922,14 +935,12 @@ func flattenCredentials(
 			stateCredential["subject_dn"] = credential.GetSubjectDN()
 
 			if isResource {
-				// This one doesn't get read back, so we have to get it from the state.
 				stateCredential["pem"] = data.Get(
 					fmt.Sprintf("%s.0.credentials.%d.pem", attribute, index),
 				)
 			}
 		case "x509_cert":
 			if isResource {
-				// This one doesn't get read back, so we have to get it from the state.
 				stateCredential["pem"] = data.Get(
 					fmt.Sprintf("%s.0.credentials.%d.pem", attribute, index),
 				)
@@ -940,6 +951,65 @@ func flattenCredentials(
 	}
 
 	return stateCredentials, nil
+}
+
+// findCredentialInState looks up a credential's PEM and parse_expiry_from_cert
+// from the current state by matching on credential ID. This avoids positional
+// index issues when credentials is a TypeSet.
+func findCredentialInState(data *schema.ResourceData, attribute string, credentialID string) (string, bool) {
+	credentialsRaw := data.Get(fmt.Sprintf("%s.0.credentials", attribute))
+	if credentialsRaw == nil {
+		return "", false
+	}
+
+	credSet, ok := credentialsRaw.(*schema.Set)
+	if !ok {
+		return "", false
+	}
+
+	for _, item := range credSet.List() {
+		credMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if id, _ := credMap["id"].(string); id == credentialID {
+			pem, _ := credMap["pem"].(string)
+			parseExpiry, _ := credMap["parse_expiry_from_cert"].(bool)
+			return pem, parseExpiry
+		}
+	}
+
+	return "", false
+}
+
+// findCredentialInStateByName searches all credentials in the planned state by
+// name. Used as a fallback for newly created credentials whose IDs aren't in
+// state yet but whose name matches the API response.
+func findCredentialInStateByName(data *schema.ResourceData, attribute string, name string) (string, bool) {
+	credentialsRaw := data.Get(fmt.Sprintf("%s.0.credentials", attribute))
+	if credentialsRaw == nil {
+		return "", false
+	}
+
+	credSet, ok := credentialsRaw.(*schema.Set)
+	if !ok {
+		return "", false
+	}
+
+	for _, item := range credSet.List() {
+		credMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		n, _ := credMap["name"].(string)
+		if n == name {
+			pem, _ := credMap["pem"].(string)
+			parseExpiry, _ := credMap["parse_expiry_from_cert"].(bool)
+			return pem, parseExpiry
+		}
+	}
+
+	return "", false
 }
 
 func flattenClientList(data *schema.ResourceData, clients []*management.Client) error {

--- a/internal/auth0/client/resource_credentials.go
+++ b/internal/auth0/client/resource_credentials.go
@@ -2,407 +2,28 @@ package client
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"time"
 
-	"encoding/json"
-
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalError "github.com/auth0/terraform-provider-auth0/internal/error"
 	"github.com/auth0/terraform-provider-auth0/internal/value"
 )
-
-// NewCredentialsResource will return a new auth0_client_credentials resource.
-func NewCredentialsResource() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"client_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "The ID of the client for which to configure the authentication method.",
-			},
-			"authentication_method": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"none",
-					"client_secret_post",
-					"client_secret_basic",
-					"private_key_jwt",
-					"tls_client_auth",
-					"self_signed_tls_client_auth",
-				}, false),
-				Description: "Configure the method to use when making requests to " +
-					"any endpoint that requires this client to authenticate. " +
-					"Options include `none` (public client without a client secret), " +
-					"`client_secret_post` (confidential client using HTTP POST parameters), " +
-					"`client_secret_basic` (confidential client using HTTP Basic), " +
-					"`private_key_jwt` (confidential client using a Private Key JWT), " +
-					"`tls_client_auth` (confidential client using CA-based mTLS authentication), " +
-					"`self_signed_tls_client_auth` (confidential client using mTLS authentication utilizing a self-signed certificate).",
-			},
-			"client_secret": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Computed:  true,
-				Sensitive: true,
-				ConflictsWith: []string{
-					"private_key_jwt",
-					"tls_client_auth",
-					"self_signed_tls_client_auth",
-				},
-				Description: "Secret for the client when using `client_secret_post` or `client_secret_basic` " +
-					"authentication method. Keep this private. To access this attribute you need to add either " +
-					"`read:client_keys` or `read:client_credentials` scope to the Terraform client. Otherwise, the attribute will contain an " +
-					"empty string. The attribute will also be an empty string in case `private_key_jwt` is selected " +
-					"as an authentication method.",
-			},
-			"private_key_jwt": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				ConflictsWith: []string{
-					"client_secret",
-					"tls_client_auth",
-					"self_signed_tls_client_auth",
-				},
-				Description: "Defines `private_key_jwt` client authentication method.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"credentials": {
-							Type:     schema.TypeList,
-							MaxItems: 2,
-							Required: true,
-							Description: "Client credentials available for use when Private Key JWT is in use as " +
-								"the client authentication method. A maximum of 2 client credentials can be set.",
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"id": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ID of the client credential.",
-									},
-									"name": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										ForceNew:    true,
-										Description: "Friendly name for a credential.",
-									},
-									"key_id": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The key identifier of the credential, generated on creation.",
-									},
-									"credential_type": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringInSlice([]string{"public_key"}, false),
-										Description:  "Credential type. Supported types: `public_key`.",
-									},
-									"pem": {
-										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
-										Description: "PEM-formatted public key (SPKI and PKCS1) or X509 certificate. " +
-											"Must be JSON escaped.",
-									},
-									"algorithm": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringInSlice([]string{"RS256", "RS384", "PS256"}, false),
-										Default:      "RS256",
-										Description: "Algorithm which will be used with the credential. " +
-											"Can be one of `RS256`, `RS384`, `PS256`. If not specified, " +
-											"`RS256` will be used.",
-									},
-									"parse_expiry_from_cert": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										ForceNew: true,
-										Description: "Parse expiry from x509 certificate. " +
-											"If true, attempts to parse the expiry date from the provided PEM. " +
-											"If also the `expires_at` is set the credential expiry will be set to " +
-											"the explicit `expires_at` value.",
-									},
-									"created_at": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ISO 8601 formatted date the credential was created.",
-									},
-									"updated_at": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ISO 8601 formatted date the credential was updated.",
-									},
-									"expires_at": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										Computed:     true,
-										ValidateFunc: validation.IsRFC3339Time,
-										Description: "The ISO 8601 formatted date representing " +
-											"the expiration of the credential. It is not possible to set this to " +
-											"never expire after it has been set. Recreate the certificate if needed.",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			"tls_client_auth": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				ConflictsWith: []string{
-					"client_secret",
-					"private_key_jwt",
-					"self_signed_tls_client_auth",
-				},
-				Description: "Defines `tls_client_auth` client authentication method.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"credentials": {
-							Type:        schema.TypeList,
-							Required:    true,
-							Description: "Credentials that will be enabled on the client for CA-based mTLS authentication.",
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"id": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ID of the client credential.",
-									},
-									"name": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										Description: "Friendly name for a credential.",
-									},
-									"credential_type": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringInSlice([]string{"cert_subject_dn"}, false),
-										Description:  "Credential type. Supported types: `cert_subject_dn`.",
-									},
-									"subject_dn": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										Computed:     true,
-										ValidateFunc: validation.StringLenBetween(1, 256),
-										Description:  "Subject Distinguished Name. Mutually exlusive with `pem` property.",
-									},
-									"pem": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(1, 4096),
-										Description: "PEM-formatted X509 certificate. Must be JSON escaped. " +
-											"Mutually exlusive with `subject_dn` property.",
-									},
-									"created_at": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ISO 8601 formatted date the credential was created.",
-									},
-									"updated_at": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ISO 8601 formatted date the credential was updated.",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			"self_signed_tls_client_auth": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				ConflictsWith: []string{
-					"client_secret",
-					"private_key_jwt",
-					"tls_client_auth",
-				},
-				Description: "Defines `tls_client_auth` client authentication method.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"credentials": {
-							Type:     schema.TypeList,
-							Required: true,
-							Description: "Credentials that will be enabled on the client for mTLS " +
-								"authentication utilizing self-signed certificates.",
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"id": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ID of the client credential.",
-									},
-									"name": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										Description: "Friendly name for a credential.",
-									},
-									"credential_type": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringInSlice([]string{"x509_cert"}, false),
-										Description:  "Credential type. Supported types: `x509_cert`.",
-									},
-									"pem": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringLenBetween(1, 4096),
-										Description:  "PEM-formatted X509 certificate. Must be JSON escaped. ",
-									},
-									"thumbprint_sha256": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The X509 certificate's SHA256 thumbprint.",
-									},
-									"created_at": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ISO 8601 formatted date the credential was created.",
-									},
-									"updated_at": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ISO 8601 formatted date the credential was updated.",
-									},
-									"expires_at": {
-										Type:     schema.TypeString,
-										Computed: true,
-										Description: "The ISO 8601 formatted date representing " +
-											"the expiration of the credential.",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			"signed_request_object": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: "Configuration for JWT-secured Authorization Requests(JAR).",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"required": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Computed:    true,
-							Description: "Require JWT-secured authorization requests.",
-						},
-						"credentials": {
-							Type:        schema.TypeList,
-							Required:    true,
-							Description: "Client credentials for use with JWT-secured authorization requests.",
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"id": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ID of the client credential.",
-									},
-									"name": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										ForceNew:    true,
-										Description: "Friendly name for a credential.",
-									},
-									"key_id": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The key identifier of the credential, generated on creation.",
-									},
-									"credential_type": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringInSlice([]string{"public_key"}, false),
-										Description:  "Credential type. Supported types: `public_key`.",
-									},
-									"pem": {
-										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
-										Description: "PEM-formatted public key (SPKI and PKCS1) or X509 certificate. " +
-											"Must be JSON escaped.",
-									},
-									"algorithm": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringInSlice([]string{"RS256", "RS384", "PS256"}, false),
-										Default:      "RS256",
-										Description: "Algorithm which will be used with the credential. " +
-											"Can be one of `RS256`, `RS384`, `PS256`. If not specified, " +
-											"`RS256` will be used.",
-									},
-									"parse_expiry_from_cert": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										ForceNew: true,
-										Description: "Parse expiry from x509 certificate. " +
-											"If true, attempts to parse the expiry date from the provided PEM. " +
-											"If also the `expires_at` is set the credential expiry will be set to " +
-											"the explicit `expires_at` value.",
-									},
-									"created_at": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ISO 8601 formatted date the credential was created.",
-									},
-									"updated_at": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The ISO 8601 formatted date the credential was updated.",
-									},
-									"expires_at": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										Computed:     true,
-										ValidateFunc: validation.IsRFC3339Time,
-										Description: "The ISO 8601 formatted date representing " +
-											"the expiration of the credential. It is not possible to set this to " +
-											"never expire after it has been set. Recreate the certificate if needed.",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		CreateContext: createClientCredentials,
-		ReadContext:   readClientCredentials,
-		UpdateContext: updateClientCredentials,
-		DeleteContext: deleteClientCredentials,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Description: "With this resource, you can configure the method to use when making requests to any endpoint " +
-			"that requires this client to authenticate.",
-	}
-}
 
 func createClientCredentials(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*config.Config).GetAPI()
@@ -464,6 +85,35 @@ func updateClientCredentials(ctx context.Context, data *schema.ResourceData, met
 	// Check that client exists.
 	if _, err := api.Client.Read(ctx, data.Id(), management.IncludeFields("client_id")); err != nil {
 		return diag.FromErr(internalError.HandleAPIError(data, err))
+	}
+
+	// When switching away from a credential-based auth method, detach and
+	// delete existing credentials before changing the auth method.
+	if data.HasChange("authentication_method") {
+		oldVal, _ := data.GetChange("authentication_method")
+		oldMethod, _ := oldVal.(string)
+		newMethod := data.Get("authentication_method").(string)
+
+		isOldCredentialBased := oldMethod == "private_key_jwt" || oldMethod == "tls_client_auth" || oldMethod == "self_signed_tls_client_auth"
+		isNewCredentialBased := newMethod == "private_key_jwt" || newMethod == "tls_client_auth" || newMethod == "self_signed_tls_client_auth"
+
+		if isOldCredentialBased && !isNewCredentialBased {
+			clientID := data.Get("client_id").(string)
+			credentials, err := api.Client.ListCredentials(ctx, clientID)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			if len(credentials) > 0 {
+				if err := detachClientCredentials(ctx, api, clientID, newMethod); err != nil {
+					return diag.FromErr(err)
+				}
+				for _, cred := range credentials {
+					if err := api.Client.DeleteCredential(ctx, clientID, cred.GetID()); err != nil {
+						return diag.FromErr(err)
+					}
+				}
+			}
+		}
 	}
 
 	authenticationMethod := data.Get("authentication_method").(string)
@@ -566,6 +216,185 @@ func createAuthenticationMethodCredentials(ctx context.Context, api *management.
 }
 
 func modifyAuthenticationMethodCredentials(ctx context.Context, api *management.Management, data *schema.ResourceData, authenticationMethod string) diag.Diagnostics {
+	if authenticationMethod == "private_key_jwt" {
+		return modifyPrivateKeyJWTCredentials(ctx, api, data)
+	}
+
+	return modifyListBasedCredentials(ctx, api, data, authenticationMethod)
+}
+
+type expiryUpdate struct {
+	credentialID string
+	expiresAt    string
+}
+
+type credentialDiff struct {
+	toAdd         []interface{}
+	toRemove      []interface{}
+	expiryUpdates []expiryUpdate
+}
+
+func classifyCredentialChanges(toAdd, toRemove []interface{}) credentialDiff {
+	var expiryUpdates []expiryUpdate
+	remainingAdd := make([]interface{}, 0, len(toAdd))
+	remainingRemove := make([]interface{}, 0, len(toRemove))
+
+	usedRemoveIndexes := make(map[int]bool)
+	for _, addedCred := range toAdd {
+		addMap := addedCred.(map[string]interface{})
+		addPEM, _ := addMap["pem"].(string)
+		addAlgo, _ := addMap["algorithm"].(string)
+		addExpiry, _ := addMap["expires_at"].(string)
+
+		matched := false
+		for i, removedCred := range toRemove {
+			if usedRemoveIndexes[i] {
+				continue
+			}
+			rmMap := removedCred.(map[string]interface{})
+			rmPEM, _ := rmMap["pem"].(string)
+			rmAlgo, _ := rmMap["algorithm"].(string)
+			rmID, _ := rmMap["id"].(string)
+			rmKeyID, _ := rmMap["key_id"].(string)
+
+			if rmID == "" {
+				continue
+			}
+
+			var pemMatch bool
+			if rmPEM == addPEM {
+				pemMatch = true
+			} else if rmPEM == "" && rmKeyID != "" && addPEM != "" {
+				pemMatch = jwkThumbprint(addPEM) == rmKeyID
+			}
+
+			if pemMatch && rmAlgo == addAlgo {
+				rmParseExpiry, _ := rmMap["parse_expiry_from_cert"].(bool)
+				if rmParseExpiry && rmPEM != "" {
+					continue
+				}
+
+				rmExpiry, _ := rmMap["expires_at"].(string)
+				if addExpiry != "" && addExpiry != rmExpiry && !rmParseExpiry {
+					expiryUpdates = append(expiryUpdates, expiryUpdate{
+						credentialID: rmID,
+						expiresAt:    addExpiry,
+					})
+				}
+
+				usedRemoveIndexes[i] = true
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			remainingAdd = append(remainingAdd, addedCred)
+		}
+	}
+	for i, removedCred := range toRemove {
+		if !usedRemoveIndexes[i] {
+			remainingRemove = append(remainingRemove, removedCred)
+		}
+	}
+
+	return credentialDiff{
+		toAdd:         remainingAdd,
+		toRemove:      remainingRemove,
+		expiryUpdates: expiryUpdates,
+	}
+}
+
+func modifyPrivateKeyJWTCredentials(ctx context.Context, api *management.Management, data *schema.ResourceData) diag.Diagnostics {
+	clientID := data.Get("client_id").(string)
+	credentialsKey := "private_key_jwt.0.credentials" //nolint:gosec // This is a Terraform schema key, not a credential.
+
+	toAdd, toRemove := value.Difference(data, credentialsKey)
+	diff := classifyCredentialChanges(toAdd, toRemove)
+
+	var result *multierror.Error
+
+	// Create new credentials first to avoid availability gaps.
+	for _, addedCred := range diff.toAdd {
+		credMap := addedCred.(map[string]interface{})
+		credential := expandClientCredentialFromMap(credMap)
+
+		if err := api.Client.CreateCredential(ctx, clientID, credential); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Collect IDs of credentials being removed so we can exclude them from re-attach.
+	removedIDs := make(map[string]bool)
+	for _, removedCred := range diff.toRemove {
+		credMap := removedCred.(map[string]interface{})
+		credentialID, _ := credMap["id"].(string)
+		if credentialID != "" {
+			removedIDs[credentialID] = true
+		}
+	}
+
+	// Re-attach credentials (excluding removed ones) BEFORE deleting, because
+	// the API rejects deletion of credentials still associated with a client.
+	if len(diff.toAdd) > 0 || len(diff.toRemove) > 0 {
+		existingCredentials, err := api.Client.ListCredentials(ctx, clientID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		allCredentials := make([]management.Credential, 0, len(existingCredentials))
+		for _, cred := range existingCredentials {
+			if !removedIDs[cred.GetID()] {
+				allCredentials = append(allCredentials, management.Credential{ID: cred.ID})
+			}
+		}
+
+		if err := attachAuthenticationMethodCredentials(ctx, api, clientID, "private_key_jwt", allCredentials); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Delete removed credentials (now detached from the client).
+	for _, removedCred := range diff.toRemove {
+		credMap := removedCred.(map[string]interface{})
+		credentialID, _ := credMap["id"].(string)
+		if credentialID == "" {
+			continue
+		}
+
+		err := api.Client.DeleteCredential(ctx, clientID, credentialID)
+		if internalError.IsStatusNotFound(err) {
+			err = nil
+		}
+		result = multierror.Append(result, err)
+	}
+
+	if result.ErrorOrNil() != nil {
+		return diag.FromErr(result.ErrorOrNil())
+	}
+
+	// Apply expires_at PATCH updates for credentials that only changed expiry.
+	for _, update := range diff.expiryUpdates {
+		t, parseErr := time.Parse(time.RFC3339, update.expiresAt)
+		if parseErr != nil {
+			t, parseErr = time.Parse(timeRFC3339WithMilliseconds, update.expiresAt)
+			if parseErr != nil {
+				continue
+			}
+		}
+
+		if err := api.Client.UpdateCredential(ctx, clientID, update.credentialID, &management.Credential{
+			ExpiresAt: &t,
+		}); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	return diag.FromErr(result.ErrorOrNil())
+}
+
+// modifyListBasedCredentials handles update for tls_client_auth and self_signed_tls_client_auth
+// which still use TypeList.
+func modifyListBasedCredentials(ctx context.Context, api *management.Management, data *schema.ResourceData, authenticationMethod string) diag.Diagnostics {
 	credentials, diagnostics := expandAuthenticationMethodCredentials(data.GetRawConfig(), authenticationMethod)
 	if diagnostics.HasError() {
 		return diagnostics
@@ -585,17 +414,46 @@ func modifyAuthenticationMethodCredentials(ctx context.Context, api *management.
 			continue
 		}
 
-		// The error can be ignored, the schema validates the type.
 		expiresAt, _ := time.Parse(time.RFC3339, stateExpiresAt)
 		credential.ExpiresAt = &expiresAt
 
-		// Limitation: Unable to update the credential to never expire. Needs to get deleted and recreated if needed.
 		if err := api.Client.UpdateCredential(ctx, clientID, credentialID, credential); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	return nil
+}
+
+func expandClientCredentialFromMap(m map[string]interface{}) *management.Credential {
+	credentialType, _ := m["credential_type"].(string)
+	credential := &management.Credential{
+		CredentialType: &credentialType,
+	}
+
+	if name, ok := m["name"].(string); ok && name != "" {
+		credential.Name = &name
+	}
+
+	if credentialType == "public_key" {
+		if pem, ok := m["pem"].(string); ok && pem != "" {
+			credential.PEM = &pem
+		}
+		if algo, ok := m["algorithm"].(string); ok && algo != "" {
+			credential.Algorithm = &algo
+		}
+		if parseExpiry, ok := m["parse_expiry_from_cert"].(bool); ok {
+			credential.ParseExpiryFromCert = &parseExpiry
+		}
+		if expiresAt, ok := m["expires_at"].(string); ok && expiresAt != "" {
+			t, err := time.Parse(time.RFC3339, expiresAt)
+			if err == nil {
+				credential.ExpiresAt = &t
+			}
+		}
+	}
+
+	return credential
 }
 
 func createSignedRequestObject(ctx context.Context, api *management.Management, data *schema.ResourceData) diag.Diagnostics {
@@ -910,4 +768,48 @@ func expandClientCredential(rawConfig cty.Value) *management.Credential {
 	}
 
 	return &clientCredential
+}
+
+// jwkThumbprint computes the RFC 7638 JWK thumbprint from a PEM-encoded
+// certificate or public key. Returns empty string if the PEM cannot be parsed
+// or the key type is not RSA.
+func jwkThumbprint(pemData string) string {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return ""
+	}
+
+	var pub *rsa.PublicKey
+
+	switch block.Type {
+	case "CERTIFICATE":
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return ""
+		}
+		var ok bool
+		pub, ok = cert.PublicKey.(*rsa.PublicKey)
+		if !ok {
+			return ""
+		}
+	case "PUBLIC KEY":
+		key, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return ""
+		}
+		var ok bool
+		pub, ok = key.(*rsa.PublicKey)
+		if !ok {
+			return ""
+		}
+	default:
+		return ""
+	}
+
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	canonical := fmt.Sprintf(`{"e":"%s","kty":"RSA","n":"%s"}`, e, n)
+
+	h := sha256.Sum256([]byte(canonical))
+	return base64.RawURLEncoding.EncodeToString(h[:])
 }

--- a/internal/auth0/client/resource_credentials_schema.go
+++ b/internal/auth0/client/resource_credentials_schema.go
@@ -1,0 +1,558 @@
+package client
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func privateKeyJWTCredentialSetHash(v interface{}) int {
+	m := v.(map[string]interface{})
+
+	var buf strings.Builder
+	buf.WriteString(m["credential_type"].(string))
+	buf.WriteString(m["pem"].(string))
+
+	if algo, ok := m["algorithm"].(string); ok && algo != "" {
+		buf.WriteString(algo)
+	} else {
+		buf.WriteString("RS256")
+	}
+
+	if name, ok := m["name"].(string); ok && name != "" {
+		buf.WriteString(name)
+	}
+
+	if expiresAt, ok := m["expires_at"].(string); ok && expiresAt != "" {
+		buf.WriteString(expiresAt)
+	}
+
+	return schema.HashString(buf.String())
+}
+
+// NewCredentialsResource will return a new auth0_client_credentials resource.
+func NewCredentialsResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"client_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the client for which to configure the authentication method.",
+			},
+			"authentication_method": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"none",
+					"client_secret_post",
+					"client_secret_basic",
+					"private_key_jwt",
+					"tls_client_auth",
+					"self_signed_tls_client_auth",
+				}, false),
+				Description: "Configure the method to use when making requests to " +
+					"any endpoint that requires this client to authenticate. " +
+					"Options include `none` (public client without a client secret), " +
+					"`client_secret_post` (confidential client using HTTP POST parameters), " +
+					"`client_secret_basic` (confidential client using HTTP Basic), " +
+					"`private_key_jwt` (confidential client using a Private Key JWT), " +
+					"`tls_client_auth` (confidential client using CA-based mTLS authentication), " +
+					"`self_signed_tls_client_auth` (confidential client using mTLS authentication utilizing a self-signed certificate).",
+			},
+			"client_secret": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
+				ConflictsWith: []string{
+					"private_key_jwt",
+					"tls_client_auth",
+					"self_signed_tls_client_auth",
+				},
+				Description: "Secret for the client when using `client_secret_post` or `client_secret_basic` " +
+					"authentication method. Keep this private. To access this attribute you need to add either " +
+					"`read:client_keys` or `read:client_credentials` scope to the Terraform client. Otherwise, the attribute will contain an " +
+					"empty string. The attribute will also be an empty string in case `private_key_jwt` is selected " +
+					"as an authentication method.",
+			},
+			"private_key_jwt": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				ConflictsWith: []string{
+					"client_secret",
+					"tls_client_auth",
+					"self_signed_tls_client_auth",
+				},
+				Description: "Defines `private_key_jwt` client authentication method.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"credentials": {
+							Type:     schema.TypeSet,
+							Set:      privateKeyJWTCredentialSetHash,
+							MaxItems: 2,
+							Required: true,
+							Description: "Client credentials available for use when Private Key JWT is in use as " +
+								"the client authentication method. A maximum of 2 client credentials can be set.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ID of the client credential.",
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Friendly name for a credential.",
+									},
+									"key_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The key identifier of the credential, generated on creation.",
+									},
+									"credential_type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"public_key"}, false),
+										Description:  "Credential type. Supported types: `public_key`.",
+									},
+									"pem": {
+										Type:     schema.TypeString,
+										Required: true,
+										Description: "PEM-formatted public key (SPKI and PKCS1) or X509 certificate. " +
+											"Must be JSON escaped.",
+									},
+									"algorithm": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"RS256", "RS384", "PS256"}, false),
+										Default:      "RS256",
+										Description: "Algorithm which will be used with the credential. " +
+											"Can be one of `RS256`, `RS384`, `PS256`. If not specified, " +
+											"`RS256` will be used.",
+									},
+									"parse_expiry_from_cert": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Description: "Parse expiry from x509 certificate. " +
+											"If true, attempts to parse the expiry date from the provided PEM. " +
+											"If also the `expires_at` is set the credential expiry will be set to " +
+											"the explicit `expires_at` value.",
+									},
+									"created_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ISO 8601 formatted date the credential was created.",
+									},
+									"updated_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ISO 8601 formatted date the credential was updated.",
+									},
+									"expires_at": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Computed:     true,
+										ValidateFunc: validation.IsRFC3339Time,
+										Description: "The ISO 8601 formatted date representing " +
+											"the expiration of the credential. It is not possible to set this to " +
+											"never expire after it has been set. Recreate the certificate if needed.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"tls_client_auth": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ConflictsWith: []string{
+					"client_secret",
+					"private_key_jwt",
+					"self_signed_tls_client_auth",
+				},
+				Description: "Defines `tls_client_auth` client authentication method.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"credentials": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: "Credentials that will be enabled on the client for CA-based mTLS authentication.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ID of the client credential.",
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Friendly name for a credential.",
+									},
+									"credential_type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice([]string{"cert_subject_dn"}, false),
+										Description:  "Credential type. Supported types: `cert_subject_dn`.",
+									},
+									"subject_dn": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										Computed:     true,
+										ValidateFunc: validation.StringLenBetween(1, 256),
+										Description:  "Subject Distinguished Name. Mutually exlusive with `pem` property.",
+									},
+									"pem": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringLenBetween(1, 4096),
+										Description: "PEM-formatted X509 certificate. Must be JSON escaped. " +
+											"Mutually exlusive with `subject_dn` property.",
+									},
+									"created_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ISO 8601 formatted date the credential was created.",
+									},
+									"updated_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ISO 8601 formatted date the credential was updated.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"self_signed_tls_client_auth": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ConflictsWith: []string{
+					"client_secret",
+					"private_key_jwt",
+					"tls_client_auth",
+				},
+				Description: "Defines `tls_client_auth` client authentication method.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"credentials": {
+							Type:     schema.TypeList,
+							Required: true,
+							Description: "Credentials that will be enabled on the client for mTLS " +
+								"authentication utilizing self-signed certificates.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ID of the client credential.",
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Friendly name for a credential.",
+									},
+									"credential_type": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice([]string{"x509_cert"}, false),
+										Description:  "Credential type. Supported types: `x509_cert`.",
+									},
+									"pem": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringLenBetween(1, 4096),
+										Description:  "PEM-formatted X509 certificate. Must be JSON escaped. ",
+									},
+									"thumbprint_sha256": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The X509 certificate's SHA256 thumbprint.",
+									},
+									"created_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ISO 8601 formatted date the credential was created.",
+									},
+									"updated_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ISO 8601 formatted date the credential was updated.",
+									},
+									"expires_at": {
+										Type:     schema.TypeString,
+										Computed: true,
+										Description: "The ISO 8601 formatted date representing " +
+											"the expiration of the credential.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"signed_request_object": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Configuration for JWT-secured Authorization Requests(JAR).",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"required": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: "Require JWT-secured authorization requests.",
+						},
+						"credentials": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: "Client credentials for use with JWT-secured authorization requests.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ID of the client credential.",
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										ForceNew:    true,
+										Description: "Friendly name for a credential.",
+									},
+									"key_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The key identifier of the credential, generated on creation.",
+									},
+									"credential_type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice([]string{"public_key"}, false),
+										Description:  "Credential type. Supported types: `public_key`.",
+									},
+									"pem": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+										Description: "PEM-formatted public key (SPKI and PKCS1) or X509 certificate. " +
+											"Must be JSON escaped.",
+									},
+									"algorithm": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice([]string{"RS256", "RS384", "PS256"}, false),
+										Default:      "RS256",
+										Description: "Algorithm which will be used with the credential. " +
+											"Can be one of `RS256`, `RS384`, `PS256`. If not specified, " +
+											"`RS256` will be used.",
+									},
+									"parse_expiry_from_cert": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+										Description: "Parse expiry from x509 certificate. " +
+											"If true, attempts to parse the expiry date from the provided PEM. " +
+											"If also the `expires_at` is set the credential expiry will be set to " +
+											"the explicit `expires_at` value.",
+									},
+									"created_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ISO 8601 formatted date the credential was created.",
+									},
+									"updated_at": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The ISO 8601 formatted date the credential was updated.",
+									},
+									"expires_at": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Computed:     true,
+										ValidateFunc: validation.IsRFC3339Time,
+										Description: "The ISO 8601 formatted date representing " +
+											"the expiration of the credential. It is not possible to set this to " +
+											"never expire after it has been set. Recreate the certificate if needed.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		CreateContext: createClientCredentials,
+		ReadContext:   readClientCredentials,
+		UpdateContext: updateClientCredentials,
+		DeleteContext: deleteClientCredentials,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    credentialsResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: upgradeCredentialsResourceStateV0toV1,
+				Version: 0,
+			},
+		},
+		Description: "With this resource, you can configure the method to use when making requests to any endpoint " +
+			"that requires this client to authenticate.",
+	}
+}
+
+// credentialsResourceV0 returns the V0 schema (before TypeList->TypeSet migration).
+func credentialsResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"client_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"authentication_method": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"client_secret": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"private_key_jwt": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"credentials": {
+							Type:     schema.TypeList,
+							MaxItems: 2,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id":                     {Type: schema.TypeString, Computed: true},
+									"name":                   {Type: schema.TypeString, Optional: true},
+									"key_id":                 {Type: schema.TypeString, Computed: true},
+									"credential_type":        {Type: schema.TypeString, Required: true},
+									"pem":                    {Type: schema.TypeString, Required: true},
+									"algorithm":              {Type: schema.TypeString, Optional: true, Default: "RS256"},
+									"parse_expiry_from_cert": {Type: schema.TypeBool, Optional: true},
+									"created_at":             {Type: schema.TypeString, Computed: true},
+									"updated_at":             {Type: schema.TypeString, Computed: true},
+									"expires_at":             {Type: schema.TypeString, Optional: true, Computed: true},
+								},
+							},
+						},
+					},
+				},
+			},
+			"tls_client_auth": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"credentials": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id":              {Type: schema.TypeString, Computed: true},
+									"name":            {Type: schema.TypeString, Optional: true},
+									"credential_type": {Type: schema.TypeString, Optional: true},
+									"pem":             {Type: schema.TypeString, Optional: true},
+									"subject_dn":      {Type: schema.TypeString, Optional: true},
+									"created_at":      {Type: schema.TypeString, Computed: true},
+									"updated_at":      {Type: schema.TypeString, Computed: true},
+									"expires_at":      {Type: schema.TypeString, Optional: true, Computed: true},
+								},
+							},
+						},
+					},
+				},
+			},
+			"self_signed_tls_client_auth": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"credentials": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id":                {Type: schema.TypeString, Computed: true},
+									"name":              {Type: schema.TypeString, Optional: true},
+									"credential_type":   {Type: schema.TypeString, Optional: true},
+									"pem":               {Type: schema.TypeString, Required: true},
+									"thumbprint_sha256": {Type: schema.TypeString, Computed: true},
+									"created_at":        {Type: schema.TypeString, Computed: true},
+									"updated_at":        {Type: schema.TypeString, Computed: true},
+									"expires_at":        {Type: schema.TypeString, Computed: true},
+								},
+							},
+						},
+					},
+				},
+			},
+			"signed_request_object": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"required": {Type: schema.TypeBool, Optional: true},
+						"credentials": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id":                     {Type: schema.TypeString, Computed: true},
+									"name":                   {Type: schema.TypeString, Optional: true},
+									"key_id":                 {Type: schema.TypeString, Computed: true},
+									"credential_type":        {Type: schema.TypeString, Required: true},
+									"pem":                    {Type: schema.TypeString, Required: true},
+									"algorithm":              {Type: schema.TypeString, Optional: true, Default: "RS256"},
+									"parse_expiry_from_cert": {Type: schema.TypeBool, Optional: true},
+									"created_at":             {Type: schema.TypeString, Computed: true},
+									"updated_at":             {Type: schema.TypeString, Computed: true},
+									"expires_at":             {Type: schema.TypeString, Optional: true, Computed: true},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func upgradeCredentialsResourceStateV0toV1(
+	_ context.Context,
+	rawState map[string]interface{},
+	_ interface{},
+) (map[string]interface{}, error) {
+	return rawState, nil
+}

--- a/internal/auth0/client/resource_credentials_test.go
+++ b/internal/auth0/client/resource_credentials_test.go
@@ -144,7 +144,6 @@ resource "auth0_client_credentials" "test" {
 			credential_type        = "public_key"
 			algorithm              = "RS256"
 			parse_expiry_from_cert = true
-			expires_at             = "2050-05-13T09:33:13.000Z" # This takes precedence.
 			pem                    = <<EOF
 %s
 EOF
@@ -154,7 +153,7 @@ EOF
 			credential_type        = "public_key"
 			algorithm              = "RS256"
 			parse_expiry_from_cert = false
-			expires_at             = "2095-05-13T09:33:13.000Z"
+			expires_at             = "2096-05-13T09:33:13.000Z"
 			pem                    = <<EOF
 %s
 EOF
@@ -182,7 +181,7 @@ resource "auth0_client_credentials" "test" {
 			name            = "Testing Credentials 2"
 			credential_type = "public_key"
 			algorithm       = "RS256"
-			expires_at      = "2095-05-13T09:33:13.000Z"
+			expires_at      = "2096-05-13T09:33:13.000Z"
 			pem             = <<EOF
 %s
 EOF
@@ -226,7 +225,7 @@ resource "auth0_client_credentials" "test" {
 			name            = "Testing Credentials 2"
 			credential_type = "public_key"
 			algorithm       = "RS256"
-			expires_at      = "2095-05-13T09:33:13.000Z"
+			expires_at      = "2096-05-13T09:33:13.000Z"
 			pem             = <<EOF
 %s
 EOF
@@ -261,15 +260,13 @@ func TestAccClientAuthenticationMethodsPrivateKeyJWT(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret", ""),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.#", "1"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.name", "Testing Credentials 1"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.credential_type", "public_key"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.algorithm", "RS256"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.parse_expiry_from_cert", "true"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.expires_at", "2033-05-13T09:33:13.000Z"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.pem"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.key_id"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.created_at"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.updated_at"),
+					resource.TestCheckTypeSetElemNestedAttrs("auth0_client_credentials.test", "private_key_jwt.0.credentials.*", map[string]string{
+						"name":                   "Testing Credentials 1",
+						"credential_type":        "public_key",
+						"algorithm":              "RS256",
+						"parse_expiry_from_cert": "true",
+						"expires_at":             "2033-05-13T09:33:13.000Z",
+					}),
 				),
 			},
 			{
@@ -281,24 +278,20 @@ func TestAccClientAuthenticationMethodsPrivateKeyJWT(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret", ""),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.#", "2"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.name", "Testing Credentials 1"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.credential_type", "public_key"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.algorithm", "RS256"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.parse_expiry_from_cert", "true"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.expires_at", "2033-05-13T09:33:13.000Z"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.pem"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.key_id"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.created_at"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.updated_at"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.name", "Testing Credentials 2"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.credential_type", "public_key"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.algorithm", "RS256"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.parse_expiry_from_cert", "false"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.expires_at", "2095-05-13T09:33:13.000Z"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.pem"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.key_id"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.created_at"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.updated_at"),
+					resource.TestCheckTypeSetElemNestedAttrs("auth0_client_credentials.test", "private_key_jwt.0.credentials.*", map[string]string{
+						"name":                   "Testing Credentials 1",
+						"credential_type":        "public_key",
+						"algorithm":              "RS256",
+						"parse_expiry_from_cert": "true",
+						"expires_at":             "2033-05-13T09:33:13.000Z",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("auth0_client_credentials.test", "private_key_jwt.0.credentials.*", map[string]string{
+						"name":                   "Testing Credentials 2",
+						"credential_type":        "public_key",
+						"algorithm":              "RS256",
+						"parse_expiry_from_cert": "false",
+						"expires_at":             "2095-05-13T09:33:13.000Z",
+					}),
 				),
 			},
 			{
@@ -310,28 +303,38 @@ func TestAccClientAuthenticationMethodsPrivateKeyJWT(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret", ""),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.#", "2"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.name", "Testing Credentials 1"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.credential_type", "public_key"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.algorithm", "RS256"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.parse_expiry_from_cert", "true"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.expires_at", "2050-05-13T09:33:13.000Z"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.pem"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.key_id"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.created_at"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.updated_at"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.name", "Testing Credentials 2"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.credential_type", "public_key"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.algorithm", "RS256"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.parse_expiry_from_cert", "false"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.expires_at", "2095-05-13T09:33:13.000Z"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.pem"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.key_id"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.created_at"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.1.updated_at"),
+					resource.TestCheckTypeSetElemNestedAttrs("auth0_client_credentials.test", "private_key_jwt.0.credentials.*", map[string]string{
+						"name":                   "Testing Credentials 1",
+						"credential_type":        "public_key",
+						"algorithm":              "RS256",
+						"parse_expiry_from_cert": "true",
+						"expires_at":             "2033-05-13T09:33:13.000Z",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("auth0_client_credentials.test", "private_key_jwt.0.credentials.*", map[string]string{
+						"name":                   "Testing Credentials 2",
+						"credential_type":        "public_key",
+						"algorithm":              "RS256",
+						"parse_expiry_from_cert": "false",
+						"expires_at":             "2096-05-13T09:33:13.000Z",
+					}),
 				),
 			},
 			{
+				Config:            fmt.Sprintf(acctest.ParseTestName(testAccAddUpdateClientCredentialsPrivateKeyJWTExpiresAt, t.Name()), credsCert1, credsCert2),
+				ResourceName:      "auth0_client_credentials.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"private_key_jwt.0.credentials",
+				},
+			},
+			{
 				Config: fmt.Sprintf(acctest.ParseTestName(testAccRemoveOneClientCredentialPrivateKeyJWT, t.Name()), credsCert2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("auth0_client_credentials.test", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Client Credentials - %s", t.Name())),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "jwt_configuration.0.alg", "RS256"),
@@ -339,15 +342,12 @@ func TestAccClientAuthenticationMethodsPrivateKeyJWT(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret", ""),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.#", "1"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.name", "Testing Credentials 2"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.credential_type", "public_key"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.algorithm", "RS256"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.parse_expiry_from_cert", "false"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.expires_at", "2095-05-13T09:33:13.000Z"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.pem"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.key_id"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.created_at"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.updated_at"),
+					resource.TestCheckTypeSetElemNestedAttrs("auth0_client_credentials.test", "private_key_jwt.0.credentials.*", map[string]string{
+						"name":            "Testing Credentials 2",
+						"credential_type": "public_key",
+						"algorithm":       "RS256",
+						"expires_at":      "2096-05-13T09:33:13.000Z",
+					}),
 				),
 			},
 			{
@@ -371,15 +371,12 @@ func TestAccClientAuthenticationMethodsPrivateKeyJWT(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret", ""),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.#", "1"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.name", "Testing Credentials 2"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.credential_type", "public_key"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.algorithm", "RS256"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.parse_expiry_from_cert", "false"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.expires_at", "2095-05-13T09:33:13.000Z"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.pem"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.key_id"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.created_at"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test", "private_key_jwt.0.credentials.0.updated_at"),
+					resource.TestCheckTypeSetElemNestedAttrs("auth0_client_credentials.test", "private_key_jwt.0.credentials.*", map[string]string{
+						"name":            "Testing Credentials 2",
+						"credential_type": "public_key",
+						"algorithm":       "RS256",
+						"expires_at":      "2096-05-13T09:33:13.000Z",
+					}),
 				),
 			},
 			{
@@ -1368,7 +1365,7 @@ func TestAccClientCredentialsImport(t *testing.T) {
 			{
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("auth0_client_credentials.test_jwt_ca_client", plancheck.ResourceActionDestroyBeforeCreate),
+						plancheck.ExpectResourceAction("auth0_client_credentials.test_jwt_ca_client", plancheck.ResourceActionUpdate),
 					},
 				},
 				Config: fmt.Sprintf(testAccImportClientWithPrivateKeyJWT, credsCert),
@@ -1377,12 +1374,10 @@ func TestAccClientCredentialsImport(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_client_credentials.test_jwt_ca_client", "client_secret", ""),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test_jwt_ca_client", "private_key_jwt.#", "1"),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test_jwt_ca_client", "private_key_jwt.0.credentials.#", "1"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test_jwt_ca_client", "private_key_jwt.0.credentials.0.credential_type", "public_key"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test_jwt_ca_client", "private_key_jwt.0.credentials.0.algorithm", "RS256"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test_jwt_ca_client", "private_key_jwt.0.credentials.0.pem"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test_jwt_ca_client", "private_key_jwt.0.credentials.0.key_id"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test_jwt_ca_client", "private_key_jwt.0.credentials.0.created_at"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.test_jwt_ca_client", "private_key_jwt.0.credentials.0.updated_at"),
+					resource.TestCheckTypeSetElemNestedAttrs("auth0_client_credentials.test_jwt_ca_client", "private_key_jwt.0.credentials.*", map[string]string{
+						"credential_type": "public_key",
+						"algorithm":       "RS256",
+					}),
 				),
 			},
 		},

--- a/internal/auth0/client/resource_test.go
+++ b/internal/auth0/client/resource_test.go
@@ -3168,8 +3168,9 @@ func TestAccClientExpressApp(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - Express App - %s", t.Name())),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "app_type", "express_configuration"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "organization_require_behavior", "post_login_prompt"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.client_creds", "private_key_jwt.0.credentials.0.credential_type", "public_key"),
-					resource.TestCheckResourceAttrSet("auth0_client_credentials.client_creds", "private_key_jwt.0.credentials.0.pem"),
+					resource.TestCheckTypeSetElemNestedAttrs("auth0_client_credentials.client_creds", "private_key_jwt.0.credentials.*", map[string]string{
+						"credential_type": "public_key",
+					}),
 				),
 			},
 		},

--- a/test/data/recordings/TestAccClientAuthenticationMethodsPrivateKeyJWT.yaml
+++ b/test/data/recordings/TestAccClientAuthenticationMethodsPrivateKeyJWT.yaml
@@ -19,7 +19,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
+                - Go-Auth0/1.39.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 653.417583ms
+        duration: 324.632834ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -52,8 +52,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -63,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 447.850625ms
+        duration: 121.888125ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -85,8 +85,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -96,13 +96,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 440.854167ms
+        duration: 123.11625ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -118,8 +118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -129,13 +129,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 426.392833ms
+        duration: 104.165541ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -151,8 +151,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -162,13 +162,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 582.784917ms
+        duration: 105.416625ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -184,8 +184,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -195,13 +195,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 392.42975ms
+        duration: 106.478167ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -217,8 +217,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials?include_totals=true&per_page=50
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -234,7 +234,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 582.744334ms
+        duration: 106.159875ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -253,8 +253,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -264,13 +264,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 477.717125ms
+        duration: 155.605625ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -289,8 +289,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -300,13 +300,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 446.7455ms
+        duration: 138.518208ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -322,8 +322,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -333,13 +333,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 427.454ms
+        duration: 123.758958ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -355,8 +355,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -366,13 +366,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 432.02575ms
+        duration: 121.239875ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -391,8 +391,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials
         method: POST
       response:
         proto: HTTP/2.0
@@ -402,13 +402,13 @@ interactions:
         trailer: {}
         content_length: 284
         uncompressed: false
-        body: '{"id":"cred_cMAava7EwYeqND8shsRS76","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:33.889Z","updated_at":"2025-11-18T17:25:33.889Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 631.334625ms
+        duration: 163.911666ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -424,8 +424,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -435,13 +435,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 398.672791ms
+        duration: 113.523625ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -454,14 +454,14 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_cMAava7EwYeqND8shsRS76"}]}},"token_endpoint_auth_method":null}
+            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}},"token_endpoint_auth_method":null}
         form: {}
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -471,13 +471,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_cMAava7EwYeqND8shsRS76"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 503.311458ms
+        duration: 115.955958ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -493,8 +493,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -504,13 +504,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_cMAava7EwYeqND8shsRS76"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 413.948208ms
+        duration: 94.131167ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -526,8 +526,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_cMAava7EwYeqND8shsRS76
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_gekrTRyhtchHhs399o7bsV
         method: GET
       response:
         proto: HTTP/2.0
@@ -537,13 +537,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_cMAava7EwYeqND8shsRS76","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:33.889Z","updated_at":"2025-11-18T17:25:33.889Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 588.774875ms
+        duration: 100.134958ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -559,8 +559,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -570,13 +570,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_cMAava7EwYeqND8shsRS76"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 431.939375ms
+        duration: 97.814708ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -592,8 +592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -603,13 +603,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_cMAava7EwYeqND8shsRS76"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 388.645ms
+        duration: 95.635458ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -625,8 +625,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_cMAava7EwYeqND8shsRS76
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_gekrTRyhtchHhs399o7bsV
         method: GET
       response:
         proto: HTTP/2.0
@@ -636,13 +636,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_cMAava7EwYeqND8shsRS76","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:33.889Z","updated_at":"2025-11-18T17:25:33.889Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 390.035917ms
+        duration: 101.462583ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -658,8 +658,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -669,13 +669,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_cMAava7EwYeqND8shsRS76"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 423.513292ms
+        duration: 114.380666ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -691,8 +691,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -702,13 +702,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_cMAava7EwYeqND8shsRS76"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 592.858959ms
+        duration: 103.613583ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -724,8 +724,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_cMAava7EwYeqND8shsRS76
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_gekrTRyhtchHhs399o7bsV
         method: GET
       response:
         proto: HTTP/2.0
@@ -735,13 +735,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_cMAava7EwYeqND8shsRS76","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:33.889Z","updated_at":"2025-11-18T17:25:33.889Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 387.897333ms
+        duration: 116.880209ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -757,8 +757,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -768,218 +768,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 485.390541ms
+        duration: 104.423917ms
     - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials?include_totals=true&per_page=50
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"cred_cMAava7EwYeqND8shsRS76","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:33.889Z","updated_at":"2025-11-18T17:25:33.889Z","expires_at":"2033-05-13T09:33:13.000Z"}]'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 392.158625ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 413.541708ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 118
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"client_authentication_methods":null,"signed_request_object":null,"token_endpoint_auth_method":"client_secret_post"}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 428.983583ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_cMAava7EwYeqND8shsRS76
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 447.22975ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id&include_fields=true
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","signing_keys":[{"cert":"[REDACTED]"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 426.423834ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 2065
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"name":"Testing Credentials 1","credential_type":"public_key","pem":"-----BEGIN CERTIFICATE-----\nMIIFWDCCA0ACCQDXqpBo3RUhkzANBgkqhkiG9w0BAQsFADBuMQswCQYDVQQGEwJl\nczEPMA0GA1UECAwGTWFkcmlkMQ8wDQYDVQQHDAZNYWRyaWQxDTALBgNVBAoMBE9r\ndGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxvcGVyIEV4cGVyaWVu\nY2UwHhcNMjMwNTE2MDkzMzEzWhcNMzMwNTEzMDkzMzEzWjBuMQswCQYDVQQGEwJl\nczEPMA0GA1UECAwGTWFkcmlkMQ8wDQYDVQQHDAZNYWRyaWQxDTALBgNVBAoMBE9r\ndGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxvcGVyIEV4cGVyaWVu\nY2UwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCupwRtoZtRk9qRaXD+\nYdtpM9dWo2vaprvNo+7J2YPlOtZB0zx7xykTEI5UMsESRwEATzVvepQzvswYBlca\n9k1nOcMBSmhkJPol9fbntWAbw4jvs/xXCtKCVOuiP2hffaeq1+6Kei8gXJKpytzN\nLPhbqpoNfqb87U4SM4pKFWSkbJSL0inUilrlc4sR9IGWs9jjCK21TpsUcb7GMZem\nv7MlZQfKQSFuTJgTs3aLJAiyF0yfYhCMbE/bFefRsTcZYnAEYfI3pLDAuZm4GjWD\nW0DCm43pO+jSRvEnbikVvFo6GAoTyUStifK44KVwhp4iPRkIrUCEMxK0mCMVJ9KF\ntaKWsFcJ5nQGJxBz6fj766Hl7SwuHvmSezzADF7/5kOAb8TnMfYsRFxak/iE/5s+\nOldEONHWuyVWuNIqEeI1DglscX02uK7jnuhUAyrCR0ayI3Ket+OvbviZIjiNyqfR\nchPuL7QyQl3CrWcTgZCqwjMzW2G9Y63k838mqL0gVhNPrH6QedOdSsnXbsjP+hS5\nPx2PRWqT+Z8otzZpfnD/pmtjoA3D93c1KJ+hFNlyIvD+R7go045l7OR5MKkgkOSO\nCXTqCSiq09XpZUQvwMtW516K5K/zOveai7V5DTmTHhCL5kthRYhA5WDfLWicG0ZP\nzl4p7gmxfmseQH/bHBSU2f+a+QIDAQABMA0GCSqGSIb3DQEBCwUAA4ICAQA7EOsl\nD5WQ+G6T0GhbyTmlC497aULzCdFfkMjlPN2MiVhje0G4u8C5zK6zEkmyWfRkqCIh\n54YLbaZu55MbvwbD64tTWqDMBmmna8HpulFcpi4RM9jGFMqx5/NSHBLqv/BC3UNt\n7c4y4YuLJkB07RljPv07k5sgf9/twF+v7UYVURfutoj0sjOImJMN66YVOTlNoGTS\nTOrDWByqc6eDHSFVU+0urrgos4iF5UN7ovfA8dLBiR7I4S5kVKSKO18UUB4qPIj0\nyMvTImrQXMepVtzaGae1V5BCyx37J12/STcUdE5urtSBjZyaugrTw+C+WHTcS829\nq5jOjmBJgFTIICz8IDTxPZIM+keVyodFOJKRtteT6vWnk8wq9k4U5HRxtdRKc52u\nd3RCO/B+RxbBLzFuKrM402LNe6j6+gek4boPkzfMbEIohJm1ukM4bATfP5gltsGe\n6UvXg7yaM+oW8jBPHK9w5azsqj+SuxqvARchHWRIrYAli5SePbUtmFKC/Lt+pKCK\nqxdawpr8EUrJXvHL3XoNHuGNbVuSm/ep+ge89UAbUEQ90A4w7fuSX5S+pr4nMOTi\nlNZtdWtIC9qcJ2Xmy5gZ+mAh3Wv+96IwQ9MWvtFEXquNNbvJdXVluUPVarNv3T1B\n8GMCiNZ0r6tknDJcnkjmRqiB8o/ExYXRnjHhGQ==\n-----END CERTIFICATE-----\n\n","alg":"RS256","parse_expiry_from_cert":true}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 284
-        uncompressed: false
-        body: '{"id":"cred_nKmqnBnfZX5F4r37pP3pk4","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:44.326Z","updated_at":"2025-11-18T17:25:44.326Z","expires_at":"2033-05-13T09:33:13.000Z"}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 201 Created
-        code: 201
-        duration: 417.552166ms
-    - id: 29
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -997,8 +793,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials
         method: POST
       response:
         proto: HTTP/2.0
@@ -1008,13 +804,214 @@ interactions:
         trailer: {}
         content_length: 284
         uncompressed: false
-        body: '{"id":"cred_racdCppkvqDda9gbWVv9Yz","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:25:44.770Z","updated_at":"2025-11-18T17:25:44.770Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:01.770Z","expires_at":"2095-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 429.143875ms
+        duration: 107.621042ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:01.770Z","expires_at":"2095-05-13T09:33:13.000Z"},{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 107.049542ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id%2Capp_type&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 103.091416ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 180
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}},"token_endpoint_auth_method":null}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 126.608458ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 135.757333ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:01.770Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 99.587125ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_gekrTRyhtchHhs399o7bsV
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 93.986959ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1030,8 +1027,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1041,34 +1038,31 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 421.990916ms
+        duration: 92.586292ms
     - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 180
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}},"token_endpoint_auth_method":null}
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: PATCH
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1077,13 +1071,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 628.358708ms
+        duration: 106.795167ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1099,8 +1093,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1110,13 +1104,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}}}'
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:01.770Z","expires_at":"2095-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 425.230166ms
+        duration: 99.474583ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1132,8 +1126,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_nKmqnBnfZX5F4r37pP3pk4
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_gekrTRyhtchHhs399o7bsV
         method: GET
       response:
         proto: HTTP/2.0
@@ -1143,13 +1137,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_nKmqnBnfZX5F4r37pP3pk4","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:44.326Z","updated_at":"2025-11-18T17:25:44.326Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 379.623667ms
+        duration: 96.283042ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1165,8 +1159,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_racdCppkvqDda9gbWVv9Yz
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1176,13 +1170,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_racdCppkvqDda9gbWVv9Yz","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:25:44.770Z","updated_at":"2025-11-18T17:25:44.770Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 395.819334ms
+        duration: 94.332291ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1198,8 +1192,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1209,13 +1203,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 430.150666ms
+        duration: 97.439958ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1231,8 +1225,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1242,13 +1236,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}}}'
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:01.770Z","expires_at":"2095-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 581.899667ms
+        duration: 93.236792ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1264,8 +1258,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_nKmqnBnfZX5F4r37pP3pk4
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_gekrTRyhtchHhs399o7bsV
         method: GET
       response:
         proto: HTTP/2.0
@@ -1275,13 +1269,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_nKmqnBnfZX5F4r37pP3pk4","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:44.326Z","updated_at":"2025-11-18T17:25:44.326Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 391.012333ms
+        duration: 89.57775ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1297,8 +1291,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_racdCppkvqDda9gbWVv9Yz
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -1308,31 +1302,34 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_racdCppkvqDda9gbWVv9Yz","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:25:44.770Z","updated_at":"2025-11-18T17:25:44.770Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 489.815667ms
+        duration: 91.732625ms
     - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 38
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: |
+            {"expires_at":"2096-05-13T09:33:13Z"}
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: GET
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1341,13 +1338,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}}}'
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:09.870Z","expires_at":"2096-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 425.0875ms
+        duration: 99.204958ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1363,8 +1360,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1374,13 +1371,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 415.278792ms
+        duration: 100.9195ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1396,8 +1393,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_nKmqnBnfZX5F4r37pP3pk4
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1407,13 +1404,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_nKmqnBnfZX5F4r37pP3pk4","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:44.326Z","updated_at":"2025-11-18T17:25:44.326Z","expires_at":"2033-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:09.870Z","expires_at":"2096-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 399.071417ms
+        duration: 160.99975ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1429,8 +1426,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_racdCppkvqDda9gbWVv9Yz
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_gekrTRyhtchHhs399o7bsV
         method: GET
       response:
         proto: HTTP/2.0
@@ -1440,13 +1437,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_racdCppkvqDda9gbWVv9Yz","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:25:44.770Z","updated_at":"2025-11-18T17:25:44.770Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 378.3645ms
+        duration: 92.054541ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1462,8 +1459,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1473,34 +1470,31 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 462.738ms
+        duration: 112.483458ms
     - id: 44
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 38
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            {"expires_at":"2050-05-13T09:33:13Z"}
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_nKmqnBnfZX5F4r37pP3pk4
-        method: PATCH
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1509,13 +1503,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_nKmqnBnfZX5F4r37pP3pk4","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:44.326Z","updated_at":"2025-11-18T17:25:53.706Z","expires_at":"2050-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 611.917375ms
+        duration: 101.50925ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1531,8 +1525,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1542,13 +1536,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}}}'
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:09.870Z","expires_at":"2096-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400.841583ms
+        duration: 111.670166ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1564,8 +1558,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_nKmqnBnfZX5F4r37pP3pk4
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_gekrTRyhtchHhs399o7bsV
         method: GET
       response:
         proto: HTTP/2.0
@@ -1575,13 +1569,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_nKmqnBnfZX5F4r37pP3pk4","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:44.326Z","updated_at":"2025-11-18T17:25:53.706Z","expires_at":"2050-05-13T09:33:13.000Z"}'
+        body: '{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 517.023708ms
+        duration: 88.124ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1597,8 +1591,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_racdCppkvqDda9gbWVv9Yz
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1608,13 +1602,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_racdCppkvqDda9gbWVv9Yz","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:25:44.770Z","updated_at":"2025-11-18T17:25:44.770Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 391.149292ms
+        duration: 109.166666ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1630,8 +1624,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1641,13 +1635,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}}}'
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:09.870Z","expires_at":"2096-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 410.187375ms
+        duration: 86.511625ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1663,8 +1657,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_gekrTRyhtchHhs399o7bsV
         method: GET
       response:
         proto: HTTP/2.0
@@ -1674,13 +1668,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}}}'
+        body: '{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 419.667541ms
+        duration: 93.82075ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1696,8 +1690,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_nKmqnBnfZX5F4r37pP3pk4
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1707,13 +1701,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_nKmqnBnfZX5F4r37pP3pk4","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:44.326Z","updated_at":"2025-11-18T17:25:53.706Z","expires_at":"2050-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 419.717959ms
+        duration: 118.4545ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1729,8 +1723,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_racdCppkvqDda9gbWVv9Yz
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1740,13 +1734,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_racdCppkvqDda9gbWVv9Yz","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:25:44.770Z","updated_at":"2025-11-18T17:25:44.770Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"},{"id":"cred_gekrTRyhtchHhs399o7bsV"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 432.506375ms
+        duration: 104.57275ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1762,8 +1756,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
         method: GET
       response:
         proto: HTTP/2.0
@@ -1773,13 +1767,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}}}'
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:09.870Z","expires_at":"2096-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 444.656166ms
+        duration: 89.503959ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1795,8 +1789,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_gekrTRyhtchHhs399o7bsV
         method: GET
       response:
         proto: HTTP/2.0
@@ -1806,13 +1800,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_nKmqnBnfZX5F4r37pP3pk4"},{"id":"cred_racdCppkvqDda9gbWVv9Yz"}]}}}'
+        body: '{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 589.627875ms
+        duration: 95.925584ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1828,8 +1822,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_nKmqnBnfZX5F4r37pP3pk4
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -1839,13 +1833,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_nKmqnBnfZX5F4r37pP3pk4","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:44.326Z","updated_at":"2025-11-18T17:25:53.706Z","expires_at":"2050-05-13T09:33:13.000Z"}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 620.259709ms
+        duration: 86.770375ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1861,8 +1855,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_racdCppkvqDda9gbWVv9Yz
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -1872,13 +1866,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_racdCppkvqDda9gbWVv9Yz","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:25:44.770Z","updated_at":"2025-11-18T17:25:44.770Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        body: '[{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:09.870Z","expires_at":"2096-05-13T09:33:13.000Z"},{"id":"cred_gekrTRyhtchHhs399o7bsV","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2026-05-08T16:00:56.685Z","updated_at":"2026-05-08T16:00:56.685Z","expires_at":"2033-05-13T09:33:13.000Z"}]'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 402.031791ms
+        duration: 105.106041ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -1894,8 +1888,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -1905,31 +1899,34 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 552.205875ms
+        duration: 88.125042ms
     - id: 57
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 143
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: |
+            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"}]}},"token_endpoint_auth_method":null}
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials?include_totals=true&per_page=50
-        method: GET
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -1938,13 +1935,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '[{"id":"cred_racdCppkvqDda9gbWVv9Yz","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:25:44.770Z","updated_at":"2025-11-18T17:25:44.770Z","expires_at":"2095-05-13T09:33:13.000Z"},{"id":"cred_nKmqnBnfZX5F4r37pP3pk4","credential_type":"public_key","kid":"w0kIFOc-q7KKK-pa2Uj5b_Cl3f0hAgFeseLg8iEmWu0","alg":"RS256","name":"Testing Credentials 1","created_at":"2025-11-18T17:25:44.326Z","updated_at":"2025-11-18T17:25:53.706Z","expires_at":"2050-05-13T09:33:13.000Z"}]'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 680.745ms
+        duration: 129.065959ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -1960,8 +1957,41 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_gekrTRyhtchHhs399o7bsV
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 93.103583ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -1971,49 +2001,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 554.900625ms
-    - id: 59
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 118
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"client_authentication_methods":null,"signed_request_object":null,"token_endpoint_auth_method":"client_secret_post"}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 430.88175ms
+        duration: 103.116375ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2029,24 +2023,24 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_racdCppkvqDda9gbWVv9Yz
-        method: DELETE
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:09.870Z","expires_at":"2096-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 574.500209ms
+        status: 200 OK
+        code: 200
+        duration: 90.31125ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -2062,24 +2056,24 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_nKmqnBnfZX5F4r37pP3pk4
-        method: DELETE
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 204 No Content
-        code: 204
-        duration: 395.518875ms
+        status: 200 OK
+        code: 200
+        duration: 140.190583ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -2095,8 +2089,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -2106,49 +2100,46 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 421.949375ms
+        duration: 106.625583ms
     - id: 63
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 2087
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            {"name":"Testing Credentials 2","credential_type":"public_key","pem":"-----BEGIN CERTIFICATE-----\nMIIFZDCCA0wCCQDNZ2SmDG1sdTANBgkqhkiG9w0BAQsFADB0MQswCQYDVQQGEwJl\nczESMBAGA1UECAwJQmFyY2Vsb25hMRIwEAYDVQQHDAlCYXJjZWxvbmExDTALBgNV\nBAoMBE9rdGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxvcGVyIEV4\ncGVyaWVuY2UwHhcNMjMwNTE2MTEyOTA4WhcNMzMwNTEzMTEyOTA4WjB0MQswCQYD\nVQQGEwJlczESMBAGA1UECAwJQmFyY2Vsb25hMRIwEAYDVQQHDAlCYXJjZWxvbmEx\nDTALBgNVBAoMBE9rdGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxv\ncGVyIEV4cGVyaWVuY2UwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDs\nY0FIvVc7gPj3aCMG5kGzYW0lD6tBnaRBdXxTsagaowKjOHc3BkbjXzavdWe1bxVN\nKtI3Itak2G/FqdL7Oh+EU+dgwnE82vlxH4J0V25Y0Bc5rQmfWlRUPOkPvnnOTx2w\n+aSZgo+3QqK9aVoKvAmuG+xXbYgXRWNDlU3sljtsa+aACSyqLNFwEoFfTIZMryb5\nZv69Jc/vMEDweQbgrCEFzFmCqNGp5gVY3Bo/1BnayusP1j7xRd7NjAGl4X36X4F9\n5ARKlh/YM+MnCfQqnSYROJKndiV/MoFnaRPSSJ8wEX3cGFZzT9O9JfdgU4CMhd4b\nb4la0gpWAjADvIIQURk2P0SEokfHv5BRRk82+6BpsvSHb79RagFT2/CYfEMIrmB7\nBUNrQOO3aJF6ZViPVoP47DvOj50Lg6WSNX/1mCzxg2s4qZpqpKHhjng/xuqpG4HP\nqaNPROFxHnxtrx0vd9FtlY9+itmUxMy3usW2g+psGgNkEYF0xIR0hQKD15iOyeQh\nrnCLXTJd0PW5v6vPhDo3vWQm7jtIENjbbvdkTdyVbLMpn4+LnOGyE3Hzw66GW6ty\njdw9So6jlDGTQACapXd3eFczN3zPinapdnMz5m/21YoYoMjmNvYuCYS2MHrnBZZJ\n9RaJOfFj6E/8VyqWyC31SLTjyDEvwmJPJu3V+ZSy+QIDAQABMA0GCSqGSIb3DQEB\nCwUAA4ICAQAmhys6SSJLclpnq0GwiU2zQCYE/zFtalDTMclXXa8KJK7lsRZXccMu\nzawDjKtZ8H2C+RqF7e9bCGXtTTEpP65Oz9vXiLjCCS/GoC67AOlWNGIhBnQkoY1s\nTlJ+4kuBKXEXbYObyvh/ZgpYXXdNtDJ4VTP5NfdzlVI+aeI7HYvpSN2w4SvKvtWq\nLIQvlDUjwnELZ7gp9AJHUE+xfR9VIZ6ycd2n+k9lWSrzP8zhTrNe7N5++vzVitw3\nvNnJDPD9oa5PKQDJC64YLOHSSTCFLkNSwU3LjV+k8kfhlDW6zDJNx9pLDRf4vRN9\nmmxlWpfg71DHcB6ZUf10hmalLAq8F9acv3k7w0tQYh2M/f2Rfji76Wb2T+tLS0ve\n6wkxgrP1pNRWX1OeWpIJoEZGyFZd5ZrV99djN3N09gfORXWhAyQXzJz6A5Xg3m1f\nru1Dbr41GYY/77B1m6S5HtSTf/KpvW2EnISnL7pz0c4K5A1ZH0DBZhbFL/Fbvghz\nYqOj0xiWNk/RfmEVaYF7mquEMYzAzr8Ma9Ivj73bHV0SgtunOKehUlvjOKf7n+lX\ngpPrAm1Sgm0ao259gYOM7wsNkPDlsTxsnFOFnuJgAyPxWAZF0k8Z/jXWlbudD6b8\nzTeW4JXOP2p9PaUJB3asHy2CoUMkAh7mGOPPJD0y0deabEfo5+dE5A==\n-----END CERTIFICATE-----\n\n","alg":"RS256","expires_at":"2095-05-13T09:33:13Z"}
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials
-        method: POST
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 284
-        uncompressed: false
-        body: '{"id":"cred_4VJQFwH3bfy845mep8mX7U","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:26:05.665Z","updated_at":"2025-11-18T17:26:05.665Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:09.870Z","expires_at":"2096-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 201 Created
-        code: 201
-        duration: 408.997208ms
+        status: 200 OK
+        code: 200
+        duration: 89.639625ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -2164,8 +2155,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -2175,34 +2166,31 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 430.068042ms
+        duration: 97.200458ms
     - id: 65
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 143
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_4VJQFwH3bfy845mep8mX7U"}]}},"token_endpoint_auth_method":null}
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: PATCH
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -2211,13 +2199,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_4VJQFwH3bfy845mep8mX7U"}]}}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_aJicrB6gED5iDP3cZVbtJH"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 463.826166ms
+        duration: 118.4565ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -2233,8 +2221,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
         method: GET
       response:
         proto: HTTP/2.0
@@ -2244,13 +2232,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_4VJQFwH3bfy845mep8mX7U"}]}}}'
+        body: '{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:09.870Z","expires_at":"2096-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 403.20675ms
+        duration: 105.293458ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -2266,8 +2254,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_4VJQFwH3bfy845mep8mX7U
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -2277,13 +2265,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_4VJQFwH3bfy845mep8mX7U","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:26:05.665Z","updated_at":"2025-11-18T17:26:05.665Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 403.115334ms
+        duration: 95.853375ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -2299,8 +2287,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials?include_totals=true&per_page=50
         method: GET
       response:
         proto: HTTP/2.0
@@ -2310,13 +2298,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_4VJQFwH3bfy845mep8mX7U"}]}}}'
+        body: '[{"id":"cred_aJicrB6gED5iDP3cZVbtJH","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:01.770Z","updated_at":"2026-05-08T16:01:09.870Z","expires_at":"2096-05-13T09:33:13.000Z"}]'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 497.308583ms
+        duration: 89.341334ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -2332,8 +2320,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -2343,31 +2331,34 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_4VJQFwH3bfy845mep8mX7U"}]}}}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 414.762875ms
+        duration: 165.374958ms
     - id: 70
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 119
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: |
+            {"client_authentication_methods":null,"signed_request_object":null,"token_endpoint_auth_method":"client_secret_basic"}
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_4VJQFwH3bfy845mep8mX7U
-        method: GET
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -2376,13 +2367,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"cred_4VJQFwH3bfy845mep8mX7U","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:26:05.665Z","updated_at":"2025-11-18T17:26:05.665Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 389.689167ms
+        duration: 119.19725ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -2398,242 +2389,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_4VJQFwH3bfy845mep8mX7U"}]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 476.019875ms
-    - id: 72
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_4VJQFwH3bfy845mep8mX7U"}]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 425.976458ms
-    - id: 73
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_4VJQFwH3bfy845mep8mX7U
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"cred_4VJQFwH3bfy845mep8mX7U","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:26:05.665Z","updated_at":"2025-11-18T17:26:05.665Z","expires_at":"2095-05-13T09:33:13.000Z"}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 388.283917ms
-    - id: 74
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 585.979833ms
-    - id: 75
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials?include_totals=true&per_page=50
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"cred_4VJQFwH3bfy845mep8mX7U","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:26:05.665Z","updated_at":"2025-11-18T17:26:05.665Z","expires_at":"2095-05-13T09:33:13.000Z"}]'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 401.068208ms
-    - id: 76
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 420.888416ms
-    - id: 77
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 118
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"client_authentication_methods":null,"signed_request_object":null,"token_endpoint_auth_method":"client_secret_post"}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 424.689542ms
-    - id: 78
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_4VJQFwH3bfy845mep8mX7U
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_aJicrB6gED5iDP3cZVbtJH
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -2649,41 +2406,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 649.682333ms
-    - id: 79
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id&include_fields=true
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","signing_keys":[{"cert":"[REDACTED]"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 492.644667ms
-    - id: 80
+        duration: 90.481584ms
+    - id: 72
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -2701,8 +2425,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -2712,13 +2436,280 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 613.265583ms
+        duration: 127.529958ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 109.377875ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 100.94725ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 106.160958ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 101.609167ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 99.6135ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 90.825833ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2118
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Testing Credentials 2","credential_type":"public_key","pem":"-----BEGIN CERTIFICATE-----\nMIIFZDCCA0wCCQDNZ2SmDG1sdTANBgkqhkiG9w0BAQsFADB0MQswCQYDVQQGEwJl\nczESMBAGA1UECAwJQmFyY2Vsb25hMRIwEAYDVQQHDAlCYXJjZWxvbmExDTALBgNV\nBAoMBE9rdGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxvcGVyIEV4\ncGVyaWVuY2UwHhcNMjMwNTE2MTEyOTA4WhcNMzMwNTEzMTEyOTA4WjB0MQswCQYD\nVQQGEwJlczESMBAGA1UECAwJQmFyY2Vsb25hMRIwEAYDVQQHDAlCYXJjZWxvbmEx\nDTALBgNVBAoMBE9rdGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxv\ncGVyIEV4cGVyaWVuY2UwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDs\nY0FIvVc7gPj3aCMG5kGzYW0lD6tBnaRBdXxTsagaowKjOHc3BkbjXzavdWe1bxVN\nKtI3Itak2G/FqdL7Oh+EU+dgwnE82vlxH4J0V25Y0Bc5rQmfWlRUPOkPvnnOTx2w\n+aSZgo+3QqK9aVoKvAmuG+xXbYgXRWNDlU3sljtsa+aACSyqLNFwEoFfTIZMryb5\nZv69Jc/vMEDweQbgrCEFzFmCqNGp5gVY3Bo/1BnayusP1j7xRd7NjAGl4X36X4F9\n5ARKlh/YM+MnCfQqnSYROJKndiV/MoFnaRPSSJ8wEX3cGFZzT9O9JfdgU4CMhd4b\nb4la0gpWAjADvIIQURk2P0SEokfHv5BRRk82+6BpsvSHb79RagFT2/CYfEMIrmB7\nBUNrQOO3aJF6ZViPVoP47DvOj50Lg6WSNX/1mCzxg2s4qZpqpKHhjng/xuqpG4HP\nqaNPROFxHnxtrx0vd9FtlY9+itmUxMy3usW2g+psGgNkEYF0xIR0hQKD15iOyeQh\nrnCLXTJd0PW5v6vPhDo3vWQm7jtIENjbbvdkTdyVbLMpn4+LnOGyE3Hzw66GW6ty\njdw9So6jlDGTQACapXd3eFczN3zPinapdnMz5m/21YoYoMjmNvYuCYS2MHrnBZZJ\n9RaJOfFj6E/8VyqWyC31SLTjyDEvwmJPJu3V+ZSy+QIDAQABMA0GCSqGSIb3DQEB\nCwUAA4ICAQAmhys6SSJLclpnq0GwiU2zQCYE/zFtalDTMclXXa8KJK7lsRZXccMu\nzawDjKtZ8H2C+RqF7e9bCGXtTTEpP65Oz9vXiLjCCS/GoC67AOlWNGIhBnQkoY1s\nTlJ+4kuBKXEXbYObyvh/ZgpYXXdNtDJ4VTP5NfdzlVI+aeI7HYvpSN2w4SvKvtWq\nLIQvlDUjwnELZ7gp9AJHUE+xfR9VIZ6ycd2n+k9lWSrzP8zhTrNe7N5++vzVitw3\nvNnJDPD9oa5PKQDJC64YLOHSSTCFLkNSwU3LjV+k8kfhlDW6zDJNx9pLDRf4vRN9\nmmxlWpfg71DHcB6ZUf10hmalLAq8F9acv3k7w0tQYh2M/f2Rfji76Wb2T+tLS0ve\n6wkxgrP1pNRWX1OeWpIJoEZGyFZd5ZrV99djN3N09gfORXWhAyQXzJz6A5Xg3m1f\nru1Dbr41GYY/77B1m6S5HtSTf/KpvW2EnISnL7pz0c4K5A1ZH0DBZhbFL/Fbvghz\nYqOj0xiWNk/RfmEVaYF7mquEMYzAzr8Ma9Ivj73bHV0SgtunOKehUlvjOKf7n+lX\ngpPrAm1Sgm0ao259gYOM7wsNkPDlsTxsnFOFnuJgAyPxWAZF0k8Z/jXWlbudD6b8\nzTeW4JXOP2p9PaUJB3asHy2CoUMkAh7mGOPPJD0y0deabEfo5+dE5A==\n-----END CERTIFICATE-----\n\n","alg":"RS256","parse_expiry_from_cert":false,"expires_at":"2096-05-13T09:33:13Z"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 284
+        uncompressed: false
+        body: '{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:30.199Z","updated_at":"2026-05-08T16:01:30.199Z","expires_at":"2096-05-13T09:33:13.000Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 179.554041ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:30.199Z","updated_at":"2026-05-08T16:01:30.199Z","expires_at":"2096-05-13T09:33:13.000Z"}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 91.209334ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -2734,8 +2725,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -2745,31 +2736,34 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 401.046291ms
+        duration: 90.940417ms
     - id: 82
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 143
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: ""
+        body: |
+            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD"}]}},"token_endpoint_auth_method":null}
         form: {}
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: GET
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -2778,13 +2772,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 402.484667ms
+        duration: 127.10875ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -2800,8 +2794,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -2811,13 +2805,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 443.023625ms
+        duration: 106.797875ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -2833,8 +2827,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_oEaUKmKMmyfRKFWJwVQhQD
         method: GET
       response:
         proto: HTTP/2.0
@@ -2844,13 +2838,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:30.199Z","updated_at":"2026-05-08T16:01:30.199Z","expires_at":"2096-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 385.348833ms
+        duration: 92.237333ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -2866,8 +2860,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -2877,13 +2871,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_basic","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 576.03575ms
+        duration: 121.762166ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -2899,8 +2893,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -2910,13 +2904,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 475.787417ms
+        duration: 104.478167ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -2932,45 +2926,9 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials?include_totals=true&per_page=50
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_oEaUKmKMmyfRKFWJwVQhQD
         method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: 2
-        uncompressed: false
-        body: '[]'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 389.914708ms
-    - id: 88
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 52
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"token_endpoint_auth_method":"client_secret_post"}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -2979,13 +2937,46 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:30.199Z","updated_at":"2026-05-08T16:01:30.199Z","expires_at":"2096-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 443.111875ms
+        duration: 104.632875ms
+    - id: 88
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 93.364708ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -3001,8 +2992,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -3012,49 +3003,46 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD"}]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 574.103916ms
+        duration: 107.991292ms
     - id: 90
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 2087
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            {"name":"Testing Credentials 2","credential_type":"public_key","pem":"-----BEGIN CERTIFICATE-----\nMIIFZDCCA0wCCQDNZ2SmDG1sdTANBgkqhkiG9w0BAQsFADB0MQswCQYDVQQGEwJl\nczESMBAGA1UECAwJQmFyY2Vsb25hMRIwEAYDVQQHDAlCYXJjZWxvbmExDTALBgNV\nBAoMBE9rdGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxvcGVyIEV4\ncGVyaWVuY2UwHhcNMjMwNTE2MTEyOTA4WhcNMzMwNTEzMTEyOTA4WjB0MQswCQYD\nVQQGEwJlczESMBAGA1UECAwJQmFyY2Vsb25hMRIwEAYDVQQHDAlCYXJjZWxvbmEx\nDTALBgNVBAoMBE9rdGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxv\ncGVyIEV4cGVyaWVuY2UwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDs\nY0FIvVc7gPj3aCMG5kGzYW0lD6tBnaRBdXxTsagaowKjOHc3BkbjXzavdWe1bxVN\nKtI3Itak2G/FqdL7Oh+EU+dgwnE82vlxH4J0V25Y0Bc5rQmfWlRUPOkPvnnOTx2w\n+aSZgo+3QqK9aVoKvAmuG+xXbYgXRWNDlU3sljtsa+aACSyqLNFwEoFfTIZMryb5\nZv69Jc/vMEDweQbgrCEFzFmCqNGp5gVY3Bo/1BnayusP1j7xRd7NjAGl4X36X4F9\n5ARKlh/YM+MnCfQqnSYROJKndiV/MoFnaRPSSJ8wEX3cGFZzT9O9JfdgU4CMhd4b\nb4la0gpWAjADvIIQURk2P0SEokfHv5BRRk82+6BpsvSHb79RagFT2/CYfEMIrmB7\nBUNrQOO3aJF6ZViPVoP47DvOj50Lg6WSNX/1mCzxg2s4qZpqpKHhjng/xuqpG4HP\nqaNPROFxHnxtrx0vd9FtlY9+itmUxMy3usW2g+psGgNkEYF0xIR0hQKD15iOyeQh\nrnCLXTJd0PW5v6vPhDo3vWQm7jtIENjbbvdkTdyVbLMpn4+LnOGyE3Hzw66GW6ty\njdw9So6jlDGTQACapXd3eFczN3zPinapdnMz5m/21YoYoMjmNvYuCYS2MHrnBZZJ\n9RaJOfFj6E/8VyqWyC31SLTjyDEvwmJPJu3V+ZSy+QIDAQABMA0GCSqGSIb3DQEB\nCwUAA4ICAQAmhys6SSJLclpnq0GwiU2zQCYE/zFtalDTMclXXa8KJK7lsRZXccMu\nzawDjKtZ8H2C+RqF7e9bCGXtTTEpP65Oz9vXiLjCCS/GoC67AOlWNGIhBnQkoY1s\nTlJ+4kuBKXEXbYObyvh/ZgpYXXdNtDJ4VTP5NfdzlVI+aeI7HYvpSN2w4SvKvtWq\nLIQvlDUjwnELZ7gp9AJHUE+xfR9VIZ6ycd2n+k9lWSrzP8zhTrNe7N5++vzVitw3\nvNnJDPD9oa5PKQDJC64YLOHSSTCFLkNSwU3LjV+k8kfhlDW6zDJNx9pLDRf4vRN9\nmmxlWpfg71DHcB6ZUf10hmalLAq8F9acv3k7w0tQYh2M/f2Rfji76Wb2T+tLS0ve\n6wkxgrP1pNRWX1OeWpIJoEZGyFZd5ZrV99djN3N09gfORXWhAyQXzJz6A5Xg3m1f\nru1Dbr41GYY/77B1m6S5HtSTf/KpvW2EnISnL7pz0c4K5A1ZH0DBZhbFL/Fbvghz\nYqOj0xiWNk/RfmEVaYF7mquEMYzAzr8Ma9Ivj73bHV0SgtunOKehUlvjOKf7n+lX\ngpPrAm1Sgm0ao259gYOM7wsNkPDlsTxsnFOFnuJgAyPxWAZF0k8Z/jXWlbudD6b8\nzTeW4JXOP2p9PaUJB3asHy2CoUMkAh7mGOPPJD0y0deabEfo5+dE5A==\n-----END CERTIFICATE-----\n\n","alg":"RS256","expires_at":"2095-05-13T09:33:13Z"}
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials
-        method: POST
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_oEaUKmKMmyfRKFWJwVQhQD
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         transfer_encoding: []
         trailer: {}
-        content_length: 284
-        uncompressed: false
-        body: '{"id":"cred_vvoryToJoiMD65LbntYqgh","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:26:22.851Z","updated_at":"2025-11-18T17:26:22.851Z","expires_at":"2095-05-13T09:33:13.000Z"}'
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:30.199Z","updated_at":"2026-05-08T16:01:30.199Z","expires_at":"2096-05-13T09:33:13.000Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
-        status: 201 Created
-        code: 201
-        duration: 406.935875ms
+        status: 200 OK
+        code: 200
+        duration: 94.026ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -3070,8 +3058,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -3081,34 +3069,31 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 382.82475ms
+        duration: 128.407833ms
     - id: 92
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 143
+        content_length: 0
         transfer_encoding: []
         trailer: {}
         host: terraform-provider-auth0-dev.eu.auth0.com
         remote_addr: ""
         request_uri: ""
-        body: |
-            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_vvoryToJoiMD65LbntYqgh"}]}},"token_endpoint_auth_method":null}
+        body: ""
         form: {}
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: PATCH
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials?include_totals=true&per_page=50
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
@@ -3117,13 +3102,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_vvoryToJoiMD65LbntYqgh"}]}}}'
+        body: '[{"id":"cred_oEaUKmKMmyfRKFWJwVQhQD","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2026-05-08T16:01:30.199Z","updated_at":"2026-05-08T16:01:30.199Z","expires_at":"2096-05-13T09:33:13.000Z"}]'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 618.114708ms
+        duration: 122.93875ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -3139,8 +3124,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg?fields=client_id%2Capp_type&include_fields=true
         method: GET
       response:
         proto: HTTP/2.0
@@ -3150,344 +3135,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_vvoryToJoiMD65LbntYqgh"}]}}}'
+        body: '{"client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 414.428625ms
+        duration: 105.055708ms
     - id: 94
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_vvoryToJoiMD65LbntYqgh
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"cred_vvoryToJoiMD65LbntYqgh","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:26:22.851Z","updated_at":"2025-11-18T17:26:22.851Z","expires_at":"2095-05-13T09:33:13.000Z"}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 421.017167ms
-    - id: 95
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_vvoryToJoiMD65LbntYqgh"}]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 471.756583ms
-    - id: 96
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_vvoryToJoiMD65LbntYqgh"}]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 824.616875ms
-    - id: 97
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_vvoryToJoiMD65LbntYqgh
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"cred_vvoryToJoiMD65LbntYqgh","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:26:22.851Z","updated_at":"2025-11-18T17:26:22.851Z","expires_at":"2095-05-13T09:33:13.000Z"}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 430.376084ms
-    - id: 98
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_vvoryToJoiMD65LbntYqgh"}]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 431.710125ms
-    - id: 99
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_vvoryToJoiMD65LbntYqgh"}]}}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 596.257667ms
-    - id: 100
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_vvoryToJoiMD65LbntYqgh
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"cred_vvoryToJoiMD65LbntYqgh","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:26:22.851Z","updated_at":"2025-11-18T17:26:22.851Z","expires_at":"2095-05-13T09:33:13.000Z"}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 420.328375ms
-    - id: 101
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 543.982875ms
-    - id: 102
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials?include_totals=true&per_page=50
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '[{"id":"cred_vvoryToJoiMD65LbntYqgh","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Testing Credentials 2","created_at":"2025-11-18T17:26:22.851Z","updated_at":"2025-11-18T17:26:22.851Z","expires_at":"2095-05-13T09:33:13.000Z"}]'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 388.777667ms
-    - id: 103
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ?fields=client_id%2Capp_type&include_fields=true
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 552.62725ms
-    - id: 104
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3505,8 +3160,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -3516,14 +3171,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 666.248875ms
-    - id: 105
+        duration: 117.443584ms
+    - id: 95
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3538,8 +3193,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ/credentials/cred_vvoryToJoiMD65LbntYqgh
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg/credentials/cred_oEaUKmKMmyfRKFWJwVQhQD
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3555,8 +3210,8 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 399.293542ms
-    - id: 106
+        duration: 98.937125ms
+    - id: 96
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3571,8 +3226,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -3582,14 +3237,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 420.970375ms
-    - id: 107
+        duration: 152.795583ms
+    - id: 97
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3604,8 +3259,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -3615,14 +3270,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 391.78325ms
-    - id: 108
+        duration: 108.578208ms
+    - id: 98
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3637,8 +3292,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: GET
       response:
         proto: HTTP/2.0
@@ -3648,14 +3303,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"rviLWyEEkItATM3TfDVPj8GZaCskdjxJ","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientAuthenticationMethodsPrivateKeyJWT","client_id":"3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256","lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 389.778375ms
-    - id: 109
+        duration: 91.533916ms
+    - id: 99
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -3670,8 +3325,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.31.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/rviLWyEEkItATM3TfDVPj8GZaCskdjxJ
+                - Go-Auth0/1.39.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/3hOYB9bXVjrjkq2k3EzrHPVuqaei9sGg
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -3687,4 +3342,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 462.49075ms
+        duration: 118.21475ms


### PR DESCRIPTION
### 🔧 Changes

The `auth0_client_credentials` resource had two bugs when managing `private_key_jwt` credentials that caused unnecessary resource destruction:

1. **Ordering issue**: Credentials used `schema.TypeList` (ordered). Removing a credential at index 0 caused subsequent credentials to shift positions, which Terraform interpreted as PEM changes — triggering `ForceNew` and destroying the entire resource.

2. **Unnecessary ForceNew on `pem`**: Any key rotation destroyed the entire `auth0_client_credentials` resource (deleting ALL credentials) and recreated from scratch, even though only one credential changed.

**What changed:**

- **Schema**: `private_key_jwt.credentials` changed from `TypeList` to `TypeSet` with a custom hash function (`credential_type + pem + algorithm + name + expires_at`). Removed `ForceNew` from `pem`, `name`, `credential_type`, `algorithm`, `parse_expiry_from_cert`. Added state migration v0 → v1.

- **Update logic**: Rewrote `modifyPrivateKeyJWTCredentials` to compute set diff. Individual credentials are created/deleted via API without affecting others. `expires_at` changes use in-place PATCH (when `parse_expiry_from_cert` is not set). Order: Create → Re-attach (excluding removed) → Delete → PATCH.

- **Import support**: After `terraform import`, state has `pem=""` (API doesn't return PEM). Credentials are matched by computing the JWK thumbprint (RFC 7638) from config PEM and comparing to the API-returned `key_id`. A single reconciliation apply writes PEM to state with zero API mutations; subsequent plans are empty.

- **Drift detection**: During refresh, if the state PEM's computed JWK thumbprint doesn't match the API-returned `key_id`, the PEM is cleared — forcing Terraform to detect external key rotation and plan corrective action.

- **JWK thumbprint**: Supports both X.509 certificates (`BEGIN CERTIFICATE`) and raw public keys (`BEGIN PUBLIC KEY`). Also fixes a pre-existing `TestAccClientExpressApp` failure.

**Behavior after upgrade:**
- Existing state is migrated automatically (v0 TypeList → v1 TypeSet) on next plan/apply.
- After import: one `terraform apply` reconciles PEM in state (no API calls). Subsequent plans are empty.

**Scope:** Only `private_key_jwt`. `tls_client_auth` and `self_signed_tls_client_auth` can be migrated in a follow-up.

### 📚 References

N/A

### 🔬 Testing

- `TestAccClientAuthenticationMethodsPrivateKeyJWT` — 13 steps covering: create single credential, add second, PATCH expires_at, import+verify, remove first credential (no ForceNew), switch to client_secret_basic, switch back to private_key_jwt, delete resource.
- `TestAccClientCredentialsImport` — VCR replay passes with existing recording.
- `TestAccClientExpressApp` — fixed pre-existing failure (raw public key PEM now handled in thumbprint computation).
- Full client test suite passes with VCR replay (0 failures).
- Manual testing: `terraform import` → `terraform apply` (TF_LOG=DEBUG confirms zero POST/DELETE/PATCH to `/credentials`) → `terraform plan` shows no changes.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
