### PR TITLE
docs: clarify inverted dashboard toggles for tenant flags

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -168,10 +168,10 @@ Optional:
 - `enable_legacy_logs_search_v2` (Boolean) Indicates whether to use the older v2 legacy logs search.
 - `enable_legacy_profile` (Boolean) Whether ID tokens and the userinfo endpoint includes a complete user profile (true) or only OpenID Connect claims (false).
 - `enable_pipeline2` (Boolean) Indicates whether advanced API Authorization scenarios are enabled.
-- `enable_public_signup_user_exists_error` (Boolean) Indicates whether the public sign up process shows a `user_exists` error if the user already exists.
+- `enable_public_signup_user_exists_error` (Boolean) Indicates whether the public sign up process shows a `user_exists` error if the user already exists. Note: the Auth0 Dashboard toggle **Use a generic response in public signup API error message** shows the inverse of this value.
 - `enable_sso` (Boolean) Flag indicating whether users will not be prompted to confirm log in before SSO redirection. This flag applies to existing tenants only; new tenants have it enforced as true.
 - `mfa_show_factor_list_on_enrollment` (Boolean) Used to allow users to pick which factor to enroll with from the list of available MFA factors.
-- `no_disclose_enterprise_connections` (Boolean) Do not Publish Enterprise Connections Information with IdP domains on the lock configuration file.
+- `no_disclose_enterprise_connections` (Boolean) Do not Publish Enterprise Connections Information with IdP domains on the lock configuration file. Note: the Auth0 Dashboard toggle **Enable Publishing of Enterprise Connections Information with IdP domains** shows the inverse of this value.
 - `remove_alg_from_jwks` (Boolean) Remove `alg` from jwks(JSON Web Key Sets).
 - `require_pushed_authorization_requests` (Boolean, Deprecated) This Flag is not supported by the Auth0 Management API and will be removed in the next major release.
 - `revoke_refresh_token_grant` (Boolean) Delete underlying grant when a refresh token is revoked via the Authentication API.

--- a/internal/auth0/tenant/resource.go
+++ b/internal/auth0/tenant/resource.go
@@ -199,10 +199,11 @@ func NewResource() *schema.Resource {
 							Description: "Indicates whether classic Universal Login prompts include additional security headers to prevent clickjacking.",
 						},
 						"enable_public_signup_user_exists_error": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Computed:    true,
-							Description: "Indicates whether the public sign up process shows a `user_exists` error if the user already exists.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+							Description: "Indicates whether the public sign up process shows a `user_exists` error if the user already exists. " +
+								"Note: the Auth0 Dashboard toggle **Use a generic response in public signup API error message** shows the inverse of this value.",
 						},
 						"use_scope_descriptions_for_consent": {
 							Type:        schema.TypeBool,
@@ -241,10 +242,11 @@ func NewResource() *schema.Resource {
 							Description: "Whether ID tokens can be used to authorize some types of requests to API v2 (true) or not (false).",
 						},
 						"no_disclose_enterprise_connections": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Computed:    true,
-							Description: "Do not Publish Enterprise Connections Information with IdP domains on the lock configuration file.",
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+							Description: "Do not Publish Enterprise Connections Information with IdP domains on the lock configuration file. " +
+								"Note: the Auth0 Dashboard toggle **Enable Publishing of Enterprise Connections Information with IdP domains** shows the inverse of this value.",
 						},
 						"disable_management_api_sms_obfuscation": {
 							Type:        schema.TypeBool,


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Clarifies the schema documentation for two `auth0_tenant` flags whose Auth0 Dashboard toggle displays the inverse of the raw Management API value.

- `enable_public_signup_user_exists_error`: notes that the Dashboard toggle "Use a generic response in public signup API error message" shows the inverse of this value.
- `no_disclose_enterprise_connections`: notes that the Dashboard toggle "Enable Publishing of Enterprise Connections Information with IdP domains" shows the inverse of this value.

Docs-only change. No behavior change: The Dashboard intentionally flips these toggles for display. The updated descriptions call out that inversion so the raw value Terraform manages is not mistaken for a bug.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- Closes #1625

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

No functional change, so no automated tests were added. Verified manually:

- Confirmed against the Management API that both flags round-trip faithfully: PATCH `true` reads back `true`, PATCH `false` reads back `false`, with no inversion by the provider.
- Confirmed in the Auth0 Dashboard that each toggle displays the inverse of the API value in both directions (API `true` shows the toggle OFF, API `false` shows it ON).
- Ran `make docs` and confirmed `docs/resources/tenant.md` regenerates cleanly with only the two intended description lines changed.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A) — N/A, documentation-only change with no behavior change.
- [x] I have added documentation for all new/changed functionality (or N/A) — schema descriptions updated and `docs/resources/tenant.md` regenerated.

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
