### PR TITLE
feat: Support client session-transfer delegation configuration for Custom Token Exchange (EA only)

### DIFF
--- a/docs/data-sources/client.md
+++ b/docs/data-sources/client.md
@@ -692,9 +692,19 @@ Read-Only:
 - `allow_refresh_token` (Boolean)
 - `allowed_authentication_methods` (Set of String)
 - `can_create_session_transfer_token` (Boolean)
+- `delegation` (List of Object) (see [below for nested schema](#nestedobjatt--session_transfer--delegation))
 - `enforce_cascade_revocation` (Boolean)
 - `enforce_device_binding` (String)
 - `enforce_online_refresh_tokens` (Boolean)
+
+<a id="nestedobjatt--session_transfer--delegation"></a>
+### Nested Schema for `session_transfer.delegation`
+
+Read-Only:
+
+- `allow_delegated_access` (Boolean)
+- `enforce_device_binding` (String)
+
 
 
 <a id="nestedatt--signed_request_object"></a>

--- a/docs/data-sources/clients.md
+++ b/docs/data-sources/clients.md
@@ -166,9 +166,19 @@ Read-Only:
 - `allow_refresh_token` (Boolean)
 - `allowed_authentication_methods` (Set of String)
 - `can_create_session_transfer_token` (Boolean)
+- `delegation` (List of Object) (see [below for nested schema](#nestedobjatt--clients--session_transfer--delegation))
 - `enforce_cascade_revocation` (Boolean)
 - `enforce_device_binding` (String)
 - `enforce_online_refresh_tokens` (Boolean)
+
+<a id="nestedobjatt--clients--session_transfer--delegation"></a>
+### Nested Schema for `clients.session_transfer.delegation`
+
+Read-Only:
+
+- `allow_delegated_access` (Boolean)
+- `enforce_device_binding` (String)
+
 
 
 <a id="nestedobjatt--clients--token_exchange"></a>

--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -738,9 +738,19 @@ Optional:
 - `allow_refresh_token` (Boolean) Indicates whether the application is allowed to use a refresh token when using a session_transfer_token session.
 - `allowed_authentication_methods` (Set of String)
 - `can_create_session_transfer_token` (Boolean) Indicates whether the application(Native app) can use the Token Exchange endpoint to create a session_transfer_token
+- `delegation` (Block List, Max: 1) Configuration for delegation (impersonation) access using Session Transfer Tokens. (EA Only) (see [below for nested schema](#nestedblock--session_transfer--delegation))
 - `enforce_cascade_revocation` (Boolean) Indicates whether revoking the parent Refresh Token that initiated a Native to Web flow and was used to issue a Session Transfer Token should trigger a cascade revocation affecting its dependent child entities. Usually configured in the native application.
 - `enforce_device_binding` (String) Configures the level of device binding enforced when a session_transfer_token is consumed. Can be one of `ip`, `asn` or `none`.
 - `enforce_online_refresh_tokens` (Boolean) Indicates whether Refresh Tokens created during a native-to-web session are tied to that session's lifetime. This determines if such refresh tokens should be automatically revoked when their corresponding sessions are. Usually configured in the web application.
+
+<a id="nestedblock--session_transfer--delegation"></a>
+### Nested Schema for `session_transfer.delegation`
+
+Optional:
+
+- `allow_delegated_access` (Boolean) Indicates whether delegation (impersonation) access is allowed using Session Transfer Tokens. Defaults to `false`. (EA Only)
+- `enforce_device_binding` (String) Indicates the device binding enforcement for delegation (impersonation) access. If set to 'ip', device binding is enforced by IP. If set to 'asn', device binding is enforced by ASN. Defaults to `ip`. (EA Only)
+
 
 
 <a id="nestedblock--token_exchange"></a>

--- a/internal/auth0/client/expand.go
+++ b/internal/auth0/client/expand.go
@@ -1117,6 +1117,17 @@ func expandSessionTransfer(data *schema.ResourceData) *management.SessionTransfe
 		enforceCascadeRevocation := data.Get("session_transfer.0.enforce_cascade_revocation").(bool)
 		sessionTransfer.EnforceCascadeRevocation = auth0.Bool(enforceCascadeRevocation)
 
+		delegationConfig := config.GetAttr("delegation")
+		if !delegationConfig.IsNull() && delegationConfig.LengthInt() > 0 {
+			delegationConfig.ForEachElement(func(_ cty.Value, dCfg cty.Value) (stopInner bool) {
+				sessionTransfer.Delegation = &management.SessionTransferDelegation{
+					AllowDelegatedAccess: value.Bool(dCfg.GetAttr("allow_delegated_access")),
+					EnforceDeviceBinding: value.String(dCfg.GetAttr("enforce_device_binding")),
+				}
+				return stopInner
+			})
+		}
+
 		return stop
 	})
 
@@ -1153,7 +1164,33 @@ func fetchNullableFields(data *schema.ResourceData, client *management.Client) m
 		}
 	}
 
+	// If session_transfer.delegation was removed while session_transfer remains. Clear it via {"session_transfer":{"delegation":null}}.
+	if _, isSessionTransferNull := nullableMap["session_transfer"]; !isSessionTransferNull && isSessionTransferDelegationNull(data) {
+		nullableMap["session_transfer"] = map[string]interface{}{"delegation": nil}
+	}
+
 	return nullableMap
+}
+
+// isSessionTransferDelegationNull reports whether the delegation sub-block was
+// just removed from an otherwise-still-present session_transfer block. That is
+// the only case that needs an explicit "delegation": null in the PATCH body to
+// clear it on the API — see fetchNullableFields.
+func isSessionTransferDelegationNull(data *schema.ResourceData) bool {
+	sessionTransfer := data.GetRawConfig().GetAttr("session_transfer")
+	if sessionTransfer.IsNull() && !data.HasChange("session_transfer.0.delegation") {
+		return false
+	}
+
+	delegationExist := false
+	sessionTransfer.ForEachElement(func(_ cty.Value, cfg cty.Value) (stop bool) {
+		delegation := cfg.GetAttr("delegation")
+		if !delegation.IsNull() && delegation.LengthInt() > 0 {
+			delegationExist = true
+		}
+		return stop
+	})
+	return !delegationExist
 }
 
 func isDefaultOrgNull(data *schema.ResourceData) bool {
@@ -1233,10 +1270,12 @@ func isSessionTransferNull(data *schema.ResourceData) bool {
 		canCreate := cfg.GetAttr("can_create_session_transfer_token")
 		enforceBinding := cfg.GetAttr("enforce_device_binding")
 		allowedMethods := cfg.GetAttr("allowed_authentication_methods")
+		delegation := cfg.GetAttr("delegation")
 
 		if (!canCreate.IsNull() && canCreate.True()) ||
 			(!enforceBinding.IsNull() && enforceBinding.AsString() != "") ||
-			(!allowedMethods.IsNull() && allowedMethods.LengthInt() > 0) {
+			(!allowedMethods.IsNull() && allowedMethods.LengthInt() > 0) ||
+			(!delegation.IsNull() && delegation.LengthInt() > 0) {
 			empty = false
 		}
 

--- a/internal/auth0/client/expand.go
+++ b/internal/auth0/client/expand.go
@@ -1173,12 +1173,10 @@ func fetchNullableFields(data *schema.ResourceData, client *management.Client) m
 }
 
 // isSessionTransferDelegationNull reports whether the delegation sub-block was
-// just removed from an otherwise-still-present session_transfer block. That is
-// the only case that needs an explicit "delegation": null in the PATCH body to
-// clear it on the API — see fetchNullableFields.
+// just removed from an otherwise-still-present session_transfer block.
 func isSessionTransferDelegationNull(data *schema.ResourceData) bool {
 	sessionTransfer := data.GetRawConfig().GetAttr("session_transfer")
-	if sessionTransfer.IsNull() && !data.HasChange("session_transfer.0.delegation") {
+	if sessionTransfer.IsNull() || !data.HasChange("session_transfer.0.delegation") {
 		return false
 	}
 

--- a/internal/auth0/client/flatten.go
+++ b/internal/auth0/client/flatten.go
@@ -738,10 +738,24 @@ func flattenSessionTransfer(sessionTransfer *management.SessionTransfer) []inter
 		"allow_refresh_token":               sessionTransfer.GetAllowRefreshToken(),
 		"enforce_online_refresh_tokens":     sessionTransfer.GetEnforceOnlineRefreshTokens(),
 		"enforce_cascade_revocation":        sessionTransfer.GetEnforceCascadeRevocation(),
+		"delegation":                        flattenSessionTransferDelegation(sessionTransfer.GetDelegation()),
 	}
 
 	return []interface{}{
 		t,
+	}
+}
+
+func flattenSessionTransferDelegation(delegation *management.SessionTransferDelegation) []interface{} {
+	if delegation == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"allow_delegated_access": delegation.GetAllowDelegatedAccess(),
+			"enforce_device_binding": delegation.GetEnforceDeviceBinding(),
+		},
 	}
 }
 

--- a/internal/auth0/client/resource.go
+++ b/internal/auth0/client/resource.go
@@ -1607,6 +1607,29 @@ func NewResource() *schema.Resource {
 							Default:     true,
 							Description: "Indicates whether Refresh Tokens created during a native-to-web session are tied to that session's lifetime. This determines if such refresh tokens should be automatically revoked when their corresponding sessions are. Usually configured in the web application.",
 						},
+						"delegation": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    1,
+							Description: "Configuration for delegation (impersonation) access using Session Transfer Tokens. (EA Only)",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"allow_delegated_access": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Computed:    true,
+										Description: "Indicates whether delegation (impersonation) access is allowed using Session Transfer Tokens. Defaults to `false`. (EA Only)",
+									},
+									"enforce_device_binding": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Computed:     true,
+										ValidateFunc: validation.StringInSlice([]string{"ip", "asn"}, false),
+										Description:  "Indicates the device binding enforcement for delegation (impersonation) access. If set to 'ip', device binding is enforced by IP. If set to 'asn', device binding is enforced by ASN. Defaults to `ip`. (EA Only)",
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/auth0/client/resource_test.go
+++ b/internal/auth0/client/resource_test.go
@@ -2746,6 +2746,44 @@ resource "auth0_client" "my_client" {
 }
 `
 
+const testAccClientSessionTransferDelegation = `
+resource "auth0_client" "my_client" {
+	name      = "Acceptance Test - Session Transfer - {{.testName}}"
+	app_type  = "native"
+	session_transfer {
+		can_create_session_transfer_token = true
+		delegation {
+			allow_delegated_access = true
+			enforce_device_binding = "asn"
+		}
+	}
+}
+`
+
+const testAccClientSessionTransferDelegationUpdate = `
+resource "auth0_client" "my_client" {
+	name      = "Acceptance Test - Session Transfer - {{.testName}}"
+	app_type  = "native"
+	session_transfer {
+		can_create_session_transfer_token = true
+		delegation {
+			allow_delegated_access = false
+			enforce_device_binding = "ip"
+		}
+	}
+}
+`
+
+const testAccClientSessionTransferDelegationRemoved = `
+resource "auth0_client" "my_client" {
+	name      = "Acceptance Test - Session Transfer - {{.testName}}"
+	app_type  = "native"
+	session_transfer {
+		can_create_session_transfer_token = true
+	}
+}
+`
+
 func TestAccClientSessionTransfer(t *testing.T) {
 	acctest.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
@@ -2810,6 +2848,55 @@ func TestAccClientSessionTransfer(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.allow_refresh_token", "false"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.enforce_online_refresh_tokens", "false"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.enforce_cascade_revocation", "false"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccClientSessionTransferDelegation, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.delegation.0.allow_delegated_access", "true"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.delegation.0.enforce_device_binding", "asn"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccClientSessionTransferDelegationUpdate, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.delegation.0.allow_delegated_access", "false"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.delegation.0.enforce_device_binding", "ip"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccClientSessionTransferDelegation, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					// Re-establish delegation so the next two steps exercise removal.
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.delegation.0.allow_delegated_access", "true"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.delegation.0.enforce_device_binding", "asn"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccClientSessionTransferDelegationRemoved, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					// Removing only the delegation block while keeping session_transfer
+					// sends an explicit {session_transfer:{delegation:null}} PATCH,
+					// clearing delegation on the API while siblings persist.
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.can_create_session_transfer_token", "true"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.delegation.#", "0"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccClientSessionTransferDelegation, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					// Set delegation again, then remove the whole session_transfer block
+					// in the next step to verify the block (with delegation) is cleared.
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.0.delegation.0.allow_delegated_access", "true"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccUpdateClientWithSessionTransfer3, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					// Removing the entire session_transfer block (which contained a
+					// delegation sub-block) is handled by isSessionTransferNull; the
+					// delegation-null guard must not double-fire. The whole block goes.
+					resource.TestCheckResourceAttr("auth0_client.my_client", "session_transfer.#", "0"),
 				),
 			},
 		},

--- a/test/data/recordings/TestAccClientSessionTransfer.yaml
+++ b/test/data/recordings/TestAccClientSessionTransfer.yaml
@@ -19,7 +19,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.32.1
+                - Go-Auth0/1.43.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients
         method: POST
       response:
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"ip","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"ip","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 490.606542ms
+        duration: 465.402792ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -52,8 +52,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: GET
       response:
         proto: HTTP/2.0
@@ -63,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"ip","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"ip","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 328.626375ms
+        duration: 311.216291ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -85,8 +85,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: GET
       response:
         proto: HTTP/2.0
@@ -96,13 +96,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"ip","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"ip","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 383.481083ms
+        duration: 573.877958ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -118,8 +118,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: GET
       response:
         proto: HTTP/2.0
@@ -129,14 +129,50 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"ip","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"ip","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.229291ms
+        duration: 353.6045ms
     - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 41
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"session_transfer":{"delegation":null}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"ip","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 349.540084ms
+    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -154,8 +190,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -165,46 +201,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"asn","allow_refresh_token":true,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"asn","allow_refresh_token":true,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.113458ms
-    - id: 5
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"asn","allow_refresh_token":true,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 320.68025ms
+        duration: 398.61475ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -220,8 +223,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: GET
       response:
         proto: HTTP/2.0
@@ -231,13 +234,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"asn","allow_refresh_token":true,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"asn","allow_refresh_token":true,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 457.679875ms
+        duration: 335.0575ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -253,8 +256,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: GET
       response:
         proto: HTTP/2.0
@@ -264,14 +267,83 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"asn","allow_refresh_token":true,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"asn","allow_refresh_token":true,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.405209ms
+        duration: 295.635959ms
     - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"asn","allow_refresh_token":true,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 307.336375ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 41
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"session_transfer":{"delegation":null}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["cookie","query"],"enforce_device_binding":"asn","allow_refresh_token":true,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 349.949666ms
+    - id: 10
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -289,8 +361,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -300,79 +372,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 459.239792ms
-    - id: 9
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 341.646917ms
-    - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 675.369042ms
+        duration: 304.458916ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -388,8 +394,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: GET
       response:
         proto: HTTP/2.0
@@ -399,14 +405,116 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.575125ms
+        duration: 304.981375ms
     - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 278.437917ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 310.560083ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 41
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"session_transfer":{"delegation":null}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 307.873834ms
+    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -424,8 +532,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -435,113 +543,113 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["query"],"enforce_device_binding":"ip","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["query"],"enforce_device_binding":"ip","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.1905ms
-    - id: 13
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["query"],"enforce_device_binding":"ip","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 421.800666ms
-    - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["query"],"enforce_device_binding":"ip","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 383.626375ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["query"],"enforce_device_binding":"ip","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 322.260083ms
+        duration: 296.441667ms
     - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["query"],"enforce_device_binding":"ip","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 301.372333ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["query"],"enforce_device_binding":"ip","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 294.611917ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":["query"],"enforce_device_binding":"ip","allow_refresh_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 354.966542ms
+    - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -559,8 +667,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -570,14 +678,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.161709ms
-    - id: 17
+        duration: 299.982917ms
+    - id: 20
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -595,8 +703,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -606,113 +714,149 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.977375ms
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 329.14225ms
-    - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 452.733458ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 316.712584ms
+        duration: 291.054458ms
     - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 305.016292ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 375.714833ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 369.598083ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 41
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"session_transfer":{"delegation":null}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"ip","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 391.398ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -730,8 +874,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -741,14 +885,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 364.602334ms
-    - id: 22
+        duration: 323.417583ms
+    - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -763,8 +907,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: GET
       response:
         proto: HTTP/2.0
@@ -774,14 +918,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.715458ms
-    - id: 23
+        duration: 298.851334ms
+    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -796,8 +940,8 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: GET
       response:
         proto: HTTP/2.0
@@ -807,14 +951,14 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.479583ms
-    - id: 24
+        duration: 298.30175ms
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -829,8 +973,890 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.32.1
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/7uAKaZhxANTCeR9E1MX6mdukPtbmlgzv
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":false,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":false,"enforce_cascade_revocation":false}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 293.959042ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 306
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","app_type":"native","session_transfer":{"can_create_session_transfer_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 394.920125ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 284.851125ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 278.491041ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 280.452209ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 306
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","app_type":"native","session_transfer":{"can_create_session_transfer_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":false,"enforce_device_binding":"ip"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":false,"enforce_device_binding":"ip"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 298.527667ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":false,"enforce_device_binding":"ip"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 275.386666ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":false,"enforce_device_binding":"ip"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 303.791375ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":false,"enforce_device_binding":"ip"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 291.706875ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 306
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","app_type":"native","session_transfer":{"can_create_session_transfer_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 394.339625ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 289.450875ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 294.848792ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 349.107ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 41
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"session_transfer":{"delegation":null}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 316.607916ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 230
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","app_type":"native","session_transfer":{"can_create_session_transfer_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 382.504875ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 364.061333ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 385.500375ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 362.330209ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 306
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","app_type":"native","session_transfer":{"can_create_session_transfer_token":true,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 391.474792ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 292.478ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 284.037667ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000},"session_transfer":{"can_create_session_transfer_token":true,"allowed_authentication_methods":[],"enforce_device_binding":"none","allow_refresh_token":false,"enforce_online_refresh_tokens":true,"enforce_cascade_revocation":true,"delegation":{"allow_delegated_access":true,"enforce_device_binding":"asn"}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 360.473333ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 26
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"session_transfer":null}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 310.68425ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 97
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","app_type":"native"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 310.535083ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 367.642834ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Session Transfer - TestAccClientSessionTransfer","client_id":"irF93GhcxfjvJkWWky8MNnQAtDJGTEEm","client_secret":"[REDACTED]","app_type":"native","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token"],"custom_login_page_on":true,"token_endpoint_auth_method":"none","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":2592000,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":1296000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 291.270333ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.43.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/irF93GhcxfjvJkWWky8MNnQAtDJGTEEm
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -846,4 +1872,4 @@ interactions:
                 - application/json; charset=utf-8
         status: 204 No Content
         code: 204
-        duration: 406.083584ms
+        duration: 325.626459ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds support for the new `session_transfer.delegation` settings on `auth0_client`, enabling Custom Token Exchange, Impersonation via Session Transfer.

Adds a nested `delegation` block inside the existing `session_transfer` block, with two attributes:

- `allow_delegated_access` (bool) — allows the client to accept Session Transfer Tokens containing an Actor. Defaults to `false`.
- `enforce_device_binding` (string) — device binding enforcement for impersonation sessions. One of `ip` or `asn`. Defaults to `ip`.

Usage:

```hcl
resource "auth0_client" "my_client" {
  name     = "My App"
  session_transfer {
    delegation {
      allow_delegated_access = true
      enforce_device_binding = "asn"
    }
  }
}
```

Notes:

- The `delegation` block and both attributes are also exposed on the `auth0_client` and `auth0_clients` data sources.
- Unlike `session_transfer.enforce_device_binding`, the delegation-level `enforce_device_binding` accepts only `ip` or `asn` (not `none`), matching the Management API.
- Removing the `delegation` block clears it on the API (an explicit null is sent) while leaving the surrounding `session_transfer` settings intact.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- SDK v1 PR: https://github.com/auth0/go-auth0/pull/803

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Extends the `TestAccClientSessionTransfer` acceptance test with steps that set, update, and remove the `delegation` block, plus a step that removes the entire `session_transfer` block while it contains a delegation sub-block.
- HTTP recordings for `TestAccClientSessionTransfer` were re-recorded against a tenant with the `cte_session_transfer_token` feature flag enabled.
- Manually verified CRUD operation of `delegation` block and its attributes.
- Verified config generation of client with/without `delegation`.

To run locally:

```bash
# Re-record against a real tenant (requires the cte_session_transfer_token flag)
make test-acc-record FILTER="TestAccClientSessionTransfer"
```

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
