### PR TITLE
feat: add support to configure `federated_connections_access_tokens` for OIDC connections

### DIFF
--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -104,6 +104,7 @@ Read-Only:
 - `enabled_database_customization` (Boolean)
 - `entity_id` (String)
 - `fed_metadata_xml` (String)
+- `federated_connections_access_tokens` (List of Object) (see [below for nested schema](#nestedobjatt--options--federated_connections_access_tokens))
 - `fields_map` (String)
 - `forward_request_info` (Boolean)
 - `from` (String)
@@ -401,6 +402,14 @@ Read-Only:
 
 - `cert` (String)
 - `key` (String)
+
+
+<a id="nestedobjatt--options--federated_connections_access_tokens"></a>
+### Nested Schema for `options.federated_connections_access_tokens`
+
+Read-Only:
+
+- `active` (Boolean)
 
 
 <a id="nestedobjatt--options--gateway_authentication"></a>

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -750,6 +750,7 @@ Optional:
 - `enabled_database_customization` (Boolean) Set to `true` to use a legacy user store.
 - `entity_id` (String) Custom Entity ID for the connection.
 - `fed_metadata_xml` (String) Federation Metadata for the ADFS connection.
+- `federated_connections_access_tokens` (Block List, Max: 1) Configuration for collecting access tokens and refresh tokens from federated connections. Only applicable for OIDC connections. (see [below for nested schema](#nestedblock--options--federated_connections_access_tokens))
 - `fields_map` (String) If you're configuring a SAML enterprise connection for a non-standard PingFederate Server, you must update the attribute mappings.
 - `forward_request_info` (Boolean) Specifies whether or not request info should be forwarded to sms gateway.
 - `from` (String) Address to use as the sender.
@@ -1050,6 +1051,14 @@ Required:
 
 - `cert` (String)
 - `key` (String)
+
+
+<a id="nestedblock--options--federated_connections_access_tokens"></a>
+### Nested Schema for `options.federated_connections_access_tokens`
+
+Optional:
+
+- `active` (Boolean) When enabled, Auth0 will collect and store access tokens and refresh tokens obtained from federated connections during authentication.
 
 
 <a id="nestedblock--options--gateway_authentication"></a>

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
+	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
 	github.com/lestrrat-go/jwx/v2 v2.1.6
@@ -54,7 +55,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.25.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect
 	github.com/hashicorp/terraform-plugin-go v0.31.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.10.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/auth0/go-auth0 v1.41.1-0.20260519110822-7c70e5b3615d h1:CCyaJIQxeIetCdyggj7nyDZbBm6UtL59/vynsnYEowU=
-github.com/auth0/go-auth0 v1.41.1-0.20260519110822-7c70e5b3615d/go.mod h1:32sQB1uAn+99fJo6N819EniKq8h785p0ag0lMWhiTaE=
 github.com/auth0/go-auth0 v1.42.0 h1:mJcdCccDpSmUwpEM8qVHvta0uAJ1BzFYl/mmg7tUjOA=
 github.com/auth0/go-auth0 v1.42.0/go.mod h1:32sQB1uAn+99fJo6N819EniKq8h785p0ag0lMWhiTaE=
 github.com/auth0/go-auth0/v2 v2.10.0 h1:fPiIE/QusagbRTBC0mTdmF2rfx7Flt+4ei0gmvTKPTw=

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -1015,6 +1015,14 @@ func expandConnectionOptionsOIDC(data *schema.ResourceData, config cty.Value) (i
 		return true
 	})
 
+	config.GetAttr("federated_connections_access_tokens").ForEachElement(func(_ cty.Value, config cty.Value) (stop bool) {
+		options.FederatedConnectionsAccessTokens = &management.ConnectionOptionsOIDCFederatedConnectionsAccessTokens{
+			Active: value.Bool(config.GetAttr("active")),
+		}
+
+		return true
+	})
+
 	var err error
 	config.GetAttr("attribute_map").ForEachElement(func(_ cty.Value, config cty.Value) (stop bool) {
 		options.AttributeMap = &management.ConnectionOptionsOIDCAttributeMap{

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -884,6 +884,14 @@ func flattenConnectionOptionsOIDC(
 		}
 	}
 
+	if options.FederatedConnectionsAccessTokens != nil {
+		optionsMap["federated_connections_access_tokens"] = []map[string]interface{}{
+			{
+				"active": options.GetFederatedConnectionsAccessTokens().GetActive(),
+			},
+		}
+	}
+
 	return optionsMap, nil
 }
 

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -1011,6 +1011,23 @@ var optionsSchema = &schema.Schema{
 					},
 				},
 			},
+			"federated_connections_access_tokens": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Computed:    true,
+				Description: "Configuration for collecting access tokens and refresh tokens from federated connections. Only applicable for OIDC connections.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"active": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: "When enabled, Auth0 will collect and store access tokens and refresh tokens obtained from federated connections during authentication.",
+						},
+					},
+				},
+			},
 			"attribute_map": {
 				Type:     schema.TypeList,
 				MaxItems: 1,


### PR DESCRIPTION
### 🔧 Changes
Adds support for configuring `federated_connections_access_tokens` for OIDC connections
<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References

```tf
resource "auth0_connection" "oidc" {
    name     = "OIDC-Connection"
    strategy = "oidc"
    options {
        client_id                     = auth0_client.my_client.id
        scopes                        = ["ext_nested_groups","openid"]
        issuer                        = "https://example.com"
        discovery_url                 = "https://www.paypalobjects.com/.well-known/openid-configuration"
        token_endpoint_auth_method    = "private_key_jwt"
        token_endpoint_auth_signing_alg = "RS256"
        federated_connections_access_tokens {
            active = true
        }
    }
}

```

### 🔬 Testing

Manual testing completed. This feature is originally deprecated. Although, `federated_connections_access_tokens` has been added for legacy usage.
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
