### PR TITLE
feat: Support write-only client secrets in client_credentials

### DIFF
--- a/docs/resources/client_credentials.md
+++ b/docs/resources/client_credentials.md
@@ -37,6 +37,18 @@ resource "auth0_client_credentials" "test" {
   authentication_method = "client_secret_basic"
 }
 
+# Configuring a write-only client secret.
+# NOTE: Write-only arguments are supported in Terraform 1.11 and later.
+# The secret is never stored in Terraform state. Increment
+# client_secret_wo_version to rotate the secret.
+resource "auth0_client_credentials" "test" {
+  client_id = auth0_client.my_client.id
+
+  authentication_method    = "client_secret_post"
+  client_secret_wo         = "LUFqPx+sRLjbL7peYRPFmFu-bbvE7u7og4YUNe_C345=683341"
+  client_secret_wo_version = 1
+}
+
 # Configuring none as an authentication method.
 resource "auth0_client_credentials" "test" {
   client_id = auth0_client.my_client.id
@@ -136,8 +148,12 @@ resource "auth0_client_credentials" "test" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `authentication_method` (String) Configure the method to use when making requests to any endpoint that requires this client to authenticate. Options include `none` (public client without a client secret), `client_secret_post` (confidential client using HTTP POST parameters), `client_secret_basic` (confidential client using HTTP Basic), `private_key_jwt` (confidential client using a Private Key JWT), `tls_client_auth` (confidential client using CA-based mTLS authentication), `self_signed_tls_client_auth` (confidential client using mTLS authentication utilizing a self-signed certificate).
-- `client_secret` (String, Sensitive) Secret for the client when using `client_secret_post` or `client_secret_basic` authentication method. Keep this private. To access this attribute you need to add either `read:client_keys` or `read:client_credentials` scope to the Terraform client. Otherwise, the attribute will contain an empty string. The attribute will also be an empty string in case `private_key_jwt` is selected as an authentication method.
+- `client_secret` (String, Sensitive) Secret for the client when using `client_secret_post` or `client_secret_basic` authentication method. Keep this private. To access this attribute you need to add either `read:client_keys` or `read:client_credentials` scope to the Terraform client. Otherwise, the attribute will contain an empty string. The attribute will also be an empty string in case `private_key_jwt` is selected as an authentication method. **Note:** For better security, consider using `client_secret_wo` instead.
+- `client_secret_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Secret for the client when using `client_secret_post` or `client_secret_basic` authentication method (write-only). This value is **not** stored in Terraform state. Bump `client_secret_wo_version` to rotate it. Requires Terraform 1.11+.
+- `client_secret_wo_version` (Number) Version counter for `client_secret_wo`. Must be a positive integer (starting at `1`). Increment this value to trigger a client secret change when using `client_secret_wo`.
 - `private_key_jwt` (Block List, Max: 1) Defines `private_key_jwt` client authentication method. (see [below for nested schema](#nestedblock--private_key_jwt))
 - `self_signed_tls_client_auth` (Block List, Max: 1) Defines `tls_client_auth` client authentication method. (see [below for nested schema](#nestedblock--self_signed_tls_client_auth))
 - `signed_request_object` (Block List, Max: 1) Configuration for JWT-secured Authorization Requests(JAR). (see [below for nested schema](#nestedblock--signed_request_object))

--- a/examples/resources/auth0_client_credentials/resource.tf
+++ b/examples/resources/auth0_client_credentials/resource.tf
@@ -21,6 +21,18 @@ resource "auth0_client_credentials" "test" {
   authentication_method = "client_secret_basic"
 }
 
+# Configuring a write-only client secret.
+# NOTE: Write-only arguments are supported in Terraform 1.11 and later.
+# The secret is never stored in Terraform state. Increment
+# client_secret_wo_version to rotate the secret.
+resource "auth0_client_credentials" "test" {
+  client_id = auth0_client.my_client.id
+
+  authentication_method    = "client_secret_post"
+  client_secret_wo         = "LUFqPx+sRLjbL7peYRPFmFu-bbvE7u7og4YUNe_C345=683341"
+  client_secret_wo_version = 1
+}
+
 # Configuring none as an authentication method.
 resource "auth0_client_credentials" "test" {
   client_id = auth0_client.my_client.id

--- a/internal/auth0/client/flatten.go
+++ b/internal/auth0/client/flatten.go
@@ -782,9 +782,14 @@ func flattenClientCredentials(ctx context.Context, api *management.Management, d
 	result := multierror.Append(
 		err,
 		data.Set("client_id", client.GetClientID()),
-		data.Set("client_secret", client.GetClientSecret()),
 		data.Set("signed_request_object", signedRequestObject),
 	)
+
+	if v, ok := data.GetOk("client_secret_wo_version"); ok {
+		result = multierror.Append(result, data.Set("client_secret_wo_version", v))
+	} else {
+		result = multierror.Append(result, data.Set("client_secret", client.GetClientSecret()))
+	}
 
 	authenticationMethods, err := flattenClientAuthenticationMethods(ctx, api, data, true, client.GetClientAuthenticationMethods())
 	result = multierror.Append(result, err)

--- a/internal/auth0/client/resource_credentials.go
+++ b/internal/auth0/client/resource_credentials.go
@@ -661,11 +661,22 @@ func updateTokenEndpointAuthMethod(ctx context.Context, api *management.Manageme
 }
 
 func updateSecret(ctx context.Context, api *management.Management, data *schema.ResourceData) error {
+	clientID := data.Get("client_id").(string)
+
+	// Write-only values are not available via data.Get(); read them from the raw config.
+	secretWO := data.GetRawConfig().GetAttr("client_secret_wo")
+	if !secretWO.IsNull() && (data.IsNewResource() || data.HasChange("client_secret_wo_version")) {
+		clientSecret := secretWO.AsString()
+
+		return api.Client.Update(ctx, clientID, &management.Client{
+			ClientSecret: &clientSecret,
+		})
+	}
+
 	if !data.HasChange("client_secret") {
 		return nil
 	}
 
-	clientID := data.Get("client_id").(string)
 	clientSecret := data.Get("client_secret").(string)
 
 	return api.Client.Update(ctx, clientID, &management.Client{

--- a/internal/auth0/client/resource_credentials_schema.go
+++ b/internal/auth0/client/resource_credentials_schema.go
@@ -69,6 +69,7 @@ func NewCredentialsResource() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 				ConflictsWith: []string{
+					"client_secret_wo",
 					"private_key_jwt",
 					"tls_client_auth",
 					"self_signed_tls_client_auth",
@@ -77,7 +78,31 @@ func NewCredentialsResource() *schema.Resource {
 					"authentication method. Keep this private. To access this attribute you need to add either " +
 					"`read:client_keys` or `read:client_credentials` scope to the Terraform client. Otherwise, the attribute will contain an " +
 					"empty string. The attribute will also be an empty string in case `private_key_jwt` is selected " +
-					"as an authentication method.",
+					"as an authentication method. **Note:** For better security, consider using `client_secret_wo` instead.",
+			},
+			"client_secret_wo": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				WriteOnly: true,
+				Sensitive: true,
+				ConflictsWith: []string{
+					"client_secret",
+					"private_key_jwt",
+					"tls_client_auth",
+					"self_signed_tls_client_auth",
+				},
+				RequiredWith: []string{"client_secret_wo_version"},
+				Description: "Secret for the client when using `client_secret_post` or `client_secret_basic` " +
+					"authentication method (write-only). This value is **not** stored in Terraform state. " +
+					"Bump `client_secret_wo_version` to rotate it. Requires Terraform 1.11+.",
+			},
+			"client_secret_wo_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"client_secret_wo"},
+				ValidateFunc: validation.IntAtLeast(1),
+				Description: "Version counter for `client_secret_wo`. Must be a positive integer (starting at `1`). " +
+					"Increment this value to trigger a client secret change when using `client_secret_wo`.",
 			},
 			"private_key_jwt": {
 				Type:     schema.TypeList,

--- a/internal/auth0/client/resource_credentials_test.go
+++ b/internal/auth0/client/resource_credentials_test.go
@@ -849,6 +849,60 @@ func TestAccAllowUpdatingTheClientSecret(t *testing.T) {
 	})
 }
 
+const testAccClientSecretWriteOnlyVersion1 = `
+resource "auth0_client" "my_client" {
+	name     = "Acceptance Test - Client Credentials Write-Only - {{.testName}}"
+	app_type = "non_interactive"
+}
+
+resource "auth0_client_credentials" "test" {
+	client_id                = auth0_client.my_client.id
+	authentication_method    = "client_secret_post"
+	client_secret_wo         = "wo-secret-value-v1-683341"
+	client_secret_wo_version = 1
+}
+`
+
+const testAccClientSecretWriteOnlyVersion2 = `
+resource "auth0_client" "my_client" {
+	name     = "Acceptance Test - Client Credentials Write-Only - {{.testName}}"
+	app_type = "non_interactive"
+}
+
+resource "auth0_client_credentials" "test" {
+	client_id                = auth0_client.my_client.id
+	authentication_method    = "client_secret_post"
+	client_secret_wo         = "wo-secret-value-v2-998877"
+	client_secret_wo_version = 2
+}
+`
+
+func TestAccClientCredentialsWriteOnlySecret(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseTestName(testAccClientSecretWriteOnlyVersion1, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client_credentials.test", "authentication_method", "client_secret_post"),
+					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret_wo_version", "1"),
+					// The write-only secret must never be persisted to state.
+					resource.TestCheckNoResourceAttr("auth0_client_credentials.test", "client_secret_wo"),
+					// The legacy param stays empty on the write-only path.
+					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret", ""),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccClientSecretWriteOnlyVersion2, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("auth0_client_credentials.test", "client_secret_wo"),
+					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret", ""),
+				),
+			},
+		},
+	})
+}
+
 const testAccThrowErrorWhenSignedRequestObjectNoCredentials = `
 resource "auth0_client" "my_client" {
 	name     = "Acceptance Test - Client Credentials - {{.testName}}"

--- a/internal/auth0/client/resource_credentials_test.go
+++ b/internal/auth0/client/resource_credentials_test.go
@@ -858,7 +858,7 @@ resource "auth0_client" "my_client" {
 resource "auth0_client_credentials" "test" {
 	client_id                = auth0_client.my_client.id
 	authentication_method    = "client_secret_post"
-	client_secret_wo         = "wo-secret-value-v1-683341"
+	client_secret_wo         = "wo-secret-value-v1-683341-LUFqPx+sRLjbL7peYRPFmFu-bbvE7u7og4YUNe_C345="
 	client_secret_wo_version = 1
 }
 `
@@ -872,7 +872,7 @@ resource "auth0_client" "my_client" {
 resource "auth0_client_credentials" "test" {
 	client_id                = auth0_client.my_client.id
 	authentication_method    = "client_secret_post"
-	client_secret_wo         = "wo-secret-value-v2-998877"
+	client_secret_wo         = "wo-secret-value-v2-998877-LUFqPx+sRLjbL7peYRPFmFu-bbvE7u7og4YUNe_C345="
 	client_secret_wo_version = 2
 }
 `
@@ -885,10 +885,8 @@ func TestAccClientCredentialsWriteOnlySecret(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "authentication_method", "client_secret_post"),
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret_wo_version", "1"),
-					// The write-only secret must never be persisted to state.
 					resource.TestCheckNoResourceAttr("auth0_client_credentials.test", "client_secret_wo"),
-					// The legacy param stays empty on the write-only path.
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret", ""),
+					resource.TestCheckNoResourceAttr("auth0_client_credentials.test", "client_secret"),
 				),
 			},
 			{
@@ -896,7 +894,7 @@ func TestAccClientCredentialsWriteOnlySecret(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret_wo_version", "2"),
 					resource.TestCheckNoResourceAttr("auth0_client_credentials.test", "client_secret_wo"),
-					resource.TestCheckResourceAttr("auth0_client_credentials.test", "client_secret", ""),
+					resource.TestCheckNoResourceAttr("auth0_client_credentials.test", "client_secret"),
 				),
 			},
 		},

