### PR TITLE
fix: Prevent state drift for api_behavior and signup_behavior in connection password authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ ENHANCEMENTS:
 - `resource/auth0_client` – Add support for configuring `invitation_landing_client_id` in the My Organization API ([#1609](https://github.com/auth0/terraform-provider-auth0/pull/1609))
 - `resource/auth0_client_credentials` – Add support for the PKCS#1 (`RSA PUBLIC KEY`) public key format when computing JWK thumbprints ([#1608](https://github.com/auth0/terraform-provider-auth0/pull/1608))
 
+BUG FIXES:
+- `resource/auth0_connection` – Prevent state drift for `api_behavior` and `signup_behavior` in the password authentication method when the Auth0 API omits these fields, returning server-side defaults ([#1621](https://github.com/auth0/terraform-provider-auth0/pull/1621))
+
 ## v1.49.0
 
 ENHANCEMENTS:

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -358,11 +358,21 @@ func flattenAuthenticationMethodPassword(passwordAuthenticationMethod *managemen
 		return nil
 	}
 
+	apiBehavior := passwordAuthenticationMethod.GetAPIBehavior()
+	if apiBehavior == "" {
+		apiBehavior = "required"
+	}
+
+	signupBehavior := passwordAuthenticationMethod.GetSignupBehavior()
+	if signupBehavior == "" {
+		signupBehavior = "allow"
+	}
+
 	return []map[string]interface{}{
 		{
 			"enabled":         passwordAuthenticationMethod.GetEnabled(),
-			"api_behavior":    passwordAuthenticationMethod.GetAPIBehavior(),
-			"signup_behavior": passwordAuthenticationMethod.GetSignupBehavior(),
+			"api_behavior":    apiBehavior,
+			"signup_behavior": signupBehavior,
 		},
 	}
 }

--- a/internal/auth0/connection/flatten_test.go
+++ b/internal/auth0/connection/flatten_test.go
@@ -50,3 +50,53 @@ func TestFlattenConnectionOptionsEmail(t *testing.T) {
 		t.Errorf("Expected no diagnostic warnings, got %v", diags)
 	}
 }
+
+func TestFlattenAuthenticationMethodPassword(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		result := flattenAuthenticationMethodPassword(nil)
+		if result != nil {
+			t.Errorf("Expected nil for nil input, got %v", result)
+		}
+	})
+
+	t.Run("fields explicitly set are echoed back unchanged", func(t *testing.T) {
+		apiBehavior := "optional"
+		signupBehavior := "block"
+		enabled := true
+
+		result := flattenAuthenticationMethodPassword(&management.PasswordAuthenticationMethod{
+			Enabled:        &enabled,
+			APIBehavior:    &apiBehavior,
+			SignupBehavior: &signupBehavior,
+		})
+
+		m := result.([]map[string]interface{})[0]
+		if m["api_behavior"] != "optional" {
+			t.Errorf("Expected api_behavior=optional, got %q", m["api_behavior"])
+		}
+		if m["signup_behavior"] != "block" {
+			t.Errorf("Expected signup_behavior=block, got %q", m["signup_behavior"])
+		}
+		if m["enabled"] != true {
+			t.Errorf("Expected enabled=true, got %v", m["enabled"])
+		}
+	})
+
+	t.Run("api_behavior defaults to required when API omits the field", func(t *testing.T) {
+		result := flattenAuthenticationMethodPassword(&management.PasswordAuthenticationMethod{})
+
+		m := result.([]map[string]interface{})[0]
+		if m["api_behavior"] != "required" {
+			t.Errorf("Expected api_behavior default=required, got %q", m["api_behavior"])
+		}
+	})
+
+	t.Run("signup_behavior defaults to allow when API omits the field", func(t *testing.T) {
+		result := flattenAuthenticationMethodPassword(&management.PasswordAuthenticationMethod{})
+
+		m := result.([]map[string]interface{})[0]
+		if m["signup_behavior"] != "allow" {
+			t.Errorf("Expected signup_behavior default=allow, got %q", m["signup_behavior"])
+		}
+	})
+}


### PR DESCRIPTION
### 🔧 Changes

When the Auth0 API omits `api_behavior` or `signup_behavior` from the password authentication method response (relying on server-side defaults), `flattenAuthenticationMethodPassword` was writing an empty string `""` into Terraform state. Since the schema declares `Default: "required"` and `Default: "allow"` respectively, this caused a perpetual plan diff — Terraform would see `""` from state vs. the schema default, producing a non-empty plan on every run without any actual configuration change.
The fix applies the same default substitution pattern used for `auth0_tenant` (#1587): if the API returns an empty string for either field, the corresponding schema default is substituted before writing to state.

### 📚 References

Closes #1621

### 🔬 Testing

`TestFlattenAuthenticationMethodPassword` in `internal/auth0/connection/flatten_test.go `covers: nil input, explicitly-set values echoed unchanged, and each default fallback independently. Run with `make test-unit`.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
