### PR TITLE
feat: add third_party_client_access attribute to organization

### DIFF
--- a/docs/data-sources/organization.md
+++ b/docs/data-sources/organization.md
@@ -42,6 +42,7 @@ data "auth0_organization" "some-organization-by-id" {
 - `id` (String) The ID of this resource.
 - `members` (Set of String) User ID(s) that are members of the organization. Skips populating if `skip_members` is `true`.
 - `metadata` (Map of String) Metadata associated with the organization. Maximum of 10 metadata properties allowed.
+- `third_party_client_access` (String) Controls whether this organization can be used in user flows with third-party clients. Available values are `allow` or `block`. Defaults to `block`.
 - `token_quota` (List of Object) The token quota configuration. (see [below for nested schema](#nestedatt--token_quota))
 
 <a id="nestedatt--branding"></a>

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -24,6 +24,8 @@ resource "auth0_organization" "my_organization" {
   name         = "auth0-inc"
   display_name = "Auth0 Inc."
 
+  third_party_client_access = "block"
+
   branding {
     logo_url = "https://example.com/assets/icons/icon.png"
     colors = {
@@ -46,6 +48,7 @@ resource "auth0_organization" "my_organization" {
 - `branding` (Block List, Max: 1) Defines how to style the login pages. (see [below for nested schema](#nestedblock--branding))
 - `display_name` (String) Friendly name of this organization.
 - `metadata` (Map of String) Metadata associated with the organization. Maximum of 10 metadata properties allowed.
+- `third_party_client_access` (String) Controls whether this organization can be used in user flows with third-party clients. Available values are `allow` or `block`. Defaults to `block`.
 - `token_quota` (Block List, Max: 1) The token quota configuration. (see [below for nested schema](#nestedblock--token_quota))
 
 ### Read-Only

--- a/examples/resources/auth0_organization/resource.tf
+++ b/examples/resources/auth0_organization/resource.tf
@@ -2,6 +2,8 @@ resource "auth0_organization" "my_organization" {
   name         = "auth0-inc"
   display_name = "Auth0 Inc."
 
+  third_party_client_access = "block"
+
   branding {
     logo_url = "https://example.com/assets/icons/icon.png"
     colors = {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/PuerkitoBio/rehttp v1.4.0
-	github.com/auth0/go-auth0 v1.44.0
+	github.com/auth0/go-auth0 v1.44.1-0.20260709070815-6eec83f1a47c
 	github.com/auth0/go-auth0/v2 v2.14.0
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/auth0/go-auth0 v1.44.0 h1:IXvJ2iP2mRLv/JL2HIIB/+1iKD/0EuDKw5BlR1hW9eI=
-github.com/auth0/go-auth0 v1.44.0/go.mod h1:32sQB1uAn+99fJo6N819EniKq8h785p0ag0lMWhiTaE=
+github.com/auth0/go-auth0 v1.44.1-0.20260709070815-6eec83f1a47c h1:zGg/1kpTPtnhaHxxEn1wW/3o01VsCkmCcAOwSkNDMdw=
+github.com/auth0/go-auth0 v1.44.1-0.20260709070815-6eec83f1a47c/go.mod h1:32sQB1uAn+99fJo6N819EniKq8h785p0ag0lMWhiTaE=
 github.com/auth0/go-auth0/v2 v2.14.0 h1:zDxwRHGAt6gLK/OG6wAkB5ScQEJ8WW/ex1EnJig8fFc=
 github.com/auth0/go-auth0/v2 v2.14.0/go.mod h1:Q/Y3VZVoI3sw87VyTPhx2TQL6Sq4Q/iCP67rW2gcn+M=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=

--- a/internal/auth0/organization/expand.go
+++ b/internal/auth0/organization/expand.go
@@ -15,10 +15,11 @@ func expandOrganization(data *schema.ResourceData) *management.Organization {
 	cfg := data.GetRawConfig()
 
 	organization := &management.Organization{
-		Name:        value.String(cfg.GetAttr("name")),
-		DisplayName: value.String(cfg.GetAttr("display_name")),
-		Branding:    expandOrganizationBranding(cfg.GetAttr("branding")),
-		TokenQuota:  commons.ExpandTokenQuota(cfg.GetAttr("token_quota")),
+		Name:                   value.String(cfg.GetAttr("name")),
+		DisplayName:            value.String(cfg.GetAttr("display_name")),
+		ThirdPartyClientAccess: value.String(cfg.GetAttr("third_party_client_access")),
+		Branding:               expandOrganizationBranding(cfg.GetAttr("branding")),
+		TokenQuota:             commons.ExpandTokenQuota(cfg.GetAttr("token_quota")),
 	}
 
 	if data.HasChange("metadata") {

--- a/internal/auth0/organization/flatten.go
+++ b/internal/auth0/organization/flatten.go
@@ -13,6 +13,7 @@ func flattenOrganization(data *schema.ResourceData, organization *management.Org
 	result := multierror.Append(
 		data.Set("name", organization.GetName()),
 		data.Set("display_name", organization.GetDisplayName()),
+		data.Set("third_party_client_access", organization.GetThirdPartyClientAccess()),
 		data.Set("branding", flattenOrganizationBranding(organization.GetBranding())),
 		data.Set("metadata", organization.GetMetadata()),
 		data.Set("token_quota", commons.FlattenTokenQuota(organization.GetTokenQuota())),

--- a/internal/auth0/organization/resource.go
+++ b/internal/auth0/organization/resource.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/auth0/terraform-provider-auth0/internal/config"
 	internalError "github.com/auth0/terraform-provider-auth0/internal/error"
@@ -40,6 +41,14 @@ func NewResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Friendly name of this organization.",
+			},
+			"third_party_client_access": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"allow", "block"}, false),
+				Description: "Controls whether this organization can be used in user flows with third-party clients. " +
+					"Available values are `allow` or `block`. Defaults to `block`.",
 			},
 			"branding": {
 				Type:        schema.TypeList,

--- a/internal/auth0/organization/resource_test.go
+++ b/internal/auth0/organization/resource_test.go
@@ -251,3 +251,59 @@ func TestAccOrganizationTokenQuota(t *testing.T) {
 		},
 	})
 }
+
+const testAccOrganizationThirdPartyClientAccessDefault = `
+resource "auth0_organization" "acme" {
+	name         = "test-{{.testName}}"
+	display_name = "Acme Inc. {{.testName}}"
+}
+`
+
+const testAccOrganizationThirdPartyClientAccessAllow = `
+resource "auth0_organization" "acme" {
+	name                      = "test-{{.testName}}"
+	display_name              = "Acme Inc. {{.testName}}"
+	third_party_client_access = "allow"
+}
+
+data "auth0_organization" "acme" {
+	organization_id = auth0_organization.acme.id
+}
+`
+
+const testAccOrganizationThirdPartyClientAccessBlock = `
+resource "auth0_organization" "acme" {
+	name                      = "test-{{.testName}}"
+	display_name              = "Acme Inc. {{.testName}}"
+	third_party_client_access = "block"
+}
+`
+
+func TestAccOrganizationThirdPartyClientAccess(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseTestName(testAccOrganizationThirdPartyClientAccessDefault, strings.ToLower(t.Name())),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_organization.acme", "name", fmt.Sprintf("test-%s", strings.ToLower(t.Name()))),
+					// Omitting the field must default to "block" (secure-by-default), materialized via Computed.
+					resource.TestCheckResourceAttr("auth0_organization.acme", "third_party_client_access", "block"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccOrganizationThirdPartyClientAccessAllow, strings.ToLower(t.Name())),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_organization.acme", "third_party_client_access", "allow"),
+					// Data source must reflect the same value (read parity).
+					resource.TestCheckResourceAttr("data.auth0_organization.acme", "third_party_client_access", "allow"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccOrganizationThirdPartyClientAccessBlock, strings.ToLower(t.Name())),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_organization.acme", "third_party_client_access", "block"),
+				),
+			},
+		},
+	})
+}

--- a/test/data/recordings/TestAccOrganizationThirdPartyClientAccess.yaml
+++ b/test/data/recordings/TestAccOrganizationThirdPartyClientAccess.yaml
@@ -1,0 +1,903 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 127
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 190
+        uncompressed: false
+        body: '{"id":"org_0uq49sRXfKUa07Bq","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","name":"test-testaccorganizationthirdpartyclientaccess","third_party_client_access":"block"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 383.807792ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"block"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 315.078875ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"block"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 360.432917ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"block"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 371.188958ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 163
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"allow"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","name":"test-testaccorganizationthirdpartyclientaccess","third_party_client_access":"allow"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 348.885625ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"allow"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 282.496125ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"allow"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 260.584916ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/connections?include_totals=true&is_enabled=true&page=0&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 49
+        uncompressed: false
+        body: '{"connections":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 366.625375ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/connections?include_totals=true&is_enabled=true&page=1&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"connections":[],"start":50,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 337.445667ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"members":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 362.734333ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/client-grants?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 265.262708ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"allow"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 346.71ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/connections?include_totals=true&is_enabled=true&page=0&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 49
+        uncompressed: false
+        body: '{"connections":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 333.555917ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/connections?include_totals=true&is_enabled=true&page=1&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"connections":[],"start":50,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 323.201125ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"members":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 347.243667ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/client-grants?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 350.258334ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"allow"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 280.732708ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"allow"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 342.780291ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/connections?include_totals=true&is_enabled=true&page=0&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 49
+        uncompressed: false
+        body: '{"connections":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 356.13125ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/connections?include_totals=true&is_enabled=true&page=1&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"connections":[],"start":50,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 305.917458ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/members?fields=user_id&include_fields=true&include_totals=true&per_page=50&take=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"members":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 350.814333ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq/client-grants?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_grants":[],"start":0,"limit":50,"total":0}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 348.907125ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"allow"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 325.112584ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 163
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"block"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","name":"test-testaccorganizationthirdpartyclientaccess","third_party_client_access":"block"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 285.361042ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"block"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 335.064917ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"org_0uq49sRXfKUa07Bq","name":"test-testaccorganizationthirdpartyclientaccess","display_name":"Acme Inc. testaccorganizationthirdpartyclientaccess","third_party_client_access":"block"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 350.2455ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.44.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/organizations/org_0uq49sRXfKUa07Bq
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 279.872125ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds support for the new `third_party_client_access` attribute on the `auth0_organization` resource and data source.

This attribute lets tenant admins control, per organization, whether third-party clients may perform standard user flows (Authorization Code, Refresh Token exchange) in that organization's context. It is secure-by-default: organizations block third-party client access unless explicitly allowed.

- New attribute `third_party_client_access` (String, `allow` | `block`) on `auth0_organization`.
- Optional and computed — when omitted, the resource reflects the server default (`block`) instead of showing plan drift. This attribute can be updated, but it cannot be unset.
- Exposed read-only on the `auth0_organization` data source.
- Bumps `github.com/auth0/go-auth0` to the version exposing `Organization.ThirdPartyClientAccess`.

Usage:

```hcl
resource "auth0_organization" "my_organization" {
  name         = "auth0-inc"
  display_name = "Auth0 Inc."

  third_party_client_access = "allow"
}
```

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- SDK v1 PR: https://github.com/auth0/go-auth0/pull/818

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Acceptance test `TestAccOrganizationThirdPartyClientAccess` covers: default value (`block`) when the attribute is omitted, toggling to `allow` (asserted on both the resource and the data source), and toggling back to `block`. HTTP recordings are committed.
- Invalid values are rejected client-side by schema validation (`allow` / `block` only).
- The attribute contract was validated against the live Management API on a tenant with the `organizations_third_party_client_support` flag enabled: enum and type enforcement, secure-by-default (`block`), presence on POST/GET/LIST/PATCH and `GET /organizations/name/{name}`, and `allow`↔`block` toggling.
- Validated config generation both with and without `third_party_client_access`.

Run the acceptance test with recordings:

```bash
make test-acc FILTER=TestAccOrganizationThirdPartyClientAccess
```

To run against a live tenant, the `organizations_third_party_client_support` feature flag must be enabled on that tenant.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