--- a/test/data/recordings/TestAccClientCredentialsWriteOnlySecret.yaml
+++ b/test/data/recordings/TestAccClientCredentialsWriteOnlySecret.yaml
@@ -1,0 +1,645 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 180
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","app_type":"non_interactive","token_endpoint_auth_method":"client_secret_post"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 10.266966291s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 2.788470167s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP?fields=client_id&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 649.117583ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 52
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"token_endpoint_auth_method":"client_secret_post"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 567.88275ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 91
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"client_secret":"wo-secret-value-v1-683341-LUFqPx+sRLjbL7peYRPFmFu-bbvE7u7og4YUNe_C345="}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 780.851958ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 958.143834ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.629187167s
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.776828417s
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 515.859458ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 506.105792ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP?fields=client_id&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 892.065417ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 91
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"client_secret":"wo-secret-value-v2-998877-LUFqPx+sRLjbL7peYRPFmFu-bbvE7u7og4YUNe_C345="}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 507.336833ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 529.077166ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 685.02875ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 609.687209ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP?fields=client_id%2Capp_type&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 862.061542ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP/credentials?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2
+        uncompressed: false
+        body: '[]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.383341916s
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 52
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"token_endpoint_auth_method":"client_secret_post"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials Write-Only - TestAccClientCredentialsWriteOnlySecret","client_id":"5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 387.748916ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.42.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/5s5seDPN8Ru6G04QCwYCRtGGYrDQeiwP
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 378.65425ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds write-only support for `client_secret` on the `auth0_client_credentials` resource. Write-only arguments are sent to Auth0 on apply but never persisted to Terraform state, so the secret no longer sits in plaintext in the state file.

**New fields:**

- `client_secret_wo` — the secret value (write-only, never stored in state).
- `client_secret_wo_version` — a positive integer version counter. Increment it to rotate the secret.

Usage (requires Terraform 1.11+):

```hcl
resource "auth0_client_credentials" "example" {
  client_id             = auth0_client.example.id
  authentication_method = "client_secret_post"

  client_secret_wo         = var.client_secret
  client_secret_wo_version = 1 # bump to rotate
}
```

The existing `client_secret` argument is unchanged and remains fully supported; it conflicts with `client_secret_wo`. On the write-only path the legacy `client_secret` is never written to state.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- Closes #1564 

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Added the `TestAccClientCredentialsWriteOnlySecret` acceptance test, which creates a resource with `client_secret_wo_version = 1`, then rotates to version `2`. It asserts that:
  - `client_secret_wo` is never present in state.
  - `client_secret` is never written to state on the write-only path.
  - `client_secret_wo_version` is persisted and updates on rotation.
- HTTP recordings for the test are included under `test/data/recordings/`.
- Manually verified CRUD and import operations resource with `_wo` param.

To run locally:

```bash
make test-acc TEST_FILTER="TestAccClientCredentialsWriteOnlySecret"
```

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
