### PR TITLE
fix: omit empty precedence from Auth0 connection options

### DIFF
--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -465,10 +465,13 @@ func expandConnectionOptionsAuth0(_ *schema.ResourceData, config cty.Value) (int
 		RequiresUsername:                 value.Bool(config.GetAttr("requires_username")),
 		CustomScripts:                    value.MapOfStrings(config.GetAttr("custom_scripts")),
 		Configuration:                    value.MapOfStrings(config.GetAttr("configuration")),
-		Precedence:                       value.Strings(config.GetAttr("precedence")),
 		Attributes:                       expandConnectionOptionsAttributes(config.GetAttr("attributes")),
 		StrategyVersion:                  value.Int(config.GetAttr("strategy_version")),
 		RealmFallback:                    value.Bool(config.GetAttr("realm_fallback")),
+	}
+
+	if precedence := value.Strings(config.GetAttr("precedence")); precedence != nil && len(*precedence) > 0 {
+		options.Precedence = precedence
 	}
 
 	config.GetAttr("validation").ForEachElement(


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Fixes a `400 Bad Request` (`Array is too short, minimum 3 on property options.precedence`) when applying a generated terraform config with `auth0_connection` that uses Flexible Password Policy without setting `precedence`.

A generated config had empty array for unset `precedence` and it was always sent as is in API causing `400`. It's now sent only when non-empty; an unset value is omitted, which the API accepts.

- **API behavior:** `precedence` is replace-on-write: omitting it means "unset", sending `[]` is rejected. A non-empty value must be sent on every PATCH to persist, which happens naturally since it stays in config.

### 📚 References

- API Docs: https://auth0.com/docs/api/management/v2/connections/post-connections#body-options-precedence

### 🔬 Testing

- Manually verified config generation and corresponding CRUD operations on `auth0_connection` with various values of `precedence`.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
