### PR TITLE
fix: prevent spurious diffs from redacted secrets in connection and log stream resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+BUG FIXES:
+- `resource/auth0_connection` – Prevent spurious diffs on `options.client_secret` caused by Auth0 API returning a redacted empty value; provider now preserves the value already in state ([#PLACEHOLDER](https://github.com/auth0/terraform-provider-auth0/pull/PLACEHOLDER))
+- `resource/auth0_log_stream` – Prevent spurious diffs on `sink.http_authorization` caused by Auth0 API returning a redacted empty value; provider now preserves the value already in state ([#PLACEHOLDER](https://github.com/auth0/terraform-provider-auth0/pull/PLACEHOLDER))
+
 ## v1.50.0
 
 ENHANCEMENTS:

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -155,7 +155,7 @@ func flattenConnectionOptions(data *schema.ResourceData, connection *management.
 }
 
 func flattenConnectionOptionsGitHub(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsGitHub)
@@ -170,7 +170,7 @@ func flattenConnectionOptionsGitHub(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                options.GetClientID(),
-		"client_secret":            options.GetClientSecret(),
+		"client_secret":            data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"set_user_root_attributes": options.GetSetUserAttributes(),
 		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
 		"scopes":                   options.Scopes(),
@@ -181,7 +181,7 @@ func flattenConnectionOptionsGitHub(
 }
 
 func flattenConnectionOptionsWindowsLive(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsWindowsLive)
@@ -196,7 +196,7 @@ func flattenConnectionOptionsWindowsLive(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                options.GetClientID(),
-		"client_secret":            options.GetClientSecret(),
+		"client_secret":            data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"scopes":                   options.Scopes(),
 		"set_user_root_attributes": options.GetSetUserAttributes(),
 		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
@@ -548,7 +548,7 @@ func flattenConnectionOptionsAuth0(
 }
 
 func flattenConnectionOptionsGoogleOAuth2(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsGoogleOAuth2)
@@ -563,7 +563,7 @@ func flattenConnectionOptionsGoogleOAuth2(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                options.GetClientID(),
-		"client_secret":            options.GetClientSecret(),
+		"client_secret":            data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"allowed_audiences":        options.GetAllowedAudiences(),
 		"scopes":                   options.Scopes(),
 		"set_user_root_attributes": options.GetSetUserAttributes(),
@@ -575,7 +575,7 @@ func flattenConnectionOptionsGoogleOAuth2(
 }
 
 func flattenConnectionOptionsGoogleApps(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsGoogleApps)
@@ -590,7 +590,7 @@ func flattenConnectionOptionsGoogleApps(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                options.GetClientID(),
-		"client_secret":            options.GetClientSecret(),
+		"client_secret":            data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"domain":                   options.GetDomain(),
 		"tenant_domain":            options.GetTenantDomain(),
 		"api_enable_users":         options.GetEnableUsersAPI(),
@@ -612,7 +612,7 @@ func flattenConnectionOptionsGoogleApps(
 }
 
 func flattenConnectionOptionsOAuth2(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsOAuth2)
@@ -627,7 +627,7 @@ func flattenConnectionOptionsOAuth2(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                options.GetClientID(),
-		"client_secret":            options.GetClientSecret(),
+		"client_secret":            data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"scopes":                   options.Scopes(),
 		"token_endpoint":           options.GetTokenURL(),
 		"authorization_endpoint":   options.GetAuthorizationURL(),
@@ -661,7 +661,7 @@ func flattenCustomHeaders(headers map[string]string) []map[string]string {
 }
 
 func flattenConnectionOptionsFacebook(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsFacebook)
@@ -676,7 +676,7 @@ func flattenConnectionOptionsFacebook(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                options.GetClientID(),
-		"client_secret":            options.GetClientSecret(),
+		"client_secret":            data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"scopes":                   options.Scopes(),
 		"set_user_root_attributes": options.GetSetUserAttributes(),
 		"non_persistent_attrs":     options.GetNonPersistentAttrs(),
@@ -687,7 +687,7 @@ func flattenConnectionOptionsFacebook(
 }
 
 func flattenConnectionOptionsApple(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsApple)
@@ -702,7 +702,7 @@ func flattenConnectionOptionsApple(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                options.GetClientID(),
-		"client_secret":            options.GetClientSecret(),
+		"client_secret":            data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"team_id":                  options.GetTeamID(),
 		"key_id":                   options.GetKeyID(),
 		"scopes":                   options.Scopes(),
@@ -715,7 +715,7 @@ func flattenConnectionOptionsApple(
 }
 
 func flattenConnectionOptionsLinkedin(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsLinkedin)
@@ -730,7 +730,7 @@ func flattenConnectionOptionsLinkedin(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                options.GetClientID(),
-		"client_secret":            options.GetClientSecret(),
+		"client_secret":            data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"strategy_version":         options.GetStrategyVersion(),
 		"scopes":                   options.Scopes(),
 		"set_user_root_attributes": options.GetSetUserAttributes(),
@@ -742,7 +742,7 @@ func flattenConnectionOptionsLinkedin(
 }
 
 func flattenConnectionOptionsSalesforce(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsSalesforce)
@@ -757,7 +757,7 @@ func flattenConnectionOptionsSalesforce(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                options.GetClientID(),
-		"client_secret":            options.GetClientSecret(),
+		"client_secret":            data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"community_base_url":       options.GetCommunityBaseURL(),
 		"scopes":                   options.Scopes(),
 		"set_user_root_attributes": options.GetSetUserAttributes(),
@@ -823,7 +823,7 @@ func flattenConnectionOptionsSMS(
 }
 
 func flattenConnectionOptionsOIDC(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsOIDC)
@@ -838,7 +838,7 @@ func flattenConnectionOptionsOIDC(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                       options.GetClientID(),
-		"client_secret":                   options.GetClientSecret(),
+		"client_secret":                   data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"icon_url":                        options.GetLogoURL(),
 		"tenant_domain":                   options.GetTenantDomain(),
 		"domain_aliases":                  options.GetDomainAliases(),
@@ -896,7 +896,7 @@ func flattenConnectionOptionsOIDC(
 }
 
 func flattenConnectionOptionsOkta(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsOkta)
@@ -911,7 +911,7 @@ func flattenConnectionOptionsOkta(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                       options.GetClientID(),
-		"client_secret":                   options.GetClientSecret(),
+		"client_secret":                   data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"domain":                          options.GetDomain(),
 		"domain_aliases":                  options.GetDomainAliases(),
 		"scopes":                          options.Scopes(),
@@ -1048,7 +1048,7 @@ func flattenConnectionOptionsAD(
 }
 
 func flattenConnectionOptionsAzureAD(
-	_ *schema.ResourceData,
+	data *schema.ResourceData,
 	rawOptions interface{},
 ) (interface{}, diag.Diagnostics) {
 	options, ok := rawOptions.(*management.ConnectionOptionsAzureAD)
@@ -1063,7 +1063,7 @@ func flattenConnectionOptionsAzureAD(
 
 	optionsMap := map[string]interface{}{
 		"client_id":                              options.GetClientID(),
-		"client_secret":                          options.GetClientSecret(),
+		"client_secret":                          data.Get("options.0.client_secret").(string), // Value does not get read back.
 		"app_id":                                 options.GetAppID(),
 		"tenant_domain":                          options.GetTenantDomain(),
 		"domain":                                 options.GetDomain(),

--- a/internal/auth0/connection/flatten_test.go
+++ b/internal/auth0/connection/flatten_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestFlattenConnectionOptions(t *testing.T) {
@@ -50,3 +51,65 @@ func TestFlattenConnectionOptionsEmail(t *testing.T) {
 		t.Errorf("Expected no diagnostic warnings, got %v", diags)
 	}
 }
+
+// newResourceDataWithSecret builds a *schema.ResourceData whose
+// options.0.client_secret is pre-populated with priorSecret.
+func newResourceDataWithSecret(t *testing.T, priorSecret string) *schema.ResourceData {
+	t.Helper()
+	d := schema.TestResourceDataRaw(t, NewResource().Schema, map[string]interface{}{})
+	if err := d.Set("options", []interface{}{
+		map[string]interface{}{"client_secret": priorSecret},
+	}); err != nil {
+		t.Fatalf("failed to set options: %v", err)
+	}
+	return d
+}
+
+// TestFlattenConnectionOptionsOAuth2_ClientSecretFallback verifies that the
+// API response's redacted/empty client_secret is replaced by the value
+// already stored in state, preventing spurious diffs.
+func TestFlattenConnectionOptionsOAuth2_ClientSecretFallback(t *testing.T) {
+	priorSecret := "stored-oauth2-secret"
+	d := newResourceDataWithSecret(t, priorSecret)
+
+	rawResult, diags := flattenConnectionOptionsOAuth2(d, &management.ConnectionOptionsOAuth2{
+		// Auth0 API returns an empty string for secrets after creation.
+		ClientSecret: nil,
+	})
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	m, ok := rawResult.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map[string]interface{}, got %T", rawResult)
+	}
+
+	if got := m["client_secret"]; got != priorSecret {
+		t.Errorf("client_secret = %q, want %q", got, priorSecret)
+	}
+}
+
+// TestFlattenConnectionOptionsGitHub_ClientSecretFallback performs the same
+// check for the GitHub connection strategy.
+func TestFlattenConnectionOptionsGitHub_ClientSecretFallback(t *testing.T) {
+	priorSecret := "stored-github-secret"
+	d := newResourceDataWithSecret(t, priorSecret)
+
+	rawResult, diags := flattenConnectionOptionsGitHub(d, &management.ConnectionOptionsGitHub{
+		ClientSecret: nil,
+	})
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	m, ok := rawResult.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map[string]interface{}, got %T", rawResult)
+	}
+
+	if got := m["client_secret"]; got != priorSecret {
+		t.Errorf("client_secret = %q, want %q", got, priorSecret)
+	}
+}
+

--- a/internal/auth0/connection/flatten_test.go
+++ b/internal/auth0/connection/flatten_test.go
@@ -112,4 +112,3 @@ func TestFlattenConnectionOptionsGitHub_ClientSecretFallback(t *testing.T) {
 		t.Errorf("client_secret = %q, want %q", got, priorSecret)
 	}
 }
-

--- a/internal/auth0/logstream/flatten.go
+++ b/internal/auth0/logstream/flatten.go
@@ -44,7 +44,7 @@ func flattenLogStreamSink(data *schema.ResourceData, sink interface{}) []interfa
 	case *management.LogStreamSinkAzureEventGrid:
 		m = flattenLogStreamSinkAzureEventGrid(sinkType)
 	case *management.LogStreamSinkHTTP:
-		m = flattenLogStreamSinkHTTP(sinkType)
+		m = flattenLogStreamSinkHTTP(data, sinkType)
 	case *management.LogStreamSinkDatadog:
 		m = flattenLogStreamSinkDatadog(data, sinkType)
 	case *management.LogStreamSinkSplunk:
@@ -77,12 +77,12 @@ func flattenLogStreamSinkAzureEventGrid(o *management.LogStreamSinkAzureEventGri
 	}
 }
 
-func flattenLogStreamSinkHTTP(o *management.LogStreamSinkHTTP) interface{} {
+func flattenLogStreamSinkHTTP(data *schema.ResourceData, o *management.LogStreamSinkHTTP) interface{} {
 	return map[string]interface{}{
 		"http_endpoint":       o.GetEndpoint(),
 		"http_content_format": o.GetContentFormat(),
 		"http_content_type":   o.GetContentType(),
-		"http_authorization":  o.GetAuthorization(),
+		"http_authorization":  data.Get("sink.0.http_authorization").(string), // Value does not get read back.
 		"http_custom_headers": o.CustomHeaders,
 	}
 }


### PR DESCRIPTION
### 🔧 Changes

Auth0's management API returns an empty string for write-only secret fields after a resource has been created (`options.client_secret` on connections, `sink.http_authorization` on HTTP log streams). When the provider reads those empty values back into state it replaces the original secret, causing a non-empty diff on every subsequent `terraform plan`.

**`internal/auth0/connection/flatten.go`**

In all 12 connection flatten functions that handle `client_secret` (strategies: `github`, `windows_live`, `google-oauth2`, `google-apps`, `oauth2`, `facebook`, `apple`, `linkedin`, `salesforce`, `oidc`, `okta`, `ad`), replace:
```go
"client_secret": options.GetClientSecret(),
```
with:
```go
"client_secret": data.Get("options.0.client_secret").(string), // Value does not get read back.
```
Function signatures updated from `_ *schema.ResourceData` to `data *schema.ResourceData` accordingly.

**`internal/auth0/logstream/flatten.go`**

In `flattenLogStreamSinkHTTP`, replace:
```go
"http_authorization": o.GetAuthorization(),
```
with:
```go
"http_authorization": data.Get("sink.0.http_authorization").(string), // Value does not get read back.
```
The function gains a `data *schema.ResourceData` parameter; the call site in `flattenLogStreamSink` is updated.

This mirrors the existing pattern already used for `options.metadata_xml` in `flattenConnectionOptionsSAML`, `sink.datadog_api_key` in `flattenLogStreamSinkDatadog`, and `sink.mixpanel_service_account_password` in `flattenLogStreamSinkMixpanel`.

Note: import-time behaviour (no prior state) is out of scope and tracked separately in #1415.

### 📚 References

Fixes #1620

### 🔬 Testing

Two new unit tests added to `internal/auth0/connection/flatten_test.go`:
- `TestFlattenConnectionOptionsOAuth2_ClientSecretFallback` – verifies that a nil `ClientSecret` in the API response is replaced by the value already in state.
- `TestFlattenConnectionOptionsGitHub_ClientSecretFallback` – same check for the GitHub strategy.

```
$ go test ./internal/auth0/connection/ -run TestFlattenConnection -v
=== RUN   TestFlattenConnectionOptions
--- PASS: TestFlattenConnectionOptions (0.00s)
=== RUN   TestFlattenConnectionOptionsEmail
--- PASS: TestFlattenConnectionOptionsEmail (0.00s)
=== RUN   TestFlattenConnectionOptionsOAuth2_ClientSecretFallback
--- PASS: TestFlattenConnectionOptionsOAuth2_ClientSecretFallback (0.00s)
=== RUN   TestFlattenConnectionOptionsGitHub_ClientSecretFallback
--- PASS: TestFlattenConnectionOptionsGitHub_ClientSecretFallback (0.00s)
PASS
ok      github.com/auth0/terraform-provider-auth0/internal/auth0/connection     0.852s
```

Acceptance tests require a live Auth0 tenant and cannot be run in CI without credentials, but the fix can be manually verified by:
1. Creating an `auth0_connection` or `auth0_log_stream` with a secret field set.
2. Running `terraform plan` after the initial apply — the plan should show no changes.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
