### PR TITLE
fix: Only send changed attributes when updating email templates

### DIFF
--- a/internal/auth0/email/expand.go
+++ b/internal/auth0/email/expand.go
@@ -174,17 +174,36 @@ func expandEmailProviderMS365(config cty.Value, data *schema.ResourceData, email
 	}
 }
 
-func expandEmailTemplate(config cty.Value) *management.EmailTemplate {
+func expandEmailTemplate(data *schema.ResourceData) *management.EmailTemplate {
+	config := data.GetRawConfig()
+
 	emailTemplate := &management.EmailTemplate{
-		Template:               value.String(config.GetAttr("template")),
-		Body:                   value.String(config.GetAttr("body")),
-		From:                   value.String(config.GetAttr("from")),
-		ResultURL:              value.String(config.GetAttr("result_url")),
-		Subject:                value.String(config.GetAttr("subject")),
-		Syntax:                 value.String(config.GetAttr("syntax")),
-		URLLifetimeInSecoonds:  value.Int(config.GetAttr("url_lifetime_in_seconds")),
-		Enabled:                value.Bool(config.GetAttr("enabled")),
-		IncludeEmailInRedirect: value.Bool(config.GetAttr("include_email_in_redirect")),
+		Template: value.String(config.GetAttr("template")),
+	}
+
+	if data.IsNewResource() || data.HasChange("body") {
+		emailTemplate.Body = value.String(config.GetAttr("body"))
+	}
+	if data.IsNewResource() || data.HasChange("from") {
+		emailTemplate.From = value.String(config.GetAttr("from"))
+	}
+	if data.IsNewResource() || data.HasChange("result_url") {
+		emailTemplate.ResultURL = value.String(config.GetAttr("result_url"))
+	}
+	if data.IsNewResource() || data.HasChange("subject") {
+		emailTemplate.Subject = value.String(config.GetAttr("subject"))
+	}
+	if data.IsNewResource() || data.HasChange("syntax") {
+		emailTemplate.Syntax = value.String(config.GetAttr("syntax"))
+	}
+	if data.IsNewResource() || data.HasChange("url_lifetime_in_seconds") {
+		emailTemplate.URLLifetimeInSecoonds = value.Int(config.GetAttr("url_lifetime_in_seconds"))
+	}
+	if data.IsNewResource() || data.HasChange("enabled") {
+		emailTemplate.Enabled = value.Bool(config.GetAttr("enabled"))
+	}
+	if data.IsNewResource() || data.HasChange("include_email_in_redirect") {
+		emailTemplate.IncludeEmailInRedirect = value.Bool(config.GetAttr("include_email_in_redirect"))
 	}
 
 	return emailTemplate

--- a/internal/auth0/email/resource_template.go
+++ b/internal/auth0/email/resource_template.go
@@ -105,7 +105,7 @@ func NewTemplateResource() *schema.Resource {
 func createEmailTemplate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*config.Config).GetAPI()
 
-	email := expandEmailTemplate(data.GetRawConfig())
+	email := expandEmailTemplate(data)
 
 	// The email template resource doesn't allow deleting templates, so in order
 	// to avoid conflicts, we first attempt to read the template. If it exists
@@ -152,7 +152,7 @@ func readEmailTemplate(ctx context.Context, data *schema.ResourceData, meta inte
 func updateEmailTemplate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*config.Config).GetAPI()
 
-	email := expandEmailTemplate(data.GetRawConfig())
+	email := expandEmailTemplate(data)
 
 	if err := api.EmailTemplate.Update(ctx, data.Id(), email); err != nil {
 		return diag.FromErr(internalError.HandleAPIError(data, err))


### PR DESCRIPTION
### 🔧 Changes

`auth0_email_template` is updated through a `PATCH` to the Management API, but `expandEmailTemplate` built the payload from the full raw config and sent **every** attribute on **every** update. As a result, changing a single attribute (e.g. `result_url`) also re-sent `body`, `from` and `subject`. This has two consequences:

- It overwrites template content that is managed outside of Terraform.
- It defeats `lifecycle { ignore_changes = [body, from, subject] }`. `ignore_changes` only suppresses the *plan* diff; it does not stop the provider from shipping those attributes in the apply payload. So any unrelated change (a perpetual `result_url` diff is enough) silently re-pushes the configured `body` on every apply.

This PR gates each attribute with `data.IsNewResource() || data.HasChange(...)` — the same idiom already used by other resources (e.g. `client`, `tenant`). On create, every attribute is sent; on update, only changed attributes are included in the `PATCH`, leaving untouched fields as-is. `expandEmailTemplate` now takes `*schema.ResourceData` for consistency with `expandClient` and friends.

### 📚 References

Reproduction:

1. Manage an `auth0_email_template` with `lifecycle { ignore_changes = [body] }` and set `body` out-of-band (e.g. via a deploy pipeline).
2. Change any other attribute (e.g. `result_url`).
3. `terraform apply` — the out-of-band `body` is silently overwritten with the value from the Terraform config, even though `body` is in `ignore_changes`.

### 🔬 Testing

- `TestAccEmailTemplate` now has two steps: (1) create, and (2) update **only** `result_url`, asserting `body`/`from`/`subject` stay unchanged. The recorded update interaction shows that only the changed attributes (+ `template`) are sent in the `PATCH`.
- HTTP recording regenerated: `make test-acc-record FILTER=TestAccEmailTemplate`.
- Replay passes: `make test-acc FILTER=TestAccEmailTemplate`.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A) — N/A, no schema or documented behavior change.
