### PR TITLE
feat: Add support for PKCS#1 public key format in client_credentials

### DIFF
--- a/internal/auth0/client/resource_credentials.go
+++ b/internal/auth0/client/resource_credentials.go
@@ -802,6 +802,12 @@ func jwkThumbprint(pemData string) string {
 		if !ok {
 			return ""
 		}
+	case "RSA PUBLIC KEY":
+		key, err := x509.ParsePKCS1PublicKey(block.Bytes)
+		if err != nil {
+			return ""
+		}
+		pub = key
 	default:
 		return ""
 	}

--- a/internal/auth0/client/resource_credentials_internal_test.go
+++ b/internal/auth0/client/resource_credentials_internal_test.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateTestRSAPEMs returns the same RSA public key encoded in the three PEM
+// formats jwkThumbprint supports: SPKI ("PUBLIC KEY"), PKCS#1 ("RSA PUBLIC
+// KEY"), and a self-signed X.509 certificate ("CERTIFICATE").
+func generateTestRSAPEMs(t *testing.T) (spkiPEM, pkcs1PEM, certPEM string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	spkiDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	require.NoError(t, err)
+	spki := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: spkiDER})
+
+	pkcs1DER := x509.MarshalPKCS1PublicKey(&key.PublicKey)
+	pkcs1 := pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: pkcs1DER})
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	return string(spki), string(pkcs1), string(cert)
+}
+
+func TestJWKThumbprint_AllFormatsMatch(t *testing.T) {
+	spkiPEM, pkcs1PEM, certPEM := generateTestRSAPEMs(t)
+
+	spkiThumb := jwkThumbprint(spkiPEM)
+	pkcs1Thumb := jwkThumbprint(pkcs1PEM)
+	certThumb := jwkThumbprint(certPEM)
+
+	assert.NotEmpty(t, spkiThumb, "SPKI thumbprint should be computed")
+	assert.NotEmpty(t, pkcs1Thumb, "PKCS#1 thumbprint should be computed")
+	assert.NotEmpty(t, certThumb, "X.509 certificate thumbprint should be computed")
+
+	assert.Equal(t, spkiThumb, pkcs1Thumb,
+		"same key in SPKI and PKCS#1 form must produce the same kid")
+	assert.Equal(t, spkiThumb, certThumb,
+		"same key in SPKI and X.509 certificate form must produce the same kid")
+}
+
+func TestJWKThumbprint_UnsupportedInputReturnsEmpty(t *testing.T) {
+	assert.Empty(t, jwkThumbprint(""), "empty input returns empty")
+	assert.Empty(t, jwkThumbprint("not a pem"), "garbage input returns empty")
+	assert.Empty(t, jwkThumbprint(
+		"-----BEGIN EC PRIVATE KEY-----\nMHcCAQE=\n-----END EC PRIVATE KEY-----\n"),
+		"unsupported block type returns empty")
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds PKCS#1 (`-----BEGIN RSA PUBLIC KEY-----`) support to the JWK thumbprint computation used for `auth0_client_credentials` `private_key_jwt` credentials.

The `jwkThumbprint` helper derives a credential's `kid` (RFC 7638 thumbprint) locally to reconcile config against state. It handled SPKI (`PUBLIC KEY`) and X.509 (`CERTIFICATE`) PEM blocks but returned an empty thumbprint for PKCS#1 keys. As a result, credentials configured with a PKCS#1 public key:

- showed persistent phantom drift on every `terraform plan` (the PEM was wiped from state on refresh), and
- failed on re-apply with `400 Bad Request: credentials contains public keys that already exist in client`, because the provider could not recognize the already-registered key and tried to create it again.

This adds a `RSA PUBLIC KEY` case that parses PKCS#1 via `x509.ParsePKCS1PublicKey`. The thumbprint is derived from the key's modulus and exponent, so the same key now yields an identical `kid` across all three supported PEM formats. The schema already documented `SPKI and PKCS1` support; this aligns the implementation with that contract.

No behavior change for SPKI or X.509 keys.

### 📚 References

- Resolves phantom state drift issue and `400 ... public keys that already exist in client` error when using PKCS#1-formatted public keys for `private_key_jwt` credentials.
- Affected helper introduced in #1570.

### 🔬 Testing

**Automated:**
- New in-package unit tests in `resource_credentials_internal_test.go`:
  - `TestJWKThumbprint_AllFormatsMatch` – encodes one RSA key as SPKI, PKCS#1, and a self-signed X.509 certificate, and asserts all three produce the same non-empty `kid`.
  - `TestJWKThumbprint_UnsupportedInputReturnsEmpty` – empty, malformed, and unsupported block types return an empty string.

**Manual (end-to-end):**
Reproduced on a live tenant with provider v1.49.0 before the fix:
1. Apply an `auth0_client_credentials` resource with `authentication_method = "private_key_jwt"` and a PKCS#1 public key — first apply succeeds.
2. Run `terraform plan` again — shows phantom drift on `pem` with no config change.
3. Run `terraform apply` — fails with `400 ... public keys that already exist in client`.

After the fix, repeated `plan`/`apply` are clean (no drift, no error) for PKCS#1 keys, and the `kid` is identical to the SPKI form of the same key.

**For reviewers:**
```bash
go test ./internal/auth0/client/ -run TestJWKThumbprint -v
```

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
