### PR TITLE
chore(deps): bump github.com/auth0/go-auth0 to 1.45.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/PuerkitoBio/rehttp v1.4.0
-	github.com/auth0/go-auth0 v1.44.1-0.20260709070815-6eec83f1a47c
+	github.com/auth0/go-auth0 v1.45.0
 	github.com/auth0/go-auth0/v2 v2.14.0
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/auth0/go-auth0 v1.44.1-0.20260709070815-6eec83f1a47c h1:zGg/1kpTPtnhaHxxEn1wW/3o01VsCkmCcAOwSkNDMdw=
-github.com/auth0/go-auth0 v1.44.1-0.20260709070815-6eec83f1a47c/go.mod h1:32sQB1uAn+99fJo6N819EniKq8h785p0ag0lMWhiTaE=
+github.com/auth0/go-auth0 v1.45.0 h1:fQaNSWpoMneYsutOr+3fTOXIsFAQThSf2A0ShL3oaZg=
+github.com/auth0/go-auth0 v1.45.0/go.mod h1:32sQB1uAn+99fJo6N819EniKq8h785p0ag0lMWhiTaE=
 github.com/auth0/go-auth0/v2 v2.14.0 h1:zDxwRHGAt6gLK/OG6wAkB5ScQEJ8WW/ex1EnJig8fFc=
 github.com/auth0/go-auth0/v2 v2.14.0/go.mod h1:Q/Y3VZVoI3sw87VyTPhx2TQL6Sq4Q/iCP67rW2gcn+M=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=


### PR DESCRIPTION
### 🔧 Changes

Bumps [github.com/auth0/go-auth0](https://github.com/auth0/go-auth0) to **v1.45.0**.

This replaces the temporary pseudo-version (`v1.44.1-0.20260709070815-6eec83f1a47c`) that was pinned during development with the tagged **v1.45.0** release.

### 📦 Upstream release notes ([v1.45.0](https://github.com/auth0/go-auth0/releases/tag/v1.45.0))

[Full changelog: v1.44.0...v1.45.0](https://github.com/auth0/go-auth0/compare/v1.44.0...v1.45.0)

**Added**
- feat: add `third_party_client_access` field in organization ([#818](https://github.com/auth0/go-auth0/pull/818))
- feat: add support for `identifiers` in branding_theme and `country_codes` in tenant structs ([#811](https://github.com/auth0/go-auth0/pull/811))