### PR TITLE
feat: IPSIE - DPoP for the OIDC and Okta Enterprise connections

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -744,7 +744,7 @@ Optional:
 - `discovery_url` (String) OpenID discovery URL, e.g. `https://auth.example.com/.well-known/openid-configuration`.
 - `domain` (String) Domain name.
 - `domain_aliases` (Set of String) List of the domains that can be authenticated using the identity provider. Only needed for Identifier First authentication flows.
-- `dpop_signing_alg` (String) Signature method used to sign the request. EA Only
+- `dpop_signing_alg` (String) The algorithm used to sign the DPoP proof. Allowed values: ES256, ES384, ES512, Ed25519.
 - `email` (Boolean) Indicates whether to request the email scope. Used by some OAuth2 connections (e.g., LINE).
 - `enable_script_context` (Boolean) Set to `true` to inject context into custom DB scripts (warning: cannot be disabled once enabled).
 - `enabled_database_customization` (Boolean) Set to `true` to use a legacy user store.

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -1153,6 +1153,20 @@ func TestAccConnectionOIDC(t *testing.T) {
 				),
 			},
 			{
+				Config: acctest.ParseTestName(testAccConnectionOIDCConfigUpdateES384, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.type", "back_channel"),
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.dpop_signing_alg", "ES384"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccConnectionOIDCConfigUpdateES512, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.type", "back_channel"),
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.dpop_signing_alg", "ES512"),
+				),
+			},
+			{
 				Config: acctest.ParseTestName(testAccConnectionOIDCConfigUpdateAgain, t.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_connection.oidc", "show_as_button", "false"),
@@ -1268,6 +1282,74 @@ resource "auth0_connection" "oidc" {
 		  	})
 		}
 		dpop_signing_alg = "Ed25519"
