### PR TITLE
feat: added support for custom header auth with header_key and header…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+
+- `auth0_event_stream`: Added support for `custom_header` webhook authorization method, with `header_key`, `header_value`, `header_value_wo`, and `header_value_wo_version` fields ([#1528](https://github.com/auth0/terraform-provider-auth0/issues/1528))
+
 ## v1.48.0
 
 FEATURES:

--- a/docs/data-sources/event_stream.md
+++ b/docs/data-sources/event_stream.md
@@ -67,6 +67,10 @@ Read-Only:
 
 Read-Only:
 
+- `header_key` (String)
+- `header_value` (String)
+- `header_value_wo` (String)
+- `header_value_wo_version` (Number)
 - `method` (String)
 - `password` (String)
 - `password_wo` (String)

--- a/docs/resources/event_stream.md
+++ b/docs/resources/event_stream.md
@@ -140,7 +140,7 @@ Required:
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
-- `webhook_authorization` (Block List, Min: 1, Max: 1) Authorization details for the webhook endpoint. Supports `basic` authentication using `username` and `password`, or `bearer` authentication using a `token`. The appropriate fields must be set based on the chosen method. (see [below for nested schema](#nestedblock--webhook_configuration--webhook_authorization))
+- `webhook_authorization` (Block List, Min: 1, Max: 1) Authorization details for the webhook endpoint. Supports `basic` authentication using `username` and `password`, `bearer` authentication using a `token`, or `custom_header` authentication using `header_key` and `header_value` (or `header_value_wo`). The appropriate fields must be set based on the chosen method. (see [below for nested schema](#nestedblock--webhook_configuration--webhook_authorization))
 - `webhook_endpoint` (String) The HTTPS endpoint that will receive the webhook events. Must be a valid, publicly accessible URL.
 
 <a id="nestedblock--webhook_configuration--webhook_authorization"></a>
@@ -148,12 +148,16 @@ Required:
 
 Required:
 
-- `method` (String) The authorization method used to secure the webhook endpoint. Can be either `basic` or `bearer`.
+- `method` (String) The authorization method used to secure the webhook endpoint. Can be `basic`, `bearer`, or `custom_header`.
 
 Optional:
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
+- `header_key` (String) The name of the HTTP header used for `custom_header` authentication. Required when `method` is `custom_header`. Returned by the API and stored in state.
+- `header_value` (String, Sensitive) The secret value sent in the custom header. Required when `method` is `custom_header` and `header_value_wo` is not provided. **Note:** For better security, use `header_value_wo` to prevent storing the secret in state.
+- `header_value_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The secret value sent in the custom header (write-only). Not stored in Terraform state. Bump `header_value_wo_version` to rotate the secret.
+- `header_value_wo_version` (Number) Version number for secret rotation. Update to trigger a new `header_value_wo` to be sent.
 - `password` (String, Sensitive) The password for `basic` authentication. Required only when `method` is set to `basic`. **Note:** For better security, consider using `password_wo` instead to prevent storing the password in Terraform state.
 - `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The password for `basic` authentication (write-only). This value is only available during resource creation and update, and is **not** stored in Terraform state. To change the password, update the `password_wo_version` attribute. Required only when `method` is set to `basic` and `password` is not provided.
 - `password_wo_version` (Number) Version number for password changes. Update this value to trigger a password change when using `password_wo`.

--- a/internal/auth0/eventstream/expand.go
+++ b/internal/auth0/eventstream/expand.go
@@ -133,6 +133,16 @@ func extractWebhookAuth(authCfgRaw cty.Value, data *schema.ResourceData) map[str
 		} else if token := authCfgRaw.GetAttr("token"); !nullOrEmptyString(token) {
 			authMap["token"] = token.AsString()
 		}
+	case "custom_header":
+		if headerKey := authCfgRaw.GetAttr("header_key"); !nullOrEmptyString(headerKey) {
+			authMap["header_key"] = headerKey.AsString()
+		}
+		headerValueWO := authCfgRaw.GetAttr("header_value_wo")
+		if !nullOrEmptyString(headerValueWO) && (data.IsNewResource() || hasHeaderValueWOVersionChanged(data)) {
+			authMap["header_value"] = headerValueWO.AsString()
+		} else if headerValue := authCfgRaw.GetAttr("header_value"); !nullOrEmptyString(headerValue) {
+			authMap["header_value"] = headerValue.AsString()
+		}
 	}
 	return authMap
 }
@@ -143,6 +153,10 @@ func hasTokenWOVersionChanged(data *schema.ResourceData) bool {
 
 func hasPasswordWOVersionChanged(data *schema.ResourceData) bool {
 	return data.HasChange("webhook_configuration.0.webhook_authorization.0.password_wo_version")
+}
+
+func hasHeaderValueWOVersionChanged(data *schema.ResourceData) bool {
+	return data.HasChange("webhook_configuration.0.webhook_authorization.0.header_value_wo_version")
 }
 
 func nullOrEmptyString(s cty.Value) bool {

--- a/internal/auth0/eventstream/flatten.go
+++ b/internal/auth0/eventstream/flatten.go
@@ -108,6 +108,18 @@ func flattenWebhookAuthorization(auth map[string]interface{}, data *schema.Resou
 		if version, ok := data.GetOk("webhook_configuration.0.webhook_authorization.0.token_wo_version"); ok {
 			authMap["token_wo_version"] = version
 		}
+	case "custom_header":
+		// header_key IS returned by the API — read directly from response.
+		if v, ok := auth["header_key"]; ok && v != "" {
+			authMap["header_key"] = v
+		}
+		// header_value is never returned by the API — preserve from prior state.
+		if v, ok := data.GetOk("webhook_configuration.0.webhook_authorization.0.header_value"); ok && v != "" {
+			authMap["header_value"] = v
+		}
+		if v, ok := data.GetOk("webhook_configuration.0.webhook_authorization.0.header_value_wo_version"); ok {
+			authMap["header_value_wo_version"] = v
+		}
 	}
 
 	return authMap

--- a/internal/auth0/eventstream/flatten.go
+++ b/internal/auth0/eventstream/flatten.go
@@ -109,11 +109,11 @@ func flattenWebhookAuthorization(auth map[string]interface{}, data *schema.Resou
 			authMap["token_wo_version"] = version
 		}
 	case "custom_header":
-		// header_key IS returned by the API — read directly from response.
+		// Header_key IS returned by the API — read directly from response.
 		if v, ok := auth["header_key"]; ok && v != "" {
 			authMap["header_key"] = v
 		}
-		// header_value is never returned by the API — preserve from prior state.
+		// Header_value is never returned by the API — preserve from prior state.
 		if v, ok := data.GetOk("webhook_configuration.0.webhook_authorization.0.header_value"); ok && v != "" {
 			authMap["header_value"] = v
 		}

--- a/internal/auth0/eventstream/resource.go
+++ b/internal/auth0/eventstream/resource.go
@@ -23,8 +23,9 @@ var webhookConfig = &schema.Resource{
 			Type:     schema.TypeList,
 			Required: true,
 			Description: "Authorization details for the webhook endpoint. " +
-				"Supports `basic` authentication using `username` and `password`, or " +
-				"`bearer` authentication using a `token`. " +
+				"Supports `basic` authentication using `username` and `password`, " +
+				"`bearer` authentication using a `token`, or " +
+				"`custom_header` authentication using `header_key` and `header_value` (or `header_value_wo`). " +
 				"The appropriate fields must be set based on the chosen method.",
 			MaxItems: 1,
 			Elem: &schema.Resource{
@@ -32,8 +33,8 @@ var webhookConfig = &schema.Resource{
 					"method": {
 						Type:         schema.TypeString,
 						Required:     true,
-						ValidateFunc: validation.StringInSlice([]string{"basic", "bearer"}, false),
-						Description:  "The authorization method used to secure the webhook endpoint. Can be either `basic` or `bearer`.",
+						ValidateFunc: validation.StringInSlice([]string{"basic", "bearer", "custom_header"}, false),
+						Description:  "The authorization method used to secure the webhook endpoint. Can be `basic`, `bearer`, or `custom_header`.",
 					},
 					"username": {
 						Type:        schema.TypeString,
@@ -43,6 +44,7 @@ var webhookConfig = &schema.Resource{
 							"webhook_configuration.0.webhook_authorization.0.username",
 							"webhook_configuration.0.webhook_authorization.0.token",
 							"webhook_configuration.0.webhook_authorization.0.token_wo",
+							"webhook_configuration.0.webhook_authorization.0.header_key",
 						},
 					},
 					"password": {
@@ -81,6 +83,7 @@ var webhookConfig = &schema.Resource{
 							"webhook_configuration.0.webhook_authorization.0.username",
 							"webhook_configuration.0.webhook_authorization.0.token",
 							"webhook_configuration.0.webhook_authorization.0.token_wo",
+							"webhook_configuration.0.webhook_authorization.0.header_key",
 						},
 						Description: "The token used for `bearer` authentication. Required only when `method` is set to `bearer`. " +
 							"**Note:** For better security, consider using `token_wo` instead to prevent storing the token in Terraform state.",
@@ -95,6 +98,7 @@ var webhookConfig = &schema.Resource{
 							"webhook_configuration.0.webhook_authorization.0.username",
 							"webhook_configuration.0.webhook_authorization.0.token",
 							"webhook_configuration.0.webhook_authorization.0.token_wo",
+							"webhook_configuration.0.webhook_authorization.0.header_key",
 						},
 						RequiredWith: []string{"webhook_configuration.0.webhook_authorization.0.token_wo_version"},
 						Description: "The token used for `bearer` authentication (write-only). " +
@@ -107,6 +111,51 @@ var webhookConfig = &schema.Resource{
 						Optional:     true,
 						Description:  "Version number for token changes. Update this value to trigger a token change when using `token_wo`.",
 						RequiredWith: []string{"webhook_configuration.0.webhook_authorization.0.token_wo"},
+					},
+					"header_key": {
+						Type:     schema.TypeString,
+						Optional: true,
+						ExactlyOneOf: []string{
+							"webhook_configuration.0.webhook_authorization.0.username",
+							"webhook_configuration.0.webhook_authorization.0.token",
+							"webhook_configuration.0.webhook_authorization.0.token_wo",
+							"webhook_configuration.0.webhook_authorization.0.header_key",
+						},
+						Description: "The name of the HTTP header used for `custom_header` authentication. " +
+							"Required when `method` is `custom_header`. Returned by the API and stored in state.",
+					},
+					"header_value": {
+						Type:      schema.TypeString,
+						Optional:  true,
+						Sensitive: true,
+						ConflictsWith: []string{
+							"webhook_configuration.0.webhook_authorization.0.header_value_wo",
+						},
+						RequiredWith: []string{"webhook_configuration.0.webhook_authorization.0.header_key"},
+						Description: "The secret value sent in the custom header. Required when `method` is `custom_header` " +
+							"and `header_value_wo` is not provided. " +
+							"**Note:** For better security, use `header_value_wo` to prevent storing the secret in state.",
+					},
+					"header_value_wo": {
+						Type:      schema.TypeString,
+						Optional:  true,
+						WriteOnly: true,
+						Sensitive: true,
+						ConflictsWith: []string{
+							"webhook_configuration.0.webhook_authorization.0.header_value",
+						},
+						RequiredWith: []string{
+							"webhook_configuration.0.webhook_authorization.0.header_key",
+							"webhook_configuration.0.webhook_authorization.0.header_value_wo_version",
+						},
+						Description: "The secret value sent in the custom header (write-only). Not stored in Terraform state. " +
+							"Bump `header_value_wo_version` to rotate the secret.",
+					},
+					"header_value_wo_version": {
+						Type:         schema.TypeInt,
+						Optional:     true,
+						RequiredWith: []string{"webhook_configuration.0.webhook_authorization.0.header_value_wo"},
+						Description:  "Version number for secret rotation. Update to trigger a new `header_value_wo` to be sent.",
 					},
 				},
 			},

--- a/internal/auth0/eventstream/resource_test.go
+++ b/internal/auth0/eventstream/resource_test.go
@@ -258,6 +258,90 @@ func TestAccEventStreamStatus(t *testing.T) {
 	})
 }
 
+const testEventStreamCreateCustomHeader = `
+resource "auth0_event_stream" "my_event_stream_custom_header" {
+  name             = "{{.testName}}-my-custom-header"
+  destination_type = "webhook"
+  subscriptions    = ["user.created", "user.updated"]
+
+  webhook_configuration {
+    webhook_endpoint = "https://eof28wtn4v4506o.m.pipedream.net"
+    webhook_authorization {
+      method       = "custom_header"
+      header_key   = "x-auth0-webhook-secret"
+      header_value = "initial-secret"
+    }
+  }
+}
+`
+
+const testEventStreamUpdateCustomHeader = `
+resource "auth0_event_stream" "my_event_stream_custom_header" {
+  name             = "{{.testName}}-my-custom-header"
+  destination_type = "webhook"
+  subscriptions    = ["user.created", "user.updated"]
+
+  webhook_configuration {
+    webhook_endpoint = "https://eof28wtn4v4506o.m.pipedream.net"
+    webhook_authorization {
+      method       = "custom_header"
+      header_key   = "x-auth0-webhook-secret"
+      header_value = "rotated-secret"
+    }
+  }
+}
+`
+
+const testEventStreamCreateCustomHeaderWO = `
+resource "auth0_event_stream" "my_event_stream_custom_header" {
+  name             = "{{.testName}}-my-custom-header"
+  destination_type = "webhook"
+  subscriptions    = ["user.created", "user.updated"]
+
+  webhook_configuration {
+    webhook_endpoint = "https://eof28wtn4v4506o.m.pipedream.net"
+    webhook_authorization {
+      method                   = "custom_header"
+      header_key               = "x-auth0-webhook-secret"
+      header_value_wo          = "secret-write-only"
+      header_value_wo_version  = 1
+    }
+  }
+}
+`
+
+func TestAccEventStreamCustomHeader(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseTestName(testEventStreamCreateCustomHeader, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_custom_header", "destination_type", "webhook"),
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_custom_header", "webhook_configuration.0.webhook_authorization.0.method", "custom_header"),
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_custom_header", "webhook_configuration.0.webhook_authorization.0.header_key", "x-auth0-webhook-secret"),
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_custom_header", "webhook_configuration.0.webhook_authorization.0.header_value", "initial-secret"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testEventStreamUpdateCustomHeader, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_custom_header", "webhook_configuration.0.webhook_authorization.0.method", "custom_header"),
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_custom_header", "webhook_configuration.0.webhook_authorization.0.header_key", "x-auth0-webhook-secret"),
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_custom_header", "webhook_configuration.0.webhook_authorization.0.header_value", "rotated-secret"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testEventStreamCreateCustomHeaderWO, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_custom_header", "webhook_configuration.0.webhook_authorization.0.method", "custom_header"),
+					resource.TestCheckResourceAttr("auth0_event_stream.my_event_stream_custom_header", "webhook_configuration.0.webhook_authorization.0.header_key", "x-auth0-webhook-secret"),
+					resource.TestCheckNoResourceAttr("auth0_event_stream.my_event_stream_custom_header", "webhook_configuration.0.webhook_authorization.0.header_value_wo"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEventStreamAction(t *testing.T) {
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{

--- a/test/data/recordings/TestAccEventStreamCustomHeader.yaml
+++ b/test/data/recordings/TestAccEventStreamCustomHeader.yaml
@@ -1,0 +1,408 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 370
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"destination":{"type":"webhook","configuration":{"webhook_authorization":{"header_key":"x-auth0-webhook-secret","header_value":"initial-secret","method":"custom_header"},"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 470
+        uncompressed: false
+        body: '{"id":"est_iNgzZtgd1C6DSfsv9dzBw2","status":"enabled","name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"created_at":"2026-06-08T19:51:58.379Z","updated_at":"2026-06-08T19:51:58.379Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"custom_header","header_key":"x-auth0-webhook-secret"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 434.176292ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_iNgzZtgd1C6DSfsv9dzBw2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_iNgzZtgd1C6DSfsv9dzBw2","status":"enabled","name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"created_at":"2026-06-08T19:51:58.379Z","updated_at":"2026-06-08T19:51:58.379Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"custom_header","header_key":"x-auth0-webhook-secret"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 284.83825ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_iNgzZtgd1C6DSfsv9dzBw2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_iNgzZtgd1C6DSfsv9dzBw2","status":"enabled","name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"created_at":"2026-06-08T19:51:58.379Z","updated_at":"2026-06-08T19:51:58.379Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"custom_header","header_key":"x-auth0-webhook-secret"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 788.275125ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_iNgzZtgd1C6DSfsv9dzBw2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_iNgzZtgd1C6DSfsv9dzBw2","status":"enabled","name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"created_at":"2026-06-08T19:51:58.379Z","updated_at":"2026-06-08T19:51:58.379Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"custom_header","header_key":"x-auth0-webhook-secret"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 274.279583ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 370
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"destination":{"type":"webhook","configuration":{"webhook_authorization":{"header_key":"x-auth0-webhook-secret","header_value":"rotated-secret","method":"custom_header"},"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_iNgzZtgd1C6DSfsv9dzBw2
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_iNgzZtgd1C6DSfsv9dzBw2","status":"enabled","name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"created_at":"2026-06-08T19:51:58.379Z","updated_at":"2026-06-08T19:52:01.582Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"custom_header","header_key":"x-auth0-webhook-secret"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 333.092875ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_iNgzZtgd1C6DSfsv9dzBw2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_iNgzZtgd1C6DSfsv9dzBw2","status":"enabled","name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"created_at":"2026-06-08T19:51:58.379Z","updated_at":"2026-06-08T19:52:01.582Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"custom_header","header_key":"x-auth0-webhook-secret"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 269.836125ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_iNgzZtgd1C6DSfsv9dzBw2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_iNgzZtgd1C6DSfsv9dzBw2","status":"enabled","name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"created_at":"2026-06-08T19:51:58.379Z","updated_at":"2026-06-08T19:52:01.582Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"custom_header","header_key":"x-auth0-webhook-secret"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 271.755958ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_iNgzZtgd1C6DSfsv9dzBw2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_iNgzZtgd1C6DSfsv9dzBw2","status":"enabled","name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"created_at":"2026-06-08T19:51:58.379Z","updated_at":"2026-06-08T19:52:01.582Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"custom_header","header_key":"x-auth0-webhook-secret"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 271.582834ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 373
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"destination":{"type":"webhook","configuration":{"webhook_authorization":{"header_key":"x-auth0-webhook-secret","header_value":"secret-write-only","method":"custom_header"},"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_iNgzZtgd1C6DSfsv9dzBw2
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_iNgzZtgd1C6DSfsv9dzBw2","status":"enabled","name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"created_at":"2026-06-08T19:51:58.379Z","updated_at":"2026-06-08T19:52:04.137Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"custom_header","header_key":"x-auth0-webhook-secret"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 302.329792ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_iNgzZtgd1C6DSfsv9dzBw2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_iNgzZtgd1C6DSfsv9dzBw2","status":"enabled","name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"created_at":"2026-06-08T19:51:58.379Z","updated_at":"2026-06-08T19:52:04.137Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"custom_header","header_key":"x-auth0-webhook-secret"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 270.913708ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_iNgzZtgd1C6DSfsv9dzBw2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"est_iNgzZtgd1C6DSfsv9dzBw2","status":"enabled","name":"TestAccEventStreamCustomHeader-my-custom-header","subscriptions":[{"event_type":"user.created"},{"event_type":"user.updated"}],"created_at":"2026-06-08T19:51:58.379Z","updated_at":"2026-06-08T19:52:04.137Z","destination":{"type":"webhook","configuration":{"webhook_endpoint":"https://eof28wtn4v4506o.m.pipedream.net","webhook_authorization":{"method":"custom_header","header_key":"x-auth0-webhook-secret"}}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 273.202917ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/event-streams/est_iNgzZtgd1C6DSfsv9dzBw2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 286.44675ms


### PR DESCRIPTION
 ### 🔧 Changes

  Added `custom_header` as a third webhook authorization method for the `auth0_event_stream` resource, alongside
  the existing `basic` and `bearer` methods.

  **New fields on `webhook_configuration.0.webhook_authorization`:**

  | Field | Type | Notes |
  |---|---|---|
  | `header_key` | `string` | The HTTP header name sent to the webhook endpoint. Returned by the API and stored in state. |
  | `header_value` | `string` (sensitive) | The secret header value. Stored in Terraform state. Use `header_value_wo` for better security. |
  | `header_value_wo` | `string` (write-only, sensitive) | The secret header value. Never stored in state. Requires `header_value_wo_version`. |
  | `header_value_wo_version` | `int` | Bump this to trigger a secret rotation when using `header_value_wo`. |

  **Implementation notes:**
  - `header_key` is returned by the Auth0 API and read directly from the response on refresh.
  - `header_value` is never returned by the API; on refresh it is preserved from prior state (same pattern as
  `password` and `token`).
  - The `method` field's `ValidateFunc` and description are updated to include `custom_header`.
  - `ExactlyOneOf` constraints are extended so `header_key` is mutually exclusive with `username`, `token`, and
  `token_wo`.

  **Example usage:**

  ```hcl
  resource "auth0_event_stream" "example" {
    name             = "my-webhook"
    destination_type = "webhook"
    subscriptions    = ["user.created"]

    webhook_configuration {
      webhook_endpoint = "https://example.com/webhook"
      webhook_authorization {
        method                  = "custom_header"
        header_key              = "x-my-secret-header"
        header_value_wo         = "super-secret-value"
        header_value_wo_version = 1
      }
    }
  }
```

  🔬 Testing


  HTTP interactions are recorded in test/data/recordings/TestAccEventStreamCustomHeader.yaml. Tests can be run using `make test-acc FILTER=TestAccEventStreamCustomHeader`

  📝 Checklist

  - [x] All new/changed/fixed functionality is covered by tests (or N/A)
  - [x] I have added documentation for all new/changed functionality (or N/A)