### PR TITLE
fix: redirection url nullable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,7 @@
 
 BREAKING CHANGES:
 
-* `auth0_tenant`: The `default_redirection_uri` field is no longer `Computed`. Users who
-  omit this field from their configuration but have a non-empty value set on the remote
-  tenant will see a plan diff on the next `terraform plan`. To prevent an unintended clear,
-  explicitly add `default_redirection_uri = "<current value>"` to your configuration before
-  upgrading.
+* `auth0_tenant`: The `default_redirection_uri` field is no longer `Computed`. Users who omit this field from their configuration but have a non-empty value set on the remote tenant will see a plan diff on the next `terraform plan`. To prevent an unintended clear, explicitly add `default_redirection_uri = "<current value>"` to your configuration before upgrading.
 
 ## v1.51.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+BREAKING CHANGES:
+
+* `auth0_tenant`: The `default_redirection_uri` field is no longer `Computed`. Users who
+  omit this field from their configuration but have a non-empty value set on the remote
+  tenant will see a plan diff on the next `terraform plan`. To prevent an unintended clear,
+  explicitly add `default_redirection_uri = "<current value>"` to your configuration before
+  upgrading.
+
 ## v1.51.0
 
 ENHANCEMENTS:

--- a/internal/auth0/tenant/expand.go
+++ b/internal/auth0/tenant/expand.go
@@ -272,46 +272,25 @@ func expandDefaultTokenQuota(data *schema.ResourceData) *management.TenantDefaul
 }
 
 func fetchNullableFields(data *schema.ResourceData) map[string]interface{} {
-	type nullCheckFunc func(*schema.ResourceData) (bool, interface{})
+	type nullCheckFunc func(*schema.ResourceData) bool
 
 	checks := map[string]nullCheckFunc{
-		"default_token_quota": func(d *schema.ResourceData) (bool, interface{}) {
-			return isDefaultTokenQuotaNull(d), nil
-		},
-		"acr_values_supported": func(d *schema.ResourceData) (bool, interface{}) {
-			return isACRValuesSupportedNull(d), nil
-		},
-		"mtls": func(d *schema.ResourceData) (bool, interface{}) {
-			return isMTLSConfigurationNull(d), nil
-		},
-		"error_page": func(d *schema.ResourceData) (bool, interface{}) {
-			return isErrorPageConfigurationNull(d), nil
-		},
-		"skip_non_verifiable_callback_uri_confirmation_prompt": func(d *schema.ResourceData) (bool, interface{}) {
-			return isSkipNonVerifiableCallbackURIConfirmationPromptNull(d), nil
-		},
-		"default_redirection_uri": func(d *schema.ResourceData) (bool, interface{}) {
-			return isDefaultRedirectionURINull(d), ""
-		},
+		"default_token_quota":  isDefaultTokenQuotaNull,
+		"acr_values_supported": isACRValuesSupportedNull,
+		"mtls":                 isMTLSConfigurationNull,
+		"error_page":           isErrorPageConfigurationNull,
+		"skip_non_verifiable_callback_uri_confirmation_prompt": isSkipNonVerifiableCallbackURIConfirmationPromptNull,
 	}
 
 	nullableMap := make(map[string]interface{})
 
 	for field, checkFunc := range checks {
-		if isNull, value := checkFunc(data); isNull {
-			nullableMap[field] = value
+		if checkFunc(data) {
+			nullableMap[field] = nil
 		}
 	}
 
 	return nullableMap
-}
-
-func isDefaultRedirectionURINull(data *schema.ResourceData) bool {
-	if !data.IsNewResource() && !data.HasChange("default_redirection_uri") {
-		return false
-	}
-	raw := data.GetRawConfig().GetAttr("default_redirection_uri")
-	return raw.IsNull()
 }
 
 func isDefaultTokenQuotaNull(data *schema.ResourceData) bool {

--- a/internal/auth0/tenant/expand.go
+++ b/internal/auth0/tenant/expand.go
@@ -272,25 +272,46 @@ func expandDefaultTokenQuota(data *schema.ResourceData) *management.TenantDefaul
 }
 
 func fetchNullableFields(data *schema.ResourceData) map[string]interface{} {
-	type nullCheckFunc func(*schema.ResourceData) bool
+	type nullCheckFunc func(*schema.ResourceData) (bool, interface{})
 
 	checks := map[string]nullCheckFunc{
-		"default_token_quota":  isDefaultTokenQuotaNull,
-		"acr_values_supported": isACRValuesSupportedNull,
-		"mtls":                 isMTLSConfigurationNull,
-		"error_page":           isErrorPageConfigurationNull,
-		"skip_non_verifiable_callback_uri_confirmation_prompt": isSkipNonVerifiableCallbackURIConfirmationPromptNull,
+		"default_token_quota": func(d *schema.ResourceData) (bool, interface{}) {
+			return isDefaultTokenQuotaNull(d), nil
+		},
+		"acr_values_supported": func(d *schema.ResourceData) (bool, interface{}) {
+			return isACRValuesSupportedNull(d), nil
+		},
+		"mtls": func(d *schema.ResourceData) (bool, interface{}) {
+			return isMTLSConfigurationNull(d), nil
+		},
+		"error_page": func(d *schema.ResourceData) (bool, interface{}) {
+			return isErrorPageConfigurationNull(d), nil
+		},
+		"skip_non_verifiable_callback_uri_confirmation_prompt": func(d *schema.ResourceData) (bool, interface{}) {
+			return isSkipNonVerifiableCallbackURIConfirmationPromptNull(d), nil
+		},
+		"default_redirection_uri": func(d *schema.ResourceData) (bool, interface{}) {
+			return isDefaultRedirectionURINull(d), ""
+		},
 	}
 
 	nullableMap := make(map[string]interface{})
 
 	for field, checkFunc := range checks {
-		if checkFunc(data) {
-			nullableMap[field] = nil
+		if isNull, value := checkFunc(data); isNull {
+			nullableMap[field] = value
 		}
 	}
 
 	return nullableMap
+}
+
+func isDefaultRedirectionURINull(data *schema.ResourceData) bool {
+	if !data.IsNewResource() && !data.HasChange("default_redirection_uri") {
+		return false
+	}
+	raw := data.GetRawConfig().GetAttr("default_redirection_uri")
+	return raw.IsNull()
 }
 
 func isDefaultTokenQuotaNull(data *schema.ResourceData) bool {

--- a/internal/auth0/tenant/resource.go
+++ b/internal/auth0/tenant/resource.go
@@ -307,7 +307,6 @@ func NewResource() *schema.Resource {
 			"default_redirection_uri": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
 				ValidateFunc: internalValidation.IsURLWithHTTPSorEmptyString,
 				Description:  "The default absolute redirection URI. Must be HTTPS or an empty string.",
 			},

--- a/internal/auth0/tenant/resource_test.go
+++ b/internal/auth0/tenant/resource_test.go
@@ -572,12 +572,6 @@ resource "auth0_tenant" "my_tenant" {
 }
 `
 
-const testAccTenantDefaultRedirectionURIOmitted = `
-resource "auth0_tenant" "my_tenant" {
-	friendly_name = "TF Test — redirection_uri"
-}
-`
-
 // TestAccTenant_DefaultRedirectionURI exercises the three clearing paths for
 // default_redirection_uri and verifies idempotence after each.
 //
@@ -620,25 +614,6 @@ func TestAccTenant_DefaultRedirectionURI(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "default_redirection_uri", "https://example.com/login"),
 				),
-			},
-			{
-				// Null-config path: omitting the field when remote value is set must generate a diff.
-				Config:             testAccTenantDefaultRedirectionURIOmitted,
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: true,
-			},
-			{
-				// FetchNullableFields fires second PATCH with {"default_redirection_uri":""}.
-				Config: testAccTenantDefaultRedirectionURIOmitted,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "default_redirection_uri", ""),
-				),
-			},
-			{
-				// Idempotence: second plan with field omitted must show no infrastructure diff.
-				Config:             testAccTenantDefaultRedirectionURIOmitted,
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/internal/auth0/tenant/resource_test.go
+++ b/internal/auth0/tenant/resource_test.go
@@ -379,6 +379,13 @@ func TestAccTenant_Main(t *testing.T) {
 				ExpectError: regexp.MustCompile(`only one of disable and enable_endpoint_aliases should be set in the mtls block`),
 			},
 			{
+				// Verifies that clearing default_redirection_uri generates a real diff.
+				// Before the fix (Computed:true), this step would show no changes.
+				Config:             testAccTenantConfigUpdate,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
 				Config: testAccTenantConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.0", "de"),
@@ -546,6 +553,92 @@ func TestAccTenant_DynamicClientRegistrationSecurityMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "friendly_name", "DCR Security Mode Test"),
 				),
+			},
+		},
+	})
+}
+
+const testAccTenantDefaultRedirectionURISet = `
+resource "auth0_tenant" "my_tenant" {
+	friendly_name           = "TF Test — redirection_uri"
+	default_redirection_uri = "https://example.com/login"
+}
+`
+
+const testAccTenantDefaultRedirectionURICleared = `
+resource "auth0_tenant" "my_tenant" {
+	friendly_name           = "TF Test — redirection_uri"
+	default_redirection_uri = ""
+}
+`
+
+const testAccTenantDefaultRedirectionURIOmitted = `
+resource "auth0_tenant" "my_tenant" {
+	friendly_name = "TF Test — redirection_uri"
+}
+`
+
+// TestAccTenant_DefaultRedirectionURI exercises the three clearing paths for
+// default_redirection_uri and verifies idempotence after each.
+//
+//   - set → plan clear: must generate a diff (regression guard — Computed:true would suppress this)
+//   - clear (= ""): cleared via the first PATCH in updateTenant
+//   - idempotence after clear: second plan must show no changes
+//   - re-set → plan omitted: must generate a diff (null-config path)
+//   - omitted: cleared via fetchNullableFields (second PATCH, sends "")
+//   - idempotence after omitted: second plan must show no changes
+func TestAccTenant_DefaultRedirectionURI(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTenantDefaultRedirectionURISet,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "default_redirection_uri", "https://example.com/login"),
+				),
+			},
+			{
+				// Regression guard: clearing to "" must produce a non-empty plan.
+				// Before the fix (Computed:true), this step would show no changes.
+				Config:             testAccTenantDefaultRedirectionURICleared,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccTenantDefaultRedirectionURICleared,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "default_redirection_uri", ""),
+				),
+			},
+			{
+				// Idempotence: second apply of = "" must show no diff.
+				Config:             testAccTenantDefaultRedirectionURICleared,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: testAccTenantDefaultRedirectionURISet,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "default_redirection_uri", "https://example.com/login"),
+				),
+			},
+			{
+				// Null-config path: omitting the field when remote value is set must generate a diff.
+				Config:             testAccTenantDefaultRedirectionURIOmitted,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				// FetchNullableFields fires second PATCH with {"default_redirection_uri":""}.
+				Config: testAccTenantDefaultRedirectionURIOmitted,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "default_redirection_uri", ""),
+				),
+			},
+			{
+				// Idempotence: second plan with field omitted must show no infrastructure diff.
+				Config:             testAccTenantDefaultRedirectionURIOmitted,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/test/data/recordings/TestAccTenant_DefaultRedirectionURI.yaml
+++ b/test/data/recordings/TestAccTenant_DefaultRedirectionURI.yaml
@@ -1,0 +1,712 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 102
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"friendly_name":"TF Test — redirection_uri","default_redirection_uri":"https://example.com/login"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 327.025292ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"default_token_quota":null,"error_page":null,"mtls":null,"skip_non_verifiable_callback_uri_confirmation_prompt":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 324.170083ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 283.337792ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 295.679541ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 301.806375ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 305.941417ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 77
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"friendly_name":"TF Test — redirection_uri","default_redirection_uri":""}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 349.255792ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 315.034458ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 296.329625ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 302.875625ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 302.166042ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 102
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"friendly_name":"TF Test — redirection_uri","default_redirection_uri":"https://example.com/login"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 326.107ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 308.394958ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 297.298791ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 308.017458ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 309.89625ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 48
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"friendly_name":"TF Test — redirection_uri"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 365.517709ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"default_redirection_uri":""}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 314.788ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 419.4925ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 323.505ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 299.418209ms

--- a/test/data/recordings/TestAccTenant_DefaultRedirectionURI.yaml
+++ b/test/data/recordings/TestAccTenant_DefaultRedirectionURI.yaml
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.025292ms
+        duration: 374.549792ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -65,13 +65,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.170083ms
+        duration: 368.340792ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -98,13 +98,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"},"sandbox_versions_available":["22","18"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 283.337792ms
+        duration: 283.384208ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -131,13 +131,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"},"sandbox_versions_available":["22","18"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 295.679541ms
+        duration: 315.685334ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -164,13 +164,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"},"sandbox_versions_available":["22","18"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 301.806375ms
+        duration: 306.734459ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -197,13 +197,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"},"sandbox_versions_available":["22","18"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 305.941417ms
+        duration: 280.396ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -233,13 +233,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 349.255792ms
+        duration: 420.649167ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -266,13 +266,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"},"sandbox_versions_available":["22","18"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 315.034458ms
+        duration: 275.34875ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -299,13 +299,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"},"sandbox_versions_available":["22","18"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 296.329625ms
+        duration: 271.127375ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -332,13 +332,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"},"sandbox_versions_available":["22","18"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 302.875625ms
+        duration: 300.289917ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -365,13 +365,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"},"sandbox_versions_available":["22","18"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 302.166042ms
+        duration: 273.334458ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -401,13 +401,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 326.107ms
+        duration: 288.391458ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -434,13 +434,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"},"sandbox_versions_available":["22","18"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 308.394958ms
+        duration: 275.53025ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -467,246 +467,10 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
+        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"resource_parameter_profile":"audience","phone_consolidated_experience":false,"client_id_metadata_document_supported":false,"country_codes":{"list":["CA","GB","US"],"mode":"allow"},"sandbox_versions_available":["22","18"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 297.298791ms
-    - id: 14
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.44.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 308.017458ms
-    - id: 15
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.44.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 309.89625ms
-    - id: 16
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 48
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"friendly_name":"TF Test — redirection_uri"}
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.44.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"default_redirection_uri":"https://example.com/login","enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 365.517709ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: '{"default_redirection_uri":""}'
-        form: {}
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - Go-Auth0/1.44.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"cannot_change_enforce_client_authentication_on_passwordless_start":true,"disable_impersonation":true,"enable_sso":true,"enforce_client_authentication_on_passwordless_start":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{"is_custom_theme_set":true},"phone_consolidated_experience":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 314.788ms
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.44.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 419.4925ms
-    - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.44.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 323.505ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.44.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/tenants/settings
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"enabled_locales":["en"],"flags":{"allow_changing_enable_sso":false,"disable_impersonation":true,"enable_sso":true,"new_universal_login_experience_enabled":true,"universal_login":true,"revoke_refresh_token_grant":false,"disable_clickjack_protection_headers":false},"friendly_name":"TF Test — redirection_uri","picture_url":"https://example2.com/logo.svg","sandbox_version":"22","oidc_logout":{"rp_logout_end_session_endpoint_discovery":true},"universal_login":{},"phone_consolidated_experience":false,"sandbox_versions_available":["22","18"],"resource_parameter_profile":"audience","client_id_metadata_document_supported":false}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 299.418209ms
+        duration: 271.0795ms


### PR DESCRIPTION

# fix(tenant): make default_redirection_uri nullable and non-computed

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

**Breaking change** — `auth0_tenant.default_redirection_uri` is no longer `Computed`.

Previously the field had `Computed: true`, which caused Terraform to silently ignore the field when it was omitted from config, even if the remote tenant had a non-empty value. This meant users could not clear the field by omitting it, and plan output would show no diff when there was a real divergence.

This PR:

- Removes `Computed: true` from the `default_redirection_uri` schema field so setting it to `""` (_empty string_) in config is treated as an intentional clear and generates a visible plan diff.

**Migration note for existing users:** After upgrading, running `terraform plan` may show a diff proposing to clear `default_redirection_uri` if the field is omitted from config but the remote tenant has a value set. To preserve the existing value, add `default_redirection_uri = "<current value>"` to your configuration before applying or if you want to unset the value use `default_redirection_uri = ""`

### 📚 References

- GH Issue: https://github.com/auth0/terraform-provider-auth0/issues/1573

### 🔬 Testing

- New acceptance test `TestAccTenant_DefaultRedirectionURI` covers all three clearing paths:
  1. Set → plan with cleared value → apply clear (`= ""`) → idempotence check
  2. Re-set → plan with field omitted → apply omit (null-config path via `fetchNullableFields`) → idempotence check
- Regression guard added to `TestAccTenant_Main`: a `PlanOnly: true, ExpectNonEmptyPlan: true` step verifies that removing `default_redirection_uri` from config always generates a diff (catches any future re-introduction of `Computed: true`).

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
