### PR TITLE
fix: increase the actions resource http timeout to 6 minutes

### DIFF
--- a/internal/auth0/action/resource.go
+++ b/internal/auth0/action/resource.go
@@ -23,7 +23,7 @@ func NewResource() *schema.Resource {
 		UpdateContext: updateAction,
 		DeleteContext: deleteAction,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(1 * time.Minute),
+			Create: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/internal/auth0/action/resource.go
+++ b/internal/auth0/action/resource.go
@@ -23,7 +23,7 @@ func NewResource() *schema.Resource {
 		UpdateContext: updateAction,
 		DeleteContext: deleteAction,
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(5 * time.Minute),
+			Create: schema.DefaultTimeout(6 * time.Minute),
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,


### PR DESCRIPTION
  ### 🔧 Changes

Increases the default `Create` timeout for the `auth0_action` resource from 1 minute to 6 minutes. 

The increment counts for 5 minutes backend timeout for actions.builder's `build` task and 1 minute is the additional network buffer.

Action build can take longer than 1 minute in some cases (e.g., during building heavy actions). Causing Terraform to report a timeout error even though the action eventually builds successfully but the deployment fails.

This change aligns the Terraform-level timeout with the observed worst-case build time on actions-builder end.


  ### 📝 Checklist

  - [x] All new/changed/fixed functionality is covered by tests (or N/A)
  - [x] I have added documentation for all new/changed functionality (or N/A)