+	}
+}
+`
+
+const testAccConnectionOIDCConfigUpdateES384 = `
+resource "auth0_connection" "oidc" {
+	name     = "Acceptance-Test-OIDC-{{.testName}}"
+	display_name     = "Acceptance-Test-OIDC-{{.testName}}"
+	strategy = "oidc"
+	show_as_button = false
+	options {
+		client_id     = "1234567"
+		client_secret = "1234567"
+		domain_aliases = [
+			"example.com"
+		]
+		type                   = "back_channel"
+		issuer                 = "https://www.paypalobjects.com"
+		jwks_uri               = "https://api.paypal.com/v1/oauth2/certs"
+		discovery_url          = "https://www.paypalobjects.com/.well-known/openid-configuration"
+		token_endpoint         = "https://api.paypal.com/v1/oauth2/token"
+		userinfo_endpoint      = "https://api.paypal.com/v1/oauth2/token/userinfo"
+		authorization_endpoint = "https://www.paypal.com/signin/authorize"
+		scopes                 = [ "openid", "email" ]
+		set_user_root_attributes = "on_first_login"
+
+		connection_settings {
+			pkce = "auto"
+		}
+
+		attribute_map {
+			mapping_mode = "bind_all"
+		}
+		dpop_signing_alg = "ES384"
+	}
+}
+`
+
+const testAccConnectionOIDCConfigUpdateES512 = `
+resource "auth0_connection" "oidc" {
+	name     = "Acceptance-Test-OIDC-{{.testName}}"
+	display_name     = "Acceptance-Test-OIDC-{{.testName}}"
+	strategy = "oidc"
+	show_as_button = false
+	options {
+		client_id     = "1234567"
+		client_secret = "1234567"
+		domain_aliases = [
+			"example.com"
+		]
+		type                   = "back_channel"
+		issuer                 = "https://www.paypalobjects.com"
+		jwks_uri               = "https://api.paypal.com/v1/oauth2/certs"
+		discovery_url          = "https://www.paypalobjects.com/.well-known/openid-configuration"
+		token_endpoint         = "https://api.paypal.com/v1/oauth2/token"
+		userinfo_endpoint      = "https://api.paypal.com/v1/oauth2/token/userinfo"
+		authorization_endpoint = "https://www.paypal.com/signin/authorize"
+		scopes                 = [ "openid", "email" ]
+		set_user_root_attributes = "on_first_login"
+
+		connection_settings {
+			pkce = "auto"
+		}
+
+		attribute_map {
+			mapping_mode = "bind_all"
+		}
+		dpop_signing_alg = "ES512"
 	}
 }
 `

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -1,9 +1,14 @@
 package connection
 
 import (
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+var allowedDPoPSigningAlgorithms = []string{"ES256", "ES384", "ES512", "Ed25519"}
+
 
 var resourceSchema = map[string]*schema.Schema{
 	"name": {
@@ -1438,8 +1443,8 @@ var optionsSchema = &schema.Schema{
 			"dpop_signing_alg": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"ES256", "Ed25519"}, false),
-				Description:  "Signature method used to sign the request. EA Only",
+				ValidateFunc: validation.StringInSlice(allowedDPoPSigningAlgorithms, false),
+				Description:  "The algorithm used to sign the DPoP proof. Allowed values: " + strings.Join(allowedDPoPSigningAlgorithms, ", ") + ".",
 			},
 			"password_options": {
 				Type:     schema.TypeList,

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -9,7 +9,6 @@ import (
 
 var allowedDPoPSigningAlgorithms = []string{"ES256", "ES384", "ES512", "Ed25519"}
 
-
 var resourceSchema = map[string]*schema.Schema{
 	"name": {
 		Type:     schema.TypeString,

--- a/test/data/recordings/TestAccConnectionOIDC.yaml
+++ b/test/data/recordings/TestAccConnectionOIDC.yaml
@@ -19,7 +19,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.39.0
+                - Go-Auth0/1.42.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"id":"con_D5Pq4WGGkD40BUwA","options":{"client_id":"123456","client_secret":"123456","domain_aliases":["api.example.com","example.com"],"discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","type":"back_channel","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","scope":"email openid profile","set_user_root_attributes":"on_each_login","non_persistent_attrs":["gender","hair_color"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"connection_settings":{"pkce":"disabled"},"attribute_map":{"mapping_mode":"bind_all"},"token_endpoint_auth_signing_alg":"RS256","id_token_signed_response_algs":["RS256","ES256"],"send_back_channel_nonce":true,"dpop_signing_alg":"ES256","token_endpoint_jwtca_aud_format":"issuer","oidc_metadata":{"issuer":"https://api.login.yahoo.com","authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"subject_types_supported":["public"],"grant_types_supported":["authorization_code","refresh_token"],"id_token_signing_alg_values_supported":["ES256","RS256"],"scopes_supported":["openid","openid2","profile","email"],"acr_values_supported":["AAL1","AAL2"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],"claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"response_modes_supported":["query"],"display_values_supported":["page"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false},"schema_version":"oidc-V4"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":true,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"client_id":"123456","client_secret":"123456","domain_aliases":["api.example.com","example.com"],"discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","type":"back_channel","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","scope":"email openid profile","set_user_root_attributes":"on_each_login","non_persistent_attrs":["gender","hair_color"],"upstream_params":{"screen_name":{"alias":"login_hint"}},"connection_settings":{"pkce":"disabled"},"attribute_map":{"mapping_mode":"bind_all"},"token_endpoint_auth_signing_alg":"RS256","id_token_signed_response_algs":["RS256","ES256"],"send_back_channel_nonce":true,"dpop_signing_alg":"ES256","token_endpoint_jwtca_aud_format":"issuer","oidc_metadata":{"issuer":"https://api.login.yahoo.com","authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"subject_types_supported":["public"],"grant_types_supported":["authorization_code","refresh_token"],"id_token_signing_alg_values_supported":["ES256","RS256"],"scopes_supported":["openid","openid2","profile","email"],"acr_values_supported":["AAL1","AAL2"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],"claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"response_modes_supported":["query"],"display_values_supported":["page"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false},"schema_version":"oidc-V4"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":true,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 564.676583ms
+        duration: 557.867417ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -52,8 +52,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.39.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_D5Pq4WGGkD40BUwA
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
         method: GET
       response:
         proto: HTTP/2.0
@@ -63,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_D5Pq4WGGkD40BUwA","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"domain_aliases":["api.example.com","example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","upstream_params":{"screen_name":{"alias":"login_hint"}},"dpop_signing_alg":"ES256","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"non_persistent_attrs":["gender","hair_color"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","send_back_channel_nonce":true,"set_user_root_attributes":"on_each_login","id_token_signed_response_algs":["RS256","ES256"],"token_endpoint_auth_signing_alg":"RS256","token_endpoint_jwtca_aud_format":"issuer"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":true,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"domain_aliases":["api.example.com","example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","upstream_params":{"screen_name":{"alias":"login_hint"}},"dpop_signing_alg":"ES256","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"non_persistent_attrs":["gender","hair_color"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","send_back_channel_nonce":true,"set_user_root_attributes":"on_each_login","id_token_signed_response_algs":["RS256","ES256"],"token_endpoint_auth_signing_alg":"RS256","token_endpoint_jwtca_aud_format":"issuer"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":true,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 846.4675ms
+        duration: 308.095167ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -85,8 +85,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.39.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_D5Pq4WGGkD40BUwA
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
         method: GET
       response:
         proto: HTTP/2.0
@@ -96,13 +96,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_D5Pq4WGGkD40BUwA","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"domain_aliases":["api.example.com","example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","upstream_params":{"screen_name":{"alias":"login_hint"}},"dpop_signing_alg":"ES256","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"non_persistent_attrs":["gender","hair_color"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","send_back_channel_nonce":true,"set_user_root_attributes":"on_each_login","id_token_signed_response_algs":["RS256","ES256"],"token_endpoint_auth_signing_alg":"RS256","token_endpoint_jwtca_aud_format":"issuer"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":true,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"domain_aliases":["api.example.com","example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","upstream_params":{"screen_name":{"alias":"login_hint"}},"dpop_signing_alg":"ES256","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"non_persistent_attrs":["gender","hair_color"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","send_back_channel_nonce":true,"set_user_root_attributes":"on_each_login","id_token_signed_response_algs":["RS256","ES256"],"token_endpoint_auth_signing_alg":"RS256","token_endpoint_jwtca_aud_format":"issuer"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":true,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.082083ms
+        duration: 322.557125ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -118,8 +118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.39.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_D5Pq4WGGkD40BUwA
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
         method: GET
       response:
         proto: HTTP/2.0
@@ -129,13 +129,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_D5Pq4WGGkD40BUwA","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"domain_aliases":["api.example.com","example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","upstream_params":{"screen_name":{"alias":"login_hint"}},"dpop_signing_alg":"ES256","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"non_persistent_attrs":["gender","hair_color"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","send_back_channel_nonce":true,"set_user_root_attributes":"on_each_login","id_token_signed_response_algs":["RS256","ES256"],"token_endpoint_auth_signing_alg":"RS256","token_endpoint_jwtca_aud_format":"issuer"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":true,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"domain_aliases":["api.example.com","example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","upstream_params":{"screen_name":{"alias":"login_hint"}},"dpop_signing_alg":"ES256","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"non_persistent_attrs":["gender","hair_color"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","send_back_channel_nonce":true,"set_user_root_attributes":"on_each_login","id_token_signed_response_algs":["RS256","ES256"],"token_endpoint_auth_signing_alg":"RS256","token_endpoint_jwtca_aud_format":"issuer"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":true,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.672667ms
+        duration: 334.008084ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -154,8 +154,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.39.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_D5Pq4WGGkD40BUwA
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -165,13 +165,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_D5Pq4WGGkD40BUwA","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"attributes":{"name":"${context.tokenset.name}","email":"${context.tokenset.email}","picture":"${context.tokenset.picture}","nickname":"${context.tokenset.nickname}","given_name":"${context.tokenset.given_name}","family_name":"${context.tokenset.family_name}","email_verified":"${context.tokenset.email_verified}"},"mapping_mode":"use_map","userinfo_scope":"openid email profile groups"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"Ed25519","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login","id_token_signed_response_algs":["RS256","RS384","ES256"],"token_endpoint_auth_signing_alg":"RS384","token_endpoint_jwtca_aud_format":"token_endpoint"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"attributes":{"name":"${context.tokenset.name}","email":"${context.tokenset.email}","picture":"${context.tokenset.picture}","nickname":"${context.tokenset.nickname}","given_name":"${context.tokenset.given_name}","family_name":"${context.tokenset.family_name}","email_verified":"${context.tokenset.email_verified}"},"mapping_mode":"use_map","userinfo_scope":"openid email profile groups"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"Ed25519","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login","id_token_signed_response_algs":["RS256","RS384","ES256"],"token_endpoint_auth_signing_alg":"RS384","token_endpoint_jwtca_aud_format":"token_endpoint"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 504.46925ms
+        duration: 439.988166ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -187,8 +187,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.39.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_D5Pq4WGGkD40BUwA
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
         method: GET
       response:
         proto: HTTP/2.0
@@ -198,13 +198,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_D5Pq4WGGkD40BUwA","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"attributes":{"name":"${context.tokenset.name}","email":"${context.tokenset.email}","picture":"${context.tokenset.picture}","nickname":"${context.tokenset.nickname}","given_name":"${context.tokenset.given_name}","family_name":"${context.tokenset.family_name}","email_verified":"${context.tokenset.email_verified}"},"mapping_mode":"use_map","userinfo_scope":"openid email profile groups"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"Ed25519","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login","id_token_signed_response_algs":["RS256","RS384","ES256"],"token_endpoint_auth_signing_alg":"RS384","token_endpoint_jwtca_aud_format":"token_endpoint"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"attributes":{"name":"${context.tokenset.name}","email":"${context.tokenset.email}","picture":"${context.tokenset.picture}","nickname":"${context.tokenset.nickname}","given_name":"${context.tokenset.given_name}","family_name":"${context.tokenset.family_name}","email_verified":"${context.tokenset.email_verified}"},"mapping_mode":"use_map","userinfo_scope":"openid email profile groups"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"Ed25519","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login","id_token_signed_response_algs":["RS256","RS384","ES256"],"token_endpoint_auth_signing_alg":"RS384","token_endpoint_jwtca_aud_format":"token_endpoint"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 370.990417ms
+        duration: 289.230875ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -220,8 +220,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.39.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_D5Pq4WGGkD40BUwA
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
         method: GET
       response:
         proto: HTTP/2.0
@@ -231,13 +231,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_D5Pq4WGGkD40BUwA","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"attributes":{"name":"${context.tokenset.name}","email":"${context.tokenset.email}","picture":"${context.tokenset.picture}","nickname":"${context.tokenset.nickname}","given_name":"${context.tokenset.given_name}","family_name":"${context.tokenset.family_name}","email_verified":"${context.tokenset.email_verified}"},"mapping_mode":"use_map","userinfo_scope":"openid email profile groups"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"Ed25519","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login","id_token_signed_response_algs":["RS256","RS384","ES256"],"token_endpoint_auth_signing_alg":"RS384","token_endpoint_jwtca_aud_format":"token_endpoint"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"attributes":{"name":"${context.tokenset.name}","email":"${context.tokenset.email}","picture":"${context.tokenset.picture}","nickname":"${context.tokenset.nickname}","given_name":"${context.tokenset.given_name}","family_name":"${context.tokenset.family_name}","email_verified":"${context.tokenset.email_verified}"},"mapping_mode":"use_map","userinfo_scope":"openid email profile groups"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"Ed25519","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login","id_token_signed_response_algs":["RS256","RS384","ES256"],"token_endpoint_auth_signing_alg":"RS384","token_endpoint_jwtca_aud_format":"token_endpoint"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 323.196208ms
+        duration: 351.599708ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -253,8 +253,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.39.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_D5Pq4WGGkD40BUwA
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
         method: GET
       response:
         proto: HTTP/2.0
@@ -264,14 +264,284 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_D5Pq4WGGkD40BUwA","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"attributes":{"name":"${context.tokenset.name}","email":"${context.tokenset.email}","picture":"${context.tokenset.picture}","nickname":"${context.tokenset.nickname}","given_name":"${context.tokenset.given_name}","family_name":"${context.tokenset.family_name}","email_verified":"${context.tokenset.email_verified}"},"mapping_mode":"use_map","userinfo_scope":"openid email profile groups"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"Ed25519","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login","id_token_signed_response_algs":["RS256","RS384","ES256"],"token_endpoint_auth_signing_alg":"RS384","token_endpoint_jwtca_aud_format":"token_endpoint"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"attributes":{"name":"${context.tokenset.name}","email":"${context.tokenset.email}","picture":"${context.tokenset.picture}","nickname":"${context.tokenset.nickname}","given_name":"${context.tokenset.given_name}","family_name":"${context.tokenset.family_name}","email_verified":"${context.tokenset.email_verified}"},"mapping_mode":"use_map","userinfo_scope":"openid email profile groups"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"Ed25519","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login","id_token_signed_response_algs":["RS256","RS384","ES256"],"token_endpoint_auth_signing_alg":"RS384","token_endpoint_jwtca_aud_format":"token_endpoint"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 335.008959ms
+        duration: 294.893958ms
     - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 745
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","show_as_button":false,"options":{"client_id":"1234567","client_secret":"1234567","domain_aliases":["example.com"],"discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","authorization_endpoint":"https://www.paypal.com/signin/authorize","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","type":"back_channel","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","token_endpoint":"https://api.paypal.com/v1/oauth2/token","scope":"email openid","set_user_root_attributes":"on_first_login","connection_settings":{"pkce":"auto"},"attribute_map":{"mapping_mode":"bind_all"},"dpop_signing_alg":"ES384"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"ES384","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 382.036542ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"ES384","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 294.449709ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"ES384","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 350.670333ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"ES384","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 320.634791ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 745
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","show_as_button":false,"options":{"client_id":"1234567","client_secret":"1234567","domain_aliases":["example.com"],"discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","authorization_endpoint":"https://www.paypal.com/signin/authorize","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","type":"back_channel","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","token_endpoint":"https://api.paypal.com/v1/oauth2/token","scope":"email openid","set_user_root_attributes":"on_first_login","connection_settings":{"pkce":"auto"},"attribute_map":{"mapping_mode":"bind_all"},"dpop_signing_alg":"ES512"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"ES512","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 423.121417ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"ES512","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 312.160375ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"ES512","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 301.992041ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"back_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","dpop_signing_alg":"ES512","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 733.673208ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -289,8 +559,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.39.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_D5Pq4WGGkD40BUwA
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -300,14 +570,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_D5Pq4WGGkD40BUwA","options":{"type":"front_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"front_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 530.3565ms
-    - id: 9
+        duration: 416.738209ms
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -322,8 +592,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.39.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_D5Pq4WGGkD40BUwA
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
         method: GET
       response:
         proto: HTTP/2.0
@@ -333,14 +603,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_D5Pq4WGGkD40BUwA","options":{"type":"front_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"front_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.184875ms
-    - id: 10
+        duration: 287.874083ms
+    - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -355,8 +625,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.39.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_D5Pq4WGGkD40BUwA
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
         method: GET
       response:
         proto: HTTP/2.0
@@ -366,14 +636,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_D5Pq4WGGkD40BUwA","options":{"type":"front_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
+        body: '{"id":"con_DzPKROBIJsb6aQk8","options":{"type":"front_channel","scope":"email openid","issuer":"https://www.paypalobjects.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","client_id":"1234567","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"1234567","discovery_url":"https://www.paypalobjects.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://www.paypal.com","jwks_uri":"https://api.paypal.com/v1/oauth2/certs","token_endpoint":"https://api.paypal.com/v1/oauth2/token","claims_supported":["aud","iss","iat","exp","auth_time","nonce","sessionIndex","user_id"],"scopes_supported":["email","address","phone","openid","profile","https://uri.paypal.com/services/wallet/sendmoney","https://uri.paypal.com/services/payments/futurepayments","https://uri.paypal.com/services/expresscheckout"],"userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","revocation_endpoint":"https://api.paypal.com/v1/oauth2/revoke","grant_types_supported":["authorization_code","refresh_token"],"registration_endpoint":"https://api.paypal.com/v1/oauth2/applications","authorization_endpoint":"https://www.paypal.com/signin/authorize","subject_types_supported":["pairwise"],"response_modes_supported":["query","form_post"],"response_types_supported":["code","code id_token"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"code_challenge_methods_supported":["RS256","ES256","S256"],"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["HS256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic"]},"domain_aliases":["example.com"],"schema_version":"oidc-V4","token_endpoint":"https://api.paypal.com/v1/oauth2/token","userinfo_endpoint":"https://api.paypal.com/v1/oauth2/token/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://www.paypal.com/signin/authorize","set_user_root_attributes":"on_first_login"},"strategy":"oidc","name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-OIDC-TestAccConnectionOIDC","enabled_clients":[],"realms":["Acceptance-Test-OIDC-TestAccConnectionOIDC"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.841417ms
-    - id: 11
+        duration: 297.835416ms
+    - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -388,8 +658,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.39.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_D5Pq4WGGkD40BUwA
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_DzPKROBIJsb6aQk8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -399,10 +669,10 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2026-05-01T15:34:11.452Z"}'
+        body: '{"deleted_at":"2026-05-22T13:32:45.418Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 334.38425ms
+        duration: 321.180042ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds `ES384` and `ES512` as allowed DPoP signing algorithms for OIDC and Okta enterprise connections.

- Extends `dpop_signing_alg` validation to accept `ES256`, `ES384`, `ES512`, `Ed25519`
- Updates attribute description to remove EA status and list all supported algorithms

**Example usage:**

```hcl
resource "auth0_connection" "oidc" {
  name     = "my-oidc-connection"
  strategy = "oidc"

  options {
    client_id     = "..."
    client_secret = "..."
    type          = "back_channel"
    issuer        = "https://idp.example.com"
    # ...

    dpop_signing_alg = "ES384"  # New in GA: ES384 and ES512 now supported
  }
}
```

### 📚 References

- API Docs: https://auth0.com/docs/api/management/v2/connections/post-connections#body-options-dpop-signing-alg
- EA implementation: #1516

### 🔬 Testing

- Added acceptance test steps for `ES384` and `ES512` in `TestAccConnectionOIDC`
- Existing tests for `ES256` and `Ed25519` remain unchanged (regression coverage)
- Re-recorded test fixtures with new steps
- Manually verified CRUD and import operataion with new values of `dpop_signing_alg`

```bash
go test ./internal/auth0/connection/ -run "TestAccConnectionOIDC$" -v -count=1
```

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
