### PR TITLE
feat: add Cross App Access support to connection and client (EA only)

### DIFF
--- a/docs/data-sources/client.md
+++ b/docs/data-sources/client.md
@@ -60,6 +60,7 @@ data "auth0_client" "some-client-by-id" {
 - `form_template` (String) HTML form template to be used for WS-Federation.
 - `grant_types` (List of String) Types of grants that this client is authorized to use.
 - `id` (String) The ID of this resource.
+- `identity_assertion_authorization_grant` (List of Object) Configures the client to participate in the Identity Assertion Authorization Grant (ID-JAG) exchange, used for Cross App Access (XAA). (EA only) (see [below for nested schema](#nestedatt--identity_assertion_authorization_grant))
 - `initiate_login_uri` (String) Initiate login URI. Must be HTTPS or an empty string. May contain Auth0 dynamic login URI placeholders such as `{organization.metadata.public_login_host}` or `{custom_domain.metadata.public_app_host}`, which are resolved by Auth0 at request time. See https://auth0.com/docs/get-started/applications/application-settings.
 - `is_first_party` (Boolean) Indicates whether this client is a first-party client.
 - `is_token_endpoint_ip_header_trusted` (Boolean) Indicates whether the token endpoint IP header is trusted. Requires the authentication method to be set to `client_secret_post` or `client_secret_basic`. Setting this property when creating the resource, will default the authentication method to `client_secret_post`. To change the authentication method to `client_secret_basic` use the `auth0_client_credentials` resource.
@@ -548,6 +549,14 @@ Read-Only:
 
 - `is_enabled` (Boolean)
 
+
+
+<a id="nestedatt--identity_assertion_authorization_grant"></a>
+### Nested Schema for `identity_assertion_authorization_grant`
+
+Read-Only:
+
+- `active` (Boolean)
 
 
 <a id="nestedatt--jwt_configuration"></a>

--- a/docs/data-sources/clients.md
+++ b/docs/data-sources/clients.md
@@ -64,6 +64,7 @@ Read-Only:
 - `external_metadata_type` (String)
 - `fedcm_login` (List of Object) (see [below for nested schema](#nestedobjatt--clients--fedcm_login))
 - `grant_types` (List of String)
+- `identity_assertion_authorization_grant` (List of Object) (see [below for nested schema](#nestedobjatt--clients--identity_assertion_authorization_grant))
 - `is_first_party` (Boolean)
 - `is_token_endpoint_ip_header_trusted` (Boolean)
 - `jwks_uri` (String)
@@ -118,6 +119,14 @@ Read-Only:
 
 - `is_enabled` (Boolean)
 
+
+
+<a id="nestedobjatt--clients--identity_assertion_authorization_grant"></a>
+### Nested Schema for `clients.identity_assertion_authorization_grant`
+
+Read-Only:
+
+- `active` (Boolean)
 
 
 <a id="nestedobjatt--clients--my_organization_configuration"></a>

--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -36,6 +36,7 @@ data "auth0_connection" "some-connection-by-id" {
 - `authentication` (List of Object) Configure the purpose of a connection to be used for authentication during login.**Note:** Once configured, removing this block from your configuration is a no-op and will not disable the purpose on the connection; set `active` to `false` explicitly to deactivate it. (see [below for nested schema](#nestedatt--authentication))
 - `connected_accounts` (List of Object) Configure the purpose of a connection to be used for connected accounts and Token Vault.**Note:** Once configured, removing this block from your configuration is a no-op and will not disable the purpose on the connection; set `active` to `false` explicitly to deactivate it. (see [below for nested schema](#nestedatt--connected_accounts))
 - `cross_app_access_requesting_app` (List of Object) Configure the purpose of a connection to be used as a requesting application authorization server for Cross-App Access (XAA). This is an Early Access feature and requires the `token_vault_xaa` flag to be enabled on your tenant. Only supported on `oidc` and `okta` strategy connections. **Note:** Once configured, removing this block from your configuration is a no-op and will not disable the purpose on the connection; set `active` to `false` explicitly to deactivate it. (EA Only) (see [below for nested schema](#nestedatt--cross_app_access_requesting_app))
+- `cross_app_access_resource_app` (List of Object) Resource App settings that apply to this connection. (EA only) (see [below for nested schema](#nestedatt--cross_app_access_resource_app))
 - `display_name` (String) Name used in login screen.
 - `enabled_clients` (Set of String) IDs of the clients for which the connection is enabled. Skips populating if `skip_enabled_clients` is `true`.
 - `id` (String) The ID of this resource.
@@ -68,6 +69,14 @@ Read-Only:
 Read-Only:
 
 - `active` (Boolean)
+
+
+<a id="nestedatt--cross_app_access_resource_app"></a>
+### Nested Schema for `cross_app_access_resource_app`
+
+Read-Only:
+
+- `status` (String)
 
 
 <a id="nestedatt--options"></a>
@@ -140,6 +149,7 @@ Read-Only:
 - `mfa` (List of Object) (see [below for nested schema](#nestedobjatt--options--mfa))
 - `name` (String)
 - `non_persistent_attrs` (Set of String)
+- `oidc_metadata` (String)
 - `passkey_options` (List of Object) (see [below for nested schema](#nestedobjatt--options--passkey_options))
 - `password_complexity_options` (List of Object) (see [below for nested schema](#nestedobjatt--options--password_complexity_options))
 - `password_dictionary` (List of Object) (see [below for nested schema](#nestedobjatt--options--password_dictionary))

--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -173,6 +173,7 @@ resource "auth0_client" "mcp_server" {
 - `fedcm_login` (Block List, Max: 1) Federated Credential Management (FedCM) configuration. (EA only) (see [below for nested schema](#nestedblock--fedcm_login))
 - `form_template` (String) HTML form template to be used for WS-Federation.
 - `grant_types` (List of String) Types of grants that this client is authorized to use.
+- `identity_assertion_authorization_grant` (Block List, Max: 1) Configures the client to participate in the Identity Assertion Authorization Grant (ID-JAG) exchange, used for Cross App Access (XAA). (EA only) (see [below for nested schema](#nestedblock--identity_assertion_authorization_grant))
 - `initiate_login_uri` (String) Initiate login URI. Must be HTTPS or an empty string. May contain Auth0 dynamic login URI placeholders such as `{organization.metadata.public_login_host}` or `{custom_domain.metadata.public_app_host}`, which are resolved by Auth0 at request time. See https://auth0.com/docs/get-started/applications/application-settings.
 - `is_first_party` (Boolean) Indicates whether this client is a first-party client.
 - `is_token_endpoint_ip_header_trusted` (Boolean) Indicates whether the token endpoint IP header is trusted. Requires the authentication method to be set to `client_secret_post` or `client_secret_basic`. Setting this property when creating the resource, will default the authentication method to `client_secret_post`. To change the authentication method to `client_secret_basic` use the `auth0_client_credentials` resource.
@@ -584,6 +585,14 @@ Required:
 
 - `is_enabled` (Boolean) Whether to show the Google FedCM prompt on Login. (EA only)
 
+
+
+<a id="nestedblock--identity_assertion_authorization_grant"></a>
+### Nested Schema for `identity_assertion_authorization_grant`
+
+Required:
+
+- `active` (Boolean) Whether the client can exchange ID-JAGs for access tokens. (EA only)
 
 
 <a id="nestedblock--jwt_configuration"></a>

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -683,6 +683,7 @@ resource "auth0_connection" "okta" {
 - `authentication` (Block List, Max: 1) Configure the purpose of a connection to be used for authentication during login.**Note:** Once configured, removing this block from your configuration is a no-op and will not disable the purpose on the connection; set `active` to `false` explicitly to deactivate it. (see [below for nested schema](#nestedblock--authentication))
 - `connected_accounts` (Block List, Max: 1) Configure the purpose of a connection to be used for connected accounts and Token Vault.**Note:** Once configured, removing this block from your configuration is a no-op and will not disable the purpose on the connection; set `active` to `false` explicitly to deactivate it. (see [below for nested schema](#nestedblock--connected_accounts))
 - `cross_app_access_requesting_app` (Block List, Max: 1) Configure the purpose of a connection to be used as a requesting application authorization server for Cross-App Access (XAA). This is an Early Access feature and requires the `token_vault_xaa` flag to be enabled on your tenant. Only supported on `oidc` and `okta` strategy connections. **Note:** Once configured, removing this block from your configuration is a no-op and will not disable the purpose on the connection; set `active` to `false` explicitly to deactivate it. (EA Only) (see [below for nested schema](#nestedblock--cross_app_access_requesting_app))
+- `cross_app_access_resource_app` (Block List, Max: 1) Resource App settings that apply to this connection. (EA only) (see [below for nested schema](#nestedblock--cross_app_access_resource_app))
 - `display_name` (String) Name used in login screen.
 - `is_domain_connection` (Boolean) Indicates whether the connection is domain level.
 - `metadata` (Map of String) Metadata associated with the connection, in the form of a map of string values (max 255 chars).
@@ -716,6 +717,14 @@ Required:
 Required:
 
 - `active` (Boolean)
+
+
+<a id="nestedblock--cross_app_access_resource_app"></a>
+### Nested Schema for `cross_app_access_resource_app`
+
+Required:
+
+- `status` (String) Whether the connection acts as a Cross App Access resource application. One of `enabled` or `disabled`. (EA only)
 
 
 <a id="nestedblock--options"></a>
@@ -788,6 +797,7 @@ Optional:
 - `mfa` (Block List, Max: 1) Configuration options for multifactor authentication. (see [below for nested schema](#nestedblock--options--mfa))
 - `name` (String) The public name of the email or SMS Connection. In most cases this is the same name as the connection name.
 - `non_persistent_attrs` (Set of String) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the DenyList here.
+- `oidc_metadata` (String) Additional OIDC metadata to include in the discovery document. Only applicable when strategy=oidc, okta, or samlp. (EA only)
 - `passkey_options` (Block List, Max: 1) Defines options for the passkey authentication method (see [below for nested schema](#nestedblock--options--passkey_options))
 - `password_complexity_options` (Block List, Max: 1) Configuration settings for password complexity. (see [below for nested schema](#nestedblock--options--password_complexity_options))
 - `password_dictionary` (Block List, Max: 1) Configuration settings for the password dictionary check, which does not allow passwords that are part of the password dictionary. (see [below for nested schema](#nestedblock--options--password_dictionary))

--- a/internal/auth0/client/expand.go
+++ b/internal/auth0/client/expand.go
@@ -43,23 +43,24 @@ func expandClient(data *schema.ResourceData) (*management.Client, error) {
 		IsTokenEndpointIPHeaderTrusted: value.Bool(config.GetAttr("is_token_endpoint_ip_header_trusted")),
 		// TODO(major): Replace OIDCBackchannelLogout with OIDCLogout when releasing v2.
 		//nolint:staticcheck // SA1019 — OIDCBackchannelLogout is deprecated, retained for backward compatibility.
-		OIDCBackchannelLogout:    expandOIDCBackchannelLogout(data),
-		OIDCLogout:               expandOIDCLogout(data),
-		ClientMetadata:           expandClientMetadata(data),
-		RefreshToken:             expandClientRefreshToken(data),
-		JWTConfiguration:         expandClientJWTConfiguration(data),
-		Addons:                   expandClientAddons(data),
-		NativeSocialLogin:        expandClientNativeSocialLogin(data),
-		Mobile:                   expandClientMobile(data),
-		DefaultOrganization:      expandDefaultOrganization(data),
-		TokenExchange:            expandTokenExchange(data),
-		RequireProofOfPossession: value.Bool(config.GetAttr("require_proof_of_possession")),
-		SessionTransfer:          expandSessionTransfer(data),
-		FedCMLogin:               expandClientFedCMLogin(data),
-		ComplianceLevel:          value.String(config.GetAttr("compliance_level")),
-		ThirdPartySecurityMode:   value.String(config.GetAttr("third_party_security_mode")),
-		RedirectionPolicy:        value.String(config.GetAttr("redirection_policy")),
-		TokenQuota:               commons.ExpandTokenQuota(config.GetAttr("token_quota")),
+		OIDCBackchannelLogout:               expandOIDCBackchannelLogout(data),
+		OIDCLogout:                          expandOIDCLogout(data),
+		ClientMetadata:                      expandClientMetadata(data),
+		RefreshToken:                        expandClientRefreshToken(data),
+		JWTConfiguration:                    expandClientJWTConfiguration(data),
+		Addons:                              expandClientAddons(data),
+		NativeSocialLogin:                   expandClientNativeSocialLogin(data),
+		Mobile:                              expandClientMobile(data),
+		DefaultOrganization:                 expandDefaultOrganization(data),
+		TokenExchange:                       expandTokenExchange(data),
+		RequireProofOfPossession:            value.Bool(config.GetAttr("require_proof_of_possession")),
+		SessionTransfer:                     expandSessionTransfer(data),
+		FedCMLogin:                          expandClientFedCMLogin(data),
+		IdentityAssertionAuthorizationGrant: expandClientIdentityAssertionAuthorizationGrant(data),
+		ComplianceLevel:                     value.String(config.GetAttr("compliance_level")),
+		ThirdPartySecurityMode:              value.String(config.GetAttr("third_party_security_mode")),
+		RedirectionPolicy:                   value.String(config.GetAttr("redirection_policy")),
+		TokenQuota:                          commons.ExpandTokenQuota(config.GetAttr("token_quota")),
 		SkipNonVerifiableCallbackURIConfirmationPrompt: value.BoolPtr(data.Get("skip_non_verifiable_callback_uri_confirmation_prompt")),
 		ExpressConfiguration:                           expandExpressConfiguration(data),
 		MyOrganizationConfiguration:                    expandMyOrganizationConfiguration(data),
@@ -392,6 +393,30 @@ func expandClientFedCMLoginGoogle(config cty.Value) *management.FedCMLoginGoogle
 	})
 
 	return &google
+}
+
+func expandClientIdentityAssertionAuthorizationGrant(data *schema.ResourceData) *management.IdentityAssertionAuthorizationGrant {
+	if !data.HasChange("identity_assertion_authorization_grant") {
+		return nil
+	}
+
+	grantConfig := data.GetRawConfig().GetAttr("identity_assertion_authorization_grant")
+
+	// When the block is removed from config we return nil here; the SDK's omitempty would
+	// then drop the field from the typed Update, so active removal is handled separately by
+	// fetchNullableFields, which sends {"identity_assertion_authorization_grant": null} via a raw PATCH.
+	if grantConfig.IsNull() || grantConfig.LengthInt() == 0 {
+		return nil
+	}
+
+	var grant management.IdentityAssertionAuthorizationGrant
+
+	grantConfig.ForEachElement(func(_ cty.Value, config cty.Value) (stop bool) {
+		grant.Active = value.Bool(config.GetAttr("active"))
+		return stop
+	})
+
+	return &grant
 }
 
 func expandClientMobile(data *schema.ResourceData) *management.ClientMobile {
@@ -1154,6 +1179,7 @@ func fetchNullableFields(data *schema.ResourceData, client *management.Client) m
 		"token_exchange":                                       isTokenExchangeNull,
 		"async_approval_notification_channels":                 isAsyncApprovalNotificationChannelsNull,
 		"fedcm_login":                                          isFedCMLoginNull,
+		"identity_assertion_authorization_grant":               isIdentityAssertionAuthorizationGrantNull,
 	}
 
 	nullableMap := make(map[string]interface{})
@@ -1289,6 +1315,15 @@ func isFedCMLoginNull(data *schema.ResourceData) bool {
 	}
 
 	rawConfig := data.GetRawConfig().GetAttr("fedcm_login")
+	return rawConfig.IsNull() || rawConfig.LengthInt() == 0
+}
+
+func isIdentityAssertionAuthorizationGrantNull(data *schema.ResourceData) bool {
+	if !data.IsNewResource() && !data.HasChange("identity_assertion_authorization_grant") {
+		return false
+	}
+
+	rawConfig := data.GetRawConfig().GetAttr("identity_assertion_authorization_grant")
 	return rawConfig.IsNull() || rawConfig.LengthInt() == 0
 }
 

--- a/internal/auth0/client/flatten.go
+++ b/internal/auth0/client/flatten.go
@@ -707,6 +707,7 @@ func flattenClient(data *schema.ResourceData, client *management.Client) error {
 		data.Set("redirection_policy", client.GetRedirectionPolicy()),
 		data.Set("session_transfer", flattenSessionTransfer(client.GetSessionTransfer())),
 		data.Set("fedcm_login", flattenFedCMLogin(client.GetFedCMLogin())),
+		data.Set("identity_assertion_authorization_grant", flattenClientIdentityAssertionAuthorizationGrant(client.GetIdentityAssertionAuthorizationGrant())),
 		data.Set("token_quota", commons.FlattenTokenQuota(client.GetTokenQuota())),
 		data.Set("resource_server_identifier", client.GetResourceServerIdentifier()),
 		data.Set("skip_non_verifiable_callback_uri_confirmation_prompt",
@@ -779,6 +780,18 @@ func flattenFedCMLoginGoogle(google *management.FedCMLoginGoogle) []interface{} 
 	return []interface{}{
 		map[string]interface{}{
 			"is_enabled": google.GetIsEnabled(),
+		},
+	}
+}
+
+func flattenClientIdentityAssertionAuthorizationGrant(grant *management.IdentityAssertionAuthorizationGrant) []interface{} {
+	if grant == nil {
+		return nil
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"active": grant.GetActive(),
 		},
 	}
 }

--- a/internal/auth0/client/flatten_test.go
+++ b/internal/auth0/client/flatten_test.go
@@ -179,3 +179,31 @@ func TestClientGrantScopesConflictWithAllowAll(t *testing.T) {
 		})
 	}
 }
+
+func TestFlattenClientIdentityAssertionAuthorizationGrant(t *testing.T) {
+	t.Run("returns nil when grant is nil", func(t *testing.T) {
+		assert.Nil(t, flattenClientIdentityAssertionAuthorizationGrant(nil))
+	})
+
+	t.Run("flattens active=true", func(t *testing.T) {
+		result := flattenClientIdentityAssertionAuthorizationGrant(&management.IdentityAssertionAuthorizationGrant{
+			Active: auth0.Bool(true),
+		})
+
+		assert.Len(t, result, 1)
+		flat, ok := result[0].(map[string]interface{})
+		assert.True(t, ok, "expected result[0] to be a map[string]interface{}")
+		assert.Equal(t, true, flat["active"])
+	})
+
+	t.Run("flattens active=false", func(t *testing.T) {
+		result := flattenClientIdentityAssertionAuthorizationGrant(&management.IdentityAssertionAuthorizationGrant{
+			Active: auth0.Bool(false),
+		})
+
+		assert.Len(t, result, 1)
+		flat, ok := result[0].(map[string]interface{})
+		assert.True(t, ok, "expected result[0] to be a map[string]interface{}")
+		assert.Equal(t, false, flat["active"])
+	})
+}

--- a/internal/auth0/client/resource.go
+++ b/internal/auth0/client/resource.go
@@ -1661,6 +1661,21 @@ func NewResource() *schema.Resource {
 					},
 				},
 			},
+			"identity_assertion_authorization_grant": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Configures the client to participate in the Identity Assertion Authorization Grant (ID-JAG) exchange, used for Cross App Access (XAA). (EA only)",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"active": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: "Whether the client can exchange ID-JAGs for access tokens. (EA only)",
+						},
+					},
+				},
+			},
 			"token_quota": commons.TokenQuotaSchema(),
 			"skip_non_verifiable_callback_uri_confirmation_prompt": {
 				Type:         schema.TypeString,

--- a/internal/auth0/client/resource_test.go
+++ b/internal/auth0/client/resource_test.go
@@ -3675,3 +3675,71 @@ func TestAccClientFedCMLogin(t *testing.T) {
 		},
 	})
 }
+
+const testAccCreateClientWithIdentityAssertionAuthorizationGrant = `
+resource "auth0_client" "my_client" {
+	name            = "Acceptance Test - ID JAG - {{.testName}}"
+	app_type        = "regular_web"
+	oidc_conformant = true
+	identity_assertion_authorization_grant {
+		active = true
+	}
+}
+`
+
+const testAccUpdateClientWithIdentityAssertionAuthorizationGrantFalse = `
+resource "auth0_client" "my_client" {
+	name            = "Acceptance Test - ID JAG - {{.testName}}"
+	app_type        = "regular_web"
+	oidc_conformant = true
+	identity_assertion_authorization_grant {
+		active = false
+	}
+}
+`
+
+const testAccClientWithoutIdentityAssertionAuthorizationGrant = `
+resource "auth0_client" "my_client" {
+	name            = "Acceptance Test - ID JAG - {{.testName}}"
+	app_type        = "regular_web"
+	oidc_conformant = true
+}
+`
+
+func TestAccClientIdentityAssertionAuthorizationGrant(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseTestName(testAccCreateClientWithIdentityAssertionAuthorizationGrant, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "name", fmt.Sprintf("Acceptance Test - ID JAG - %s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "identity_assertion_authorization_grant.#", "1"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "identity_assertion_authorization_grant.0.active", "true"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccUpdateClientWithIdentityAssertionAuthorizationGrantFalse, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "identity_assertion_authorization_grant.#", "1"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "identity_assertion_authorization_grant.0.active", "false"),
+				),
+			},
+			{
+				// Re-enable to exercise toggling active back on before testing removal.
+				Config: acctest.ParseTestName(testAccCreateClientWithIdentityAssertionAuthorizationGrant, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "identity_assertion_authorization_grant.#", "1"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "identity_assertion_authorization_grant.0.active", "true"),
+				),
+			},
+			{
+				// Dropping the block from config actively removes it via a raw PATCH
+				// ({"identity_assertion_authorization_grant": null}) issued by fetchNullableFields.
+				Config: acctest.ParseTestName(testAccClientWithoutIdentityAssertionAuthorizationGrant, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "identity_assertion_authorization_grant.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -79,6 +79,7 @@ func expandConnection(
 		Authentication:              expandConnectionAuthentication(data),
 		ConnectedAccounts:           expandConnectionConnectedAccounts(data),
 		CrossAppAccessRequestingApp: expandConnectionCrossAppAccessRequestingApp(data),
+		CrossAppAccessResourceApp:   expandConnectionCrossAppAccessResourceApp(data),
 	}
 
 	strategy := data.Get("strategy").(string)
@@ -185,6 +186,35 @@ func expandConnectionCrossAppAccessRequestingApp(data *schema.ResourceData) *man
 	})
 
 	return &crossAppAccessRequestingApp
+}
+
+func expandConnectionCrossAppAccessResourceApp(data *schema.ResourceData) *management.CrossAppAccessResourceApp {
+	if !data.HasChange("cross_app_access_resource_app") {
+		return nil
+	}
+
+	var resourceApp *management.CrossAppAccessResourceApp
+
+	// Returns nil when removed; updateConnection sends the null PATCH to actually remove it.
+	data.GetRawConfig().GetAttr("cross_app_access_resource_app").ForEachElement(func(_, config cty.Value) (stop bool) {
+		resourceApp = &management.CrossAppAccessResourceApp{
+			Status: value.String(config.GetAttr("status")),
+		}
+
+		return stop
+	})
+
+	return resourceApp
+}
+
+// isConnectionCrossAppAccessResourceAppNull reports whether the block was removed from config.
+func isConnectionCrossAppAccessResourceAppNull(data *schema.ResourceData) bool {
+	if !data.HasChange("cross_app_access_resource_app") {
+		return false
+	}
+
+	rawConfig := data.GetRawConfig().GetAttr("cross_app_access_resource_app")
+	return rawConfig.IsNull() || rawConfig.LengthInt() == 0
 }
 
 func connectionIsEnterprise(strategy string) bool {
@@ -1080,6 +1110,11 @@ func expandConnectionOptionsOIDC(data *schema.ResourceData, config cty.Value) (i
 	expandConnectionOptionsScopes(data, options)
 
 	options.UpstreamParams, err = value.MapFromJSON(config.GetAttr("upstream_params"))
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+
+	options.OIDCMetadata, err = value.MapFromJSON(config.GetAttr("oidc_metadata"))
 
 	return options, diag.FromErr(err)
 }
@@ -1138,6 +1173,11 @@ func expandConnectionOptionsOkta(data *schema.ResourceData, config cty.Value) (i
 	expandConnectionOptionsScopes(data, options)
 
 	options.UpstreamParams, err = value.MapFromJSON(config.GetAttr("upstream_params"))
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+
+	options.OIDCMetadata, err = value.MapFromJSON(config.GetAttr("oidc_metadata"))
 
 	return options, diag.FromErr(err)
 }
@@ -1176,6 +1216,7 @@ func expandConnectionOptionsSAML(_ *schema.ResourceData, config cty.Value) (inte
 		GlobalTokenRevocationJWTSub: value.String(config.GetAttr("global_token_revocation_jwt_sub")),
 		DestinationURL:              value.String(config.GetAttr("destination_url")),
 		RecipientURL:                value.String(config.GetAttr("recipient_url")),
+		DiscoveryURL:                value.String(config.GetAttr("discovery_url")),
 	}
 
 	options.SetUserAttributes = value.String(config.GetAttr("set_user_root_attributes"))
@@ -1218,6 +1259,9 @@ func expandConnectionOptionsSAML(_ *schema.ResourceData, config cty.Value) (inte
 	diagnostics := diag.FromErr(err)
 
 	options.UpstreamParams, err = value.MapFromJSON(config.GetAttr("upstream_params"))
+	diagnostics = append(diagnostics, diag.FromErr(err)...)
+
+	options.OIDCMetadata, err = value.MapFromJSON(config.GetAttr("oidc_metadata"))
 	diagnostics = append(diagnostics, diag.FromErr(err)...)
 
 	return options, diagnostics

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -1110,11 +1110,6 @@ func expandConnectionOptionsOIDC(data *schema.ResourceData, config cty.Value) (i
 	expandConnectionOptionsScopes(data, options)
 
 	options.UpstreamParams, err = value.MapFromJSON(config.GetAttr("upstream_params"))
-	if err != nil {
-		return nil, diag.FromErr(err)
-	}
-
-	options.OIDCMetadata, err = value.MapFromJSON(config.GetAttr("oidc_metadata"))
 
 	return options, diag.FromErr(err)
 }
@@ -1173,11 +1168,6 @@ func expandConnectionOptionsOkta(data *schema.ResourceData, config cty.Value) (i
 	expandConnectionOptionsScopes(data, options)
 
 	options.UpstreamParams, err = value.MapFromJSON(config.GetAttr("upstream_params"))
-	if err != nil {
-		return nil, diag.FromErr(err)
-	}
-
-	options.OIDCMetadata, err = value.MapFromJSON(config.GetAttr("oidc_metadata"))
 
 	return options, diag.FromErr(err)
 }

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -78,6 +78,7 @@ func flattenConnection(data *schema.ResourceData, connection *management.Connect
 		data.Set("authentication", flattenConnectionAuthentication(connection.GetAuthentication())),
 		data.Set("connected_accounts", flattenConnectionConnectedAccounts(connection.GetConnectedAccounts())),
 		data.Set("cross_app_access_requesting_app", flattenConnectionCrossAppAccessRequestingApp(connection.GetCrossAppAccessRequestingApp())),
+		data.Set("cross_app_access_resource_app", flattenConnectionCrossAppAccessResourceApp(connection.GetCrossAppAccessResourceApp())),
 	)
 
 	if connectionIsEnterprise(connection.GetStrategy()) {
@@ -136,6 +137,20 @@ func flattenConnectionCrossAppAccessRequestingApp(crossAppAccessRequestingApp *m
 
 	flattened := map[string]interface{}{
 		"active": crossAppAccessRequestingApp.GetActive(),
+	}
+
+	return []interface{}{
+		flattened,
+	}
+}
+
+func flattenConnectionCrossAppAccessResourceApp(resourceApp *management.CrossAppAccessResourceApp) []interface{} {
+	if resourceApp == nil {
+		return nil
+	}
+
+	flattened := map[string]interface{}{
+		"status": resourceApp.GetStatus(),
 	}
 
 	return []interface{}{
@@ -861,6 +876,11 @@ func flattenConnectionOptionsOIDC(
 		return nil, diag.FromErr(err)
 	}
 
+	oidcMetadata, err := structure.FlattenJsonToString(options.GetOIDCMetadata())
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+
 	optionsMap := map[string]interface{}{
 		"client_id":                         options.GetClientID(),
 		"client_secret":                     options.GetClientSecret(),
@@ -879,6 +899,7 @@ func flattenConnectionOptionsOIDC(
 		"set_user_root_attributes":          options.GetSetUserAttributes(),
 		"non_persistent_attrs":              options.GetNonPersistentAttrs(),
 		"upstream_params":                   upstreamParams,
+		"oidc_metadata":                     oidcMetadata,
 		"token_endpoint_auth_method":        options.GetTokenEndpointAuthMethod(),
 		"token_endpoint_auth_signing_alg":   options.GetTokenEndpointAuthSigningAlg(),
 		"dpop_signing_alg":                  options.GetDPoPSigningAlg(),
@@ -935,6 +956,11 @@ func flattenConnectionOptionsOkta(
 		return nil, diag.FromErr(err)
 	}
 
+	oidcMetadata, err := structure.FlattenJsonToString(options.GetOIDCMetadata())
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+
 	optionsMap := map[string]interface{}{
 		"client_id":                         options.GetClientID(),
 		"client_secret":                     options.GetClientSecret(),
@@ -952,6 +978,7 @@ func flattenConnectionOptionsOkta(
 		"type":                              options.GetType(),
 		"send_back_channel_nonce":           options.GetSendBackChannelNonce(),
 		"upstream_params":                   upstreamParams,
+		"oidc_metadata":                     oidcMetadata,
 		"token_endpoint_auth_method":        options.GetTokenEndpointAuthMethod(),
 		"token_endpoint_auth_signing_alg":   options.GetTokenEndpointAuthSigningAlg(),
 		"dpop_signing_alg":                  options.GetDPoPSigningAlg(),
@@ -1175,6 +1202,11 @@ func flattenConnectionOptionsSAML(
 		return nil, diag.FromErr(err)
 	}
 
+	oidcMetadata, err := structure.FlattenJsonToString(options.GetOIDCMetadata())
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+
 	optionsMap := map[string]interface{}{
 		"signing_cert":                    options.GetSigningCert(),
 		"protocol_binding":                options.GetProtocolBinding(),
@@ -1198,6 +1230,8 @@ func flattenConnectionOptionsSAML(
 		"strategy_version":                options.GetStrategyVersion(),
 		"fields_map":                      fieldsMap,
 		"upstream_params":                 upstreamParams,
+		"oidc_metadata":                   oidcMetadata,
+		"discovery_url":                   options.GetDiscoveryURL(),
 		"global_token_revocation_jwt_iss": options.GetGlobalTokenRevocationJWTIss(),
 		"global_token_revocation_jwt_sub": options.GetGlobalTokenRevocationJWTSub(),
 		"destination_url":                 options.GetDestinationURL(),

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -876,11 +876,6 @@ func flattenConnectionOptionsOIDC(
 		return nil, diag.FromErr(err)
 	}
 
-	oidcMetadata, err := structure.FlattenJsonToString(options.GetOIDCMetadata())
-	if err != nil {
-		return nil, diag.FromErr(err)
-	}
-
 	optionsMap := map[string]interface{}{
 		"client_id":                         options.GetClientID(),
 		"client_secret":                     options.GetClientSecret(),
@@ -899,7 +894,6 @@ func flattenConnectionOptionsOIDC(
 		"set_user_root_attributes":          options.GetSetUserAttributes(),
 		"non_persistent_attrs":              options.GetNonPersistentAttrs(),
 		"upstream_params":                   upstreamParams,
-		"oidc_metadata":                     oidcMetadata,
 		"token_endpoint_auth_method":        options.GetTokenEndpointAuthMethod(),
 		"token_endpoint_auth_signing_alg":   options.GetTokenEndpointAuthSigningAlg(),
 		"dpop_signing_alg":                  options.GetDPoPSigningAlg(),
@@ -956,11 +950,6 @@ func flattenConnectionOptionsOkta(
 		return nil, diag.FromErr(err)
 	}
 
-	oidcMetadata, err := structure.FlattenJsonToString(options.GetOIDCMetadata())
-	if err != nil {
-		return nil, diag.FromErr(err)
-	}
-
 	optionsMap := map[string]interface{}{
 		"client_id":                         options.GetClientID(),
 		"client_secret":                     options.GetClientSecret(),
@@ -978,7 +967,6 @@ func flattenConnectionOptionsOkta(
 		"type":                              options.GetType(),
 		"send_back_channel_nonce":           options.GetSendBackChannelNonce(),
 		"upstream_params":                   upstreamParams,
-		"oidc_metadata":                     oidcMetadata,
 		"token_endpoint_auth_method":        options.GetTokenEndpointAuthMethod(),
 		"token_endpoint_auth_signing_alg":   options.GetTokenEndpointAuthSigningAlg(),
 		"dpop_signing_alg":                  options.GetDPoPSigningAlg(),

--- a/internal/auth0/connection/flatten_test.go
+++ b/internal/auth0/connection/flatten_test.go
@@ -3,8 +3,10 @@ package connection
 import (
 	"testing"
 
+	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFlattenConnectionOptions(t *testing.T) {
@@ -98,5 +100,33 @@ func TestFlattenAuthenticationMethodPassword(t *testing.T) {
 		if m["signup_behavior"] != "allow" {
 			t.Errorf("Expected signup_behavior default=allow, got %q", m["signup_behavior"])
 		}
+	})
+}
+
+func TestFlattenConnectionCrossAppAccessResourceApp(t *testing.T) {
+	t.Run("returns nil when resource app is nil", func(t *testing.T) {
+		assert.Nil(t, flattenConnectionCrossAppAccessResourceApp(nil))
+	})
+
+	t.Run("flattens status enabled", func(t *testing.T) {
+		result := flattenConnectionCrossAppAccessResourceApp(&management.CrossAppAccessResourceApp{
+			Status: auth0.String("enabled"),
+		})
+
+		assert.Len(t, result, 1)
+		flat, ok := result[0].(map[string]interface{})
+		assert.True(t, ok, "expected result[0] to be a map[string]interface{}")
+		assert.Equal(t, "enabled", flat["status"])
+	})
+
+	t.Run("flattens status disabled", func(t *testing.T) {
+		result := flattenConnectionCrossAppAccessResourceApp(&management.CrossAppAccessResourceApp{
+			Status: auth0.String("disabled"),
+		})
+
+		assert.Len(t, result, 1)
+		flat, ok := result[0].(map[string]interface{})
+		assert.True(t, ok, "expected result[0] to be a map[string]interface{}")
+		assert.Equal(t, "disabled", flat["status"])
 	})
 }

--- a/internal/auth0/connection/resource.go
+++ b/internal/auth0/connection/resource.go
@@ -2,6 +2,7 @@ package connection
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -63,6 +64,14 @@ func updateConnection(ctx context.Context, data *schema.ResourceData, meta inter
 	connection, diagnostics := expandConnection(ctx, data, api)
 	if diagnostics.HasError() {
 		return diagnostics
+	}
+
+	// omitempty drops the nil field from the typed Update, so null it out via a raw PATCH.
+	if isConnectionCrossAppAccessResourceAppNull(data) {
+		nullFields := map[string]interface{}{"cross_app_access_resource_app": nil}
+		if err := api.Request(ctx, http.MethodPatch, api.URI("connections", data.Id()), nullFields); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	if err := api.Connection.Update(ctx, data.Id(), connection); err != nil {

--- a/internal/auth0/connection/resource.go
+++ b/internal/auth0/connection/resource.go
@@ -66,7 +66,7 @@ func updateConnection(ctx context.Context, data *schema.ResourceData, meta inter
 		return diagnostics
 	}
 
-	// omitempty drops the nil field from the typed Update, so null it out via a raw PATCH.
+	// The typed Update drops the nil field (omitempty), so null it out via a raw PATCH.
 	if isConnectionCrossAppAccessResourceAppNull(data) {
 		nullFields := map[string]interface{}{"cross_app_access_resource_app": nil}
 		if err := api.Request(ctx, http.MethodPatch, api.URI("connections", data.Id()), nullFields); err != nil {

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -3584,3 +3584,155 @@ func TestAccConnectionPasswordHash(t *testing.T) {
 		},
 	})
 }
+
+const testAccConnectionCrossAppAccessResourceAppEnabled = `
+resource "auth0_connection" "oidc" {
+	name     = "Acceptance-Test-XAA-{{.testName}}"
+	strategy = "oidc"
+	options {
+		client_id     = "123456"
+		client_secret = "123456"
+		type          = "back_channel"
+		issuer        = "https://api.login.yahoo.com"
+		jwks_uri      = "https://api.login.yahoo.com/openid/v1/certs"
+		discovery_url = "https://api.login.yahoo.com/.well-known/openid-configuration"
+		scopes        = ["openid", "profile"]
+	}
+
+	cross_app_access_resource_app {
+		status = "enabled"
+	}
+}
+`
+
+const testAccConnectionCrossAppAccessResourceAppDisabled = `
+resource "auth0_connection" "oidc" {
+	name     = "Acceptance-Test-XAA-{{.testName}}"
+	strategy = "oidc"
+	options {
+		client_id     = "123456"
+		client_secret = "123456"
+		type          = "back_channel"
+		issuer        = "https://api.login.yahoo.com"
+		jwks_uri      = "https://api.login.yahoo.com/openid/v1/certs"
+		discovery_url = "https://api.login.yahoo.com/.well-known/openid-configuration"
+		scopes        = ["openid", "profile"]
+	}
+
+	cross_app_access_resource_app {
+		status = "disabled"
+	}
+}
+`
+
+const testAccConnectionCrossAppAccessResourceAppRemoved = `
+resource "auth0_connection" "oidc" {
+	name     = "Acceptance-Test-XAA-{{.testName}}"
+	strategy = "oidc"
+	options {
+		client_id     = "123456"
+		client_secret = "123456"
+		type          = "back_channel"
+		issuer        = "https://api.login.yahoo.com"
+		jwks_uri      = "https://api.login.yahoo.com/openid/v1/certs"
+		discovery_url = "https://api.login.yahoo.com/.well-known/openid-configuration"
+		scopes        = ["openid", "profile"]
+	}
+}
+`
+
+func TestAccConnectionCrossAppAccessResourceApp(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseTestName(testAccConnectionCrossAppAccessResourceAppEnabled, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "name", fmt.Sprintf("Acceptance-Test-XAA-%s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "strategy", "oidc"),
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "cross_app_access_resource_app.#", "1"),
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "cross_app_access_resource_app.0.status", "enabled"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccConnectionCrossAppAccessResourceAppDisabled, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "cross_app_access_resource_app.#", "1"),
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "cross_app_access_resource_app.0.status", "disabled"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccConnectionCrossAppAccessResourceAppRemoved, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "cross_app_access_resource_app.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// testAccConnectionSAMLOIDCMetadata mirrors the validated CN_SAML2 audit case: a SAML
+// connection acting as a Cross App Access resource application, with the OIDC discovery
+// document uploaded directly via oidc_metadata (no discovery_url). When discovery_url is
+// absent the API preserves the uploaded document verbatim, so the value round-trips and
+// the plan stays empty.
+const testAccConnectionSAMLOIDCMetadata = `
+resource "auth0_connection" "saml" {
+	name     = "Acceptance-Test-OIDCMeta-{{.testName}}"
+	strategy = "samlp"
+	options {
+		sign_in_endpoint = "https://saml.example.com/sso"
+		signing_cert     = <<EOF
+-----BEGIN CERTIFICATE-----
+MIIDCzCCAfOgAwIBAgIUCdRoetBaO+Fr+NdcNdtnL0slU0swDQYJKoZIhvcNAQEL
+BQAwFTETMBEGA1UEAwwKZXhhbXBsZS5jbzAeFw0yNjA3MjMxMDQyMjZaFw0zNjA3
+MjAxMDQyMjZaMBUxEzARBgNVBAMMCmV4YW1wbGUuY28wggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCvkWF+EDRDxldOx5rqvecWO1fDElU3qEArKzs05vSK
+V4wyndGBLtGcmPNMM3rftyHquGQHjFyxo9lv91xBSTv8vxPox6WbtcoDxRbItyco
+dfhp1cst6D2e7/HC6lttMeCH6lyN7VBWzz8+j7EKe7aW7x23f0WQFU5VbScgxnBY
+6terHOUdHSdS57YrCvyWXPtuQ1J9eJOuLsntRKtTorqWf833IYPC9UJQFWcj3H+A
+T1qayQFpCCcGTi8AY1QWb6soSqu31D1ntr5xQBygkZN2hqAHuoZvJce0ZKuOu57a
+33Zc6eniuVO51zgUlG+sW/g9tQyzLw/isIni9Uv1WphrAgMBAAGjUzBRMB0GA1Ud
+DgQWBBQl3+X4u7aRQRaRpPPMO2gypy6uPzAfBgNVHSMEGDAWgBQl3+X4u7aRQRaR
+pPPMO2gypy6uPzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBt
+/MuP34GNq+orLEwDqBzDRQK0Ty4jSOM5ZGfdSBHZhypHWUcvQdGNkxeK9cu8WJC/
+8ulovvgnKyWVzVKezdhpCmNInldsuxWC2I9Wu0LB3Jr203BPFNcpAFE6c+aT6ASd
+GtuQ6kElsyfcwCJvIr9RzP2DSPftwCRgqTriJCLRmYf71eV5OFvhkCVQPU1H2Giw
+V1oF1EfQM54000xuVEUlhFlFQHmHmRfeX1Aqir8cXGefdxr3t6bAM3PgM93e/dET
+qzsMQBATo8yKgrirPzmNc5bxfhKS+3fpQOFON+tqsgnXnb9Hksd7zJ52TM5w3RyZ
+/OY2k3sWyAuCKbX1Em/h
+-----END CERTIFICATE-----
+EOF
+
+		oidc_metadata = jsonencode({
+			issuer                                = "https://idp.apitest-xaa.example.com"
+			jwks_uri                              = "https://idp.apitest-xaa.example.com/jwks"
+			authorization_endpoint                = "https://idp.apitest-xaa.example.com/authorize"
+			token_endpoint                        = "https://idp.apitest-xaa.example.com/token"
+			response_types_supported              = ["code"]
+			subject_types_supported               = ["public"]
+			id_token_signing_alg_values_supported = ["RS256"]
+		})
+	}
+
+	cross_app_access_resource_app {
+		status = "enabled"
+	}
+}
+`
+
+func TestAccConnectionOIDCMetadata(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseTestName(testAccConnectionSAMLOIDCMetadata, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.saml", "name", fmt.Sprintf("Acceptance-Test-OIDCMeta-%s", t.Name())),
+					resource.TestCheckResourceAttr("auth0_connection.saml", "strategy", "samlp"),
+					resource.TestCheckResourceAttr("auth0_connection.saml", "cross_app_access_resource_app.0.status", "enabled"),
+					resource.TestCheckResourceAttrSet("auth0_connection.saml", "options.0.oidc_metadata"),
+					resource.TestCheckResourceAttr("auth0_connection.saml", "options.0.oidc_metadata", "{\"authorization_endpoint\":\"https://idp.apitest-xaa.example.com/authorize\",\"id_token_signing_alg_values_supported\":[\"RS256\"],\"issuer\":\"https://idp.apitest-xaa.example.com\",\"jwks_uri\":\"https://idp.apitest-xaa.example.com/jwks\",\"response_types_supported\":[\"code\"],\"subject_types_supported\":[\"public\"],\"token_endpoint\":\"https://idp.apitest-xaa.example.com/token\"}"),
+				),
+			},
+		},
+	})
+}

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -80,6 +80,7 @@ var resourceSchema = map[string]*schema.Schema{
 	"authentication":                  authenticationSchema,
 	"connected_accounts":              connectedAccountsSchema,
 	"cross_app_access_requesting_app": crossAppAccessRequestingAppSchema,
+	"cross_app_access_resource_app":   crossAppAccessResourceAppSchema,
 }
 
 var optionsSchema = &schema.Schema{
@@ -981,6 +982,13 @@ var optionsSchema = &schema.Schema{
 				Description: "You can pass provider-specific parameters to an identity provider during " +
 					"authentication. The values can either be static per connection or dynamic per user.",
 			},
+			"oidc_metadata": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Description:  "Additional OIDC metadata to include in the discovery document. Only applicable when strategy=oidc, okta, or samlp. (EA only)",
+			},
 			"global_token_revocation_jwt_iss": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -1687,6 +1695,23 @@ var crossAppAccessRequestingAppSchema = &schema.Schema{
 			"active": {
 				Type:     schema.TypeBool,
 				Required: true,
+			},
+		},
+	},
+}
+
+var crossAppAccessResourceAppSchema = &schema.Schema{
+	Type:        schema.TypeList,
+	Optional:    true,
+	MaxItems:    1,
+	Description: "Resource App settings that apply to this connection. (EA only)",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"status": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"enabled", "disabled"}, false),
+				Description:  "Whether the connection acts as a Cross App Access resource application. One of `enabled` or `disabled`. (EA only)",
 			},
 		},
 	},

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
@@ -983,11 +984,12 @@ var optionsSchema = &schema.Schema{
 					"authentication. The values can either be static per connection or dynamic per user.",
 			},
 			"oidc_metadata": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringIsJSON,
-				Description:  "Additional OIDC metadata to include in the discovery document. Only applicable when strategy=oidc, okta, or samlp. (EA only)",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: structure.SuppressJsonDiff,
+				Description:      "Additional OIDC metadata to include in the discovery document. Only applicable when strategy=oidc, okta, or samlp. (EA only)",
 			},
 			"global_token_revocation_jwt_iss": {
 				Type:        schema.TypeString,

--- a/test/data/recordings/TestAccClientIdentityAssertionAuthorizationGrant.yaml
+++ b/test/data/recordings/TestAccClientIdentityAssertionAuthorizationGrant.yaml
@@ -1,0 +1,579 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 242
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","app_type":"regular_web","oidc_conformant":true,"token_endpoint_auth_method":"client_secret_post","identity_assertion_authorization_grant":{"active":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 671.803791ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 313.726458ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 307.538291ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 302.439667ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 193
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","app_type":"regular_web","oidc_conformant":true,"identity_assertion_authorization_grant":{"active":false}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":false}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 332.688416ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":false}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 326.827ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":false}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 291.201541ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":false}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 292.103834ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 192
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","app_type":"regular_web","oidc_conformant":true,"identity_assertion_authorization_grant":{"active":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 293.324083ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 341.001791ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 301.035625ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"identity_assertion_authorization_grant":{"active":true}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 301.035625ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 46
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"identity_assertion_authorization_grant":null}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 310.638375ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 85
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 306.865667ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 294.808375ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - ID JAG - TestAccClientIdentityAssertionAuthorizationGrant","client_id":"euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC","client_secret":"[REDACTED]","app_type":"regular_web","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":true,"jwt_configuration":{"secret_encoded":false,"lifetime_in_seconds":36000},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 291.201541ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/euHQ5zT5OQnWXhzRBKucJiwdQxK97VqC
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 299.756667ms

--- a/test/data/recordings/TestAccConnectionCrossAppAccessResourceApp.yaml
+++ b/test/data/recordings/TestAccConnectionCrossAppAccessResourceApp.yaml
@@ -1,0 +1,444 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 502
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","strategy":"oidc","cross_app_access_resource_app":{"status":"enabled"},"options":{"client_id":"123456","client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","authorization_endpoint":null,"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","type":"back_channel","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid profile"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"client_id":"123456","client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","type":"back_channel","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","scope":"openid profile","oidc_metadata":{"issuer":"https://api.login.yahoo.com","authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"subject_types_supported":["public"],"grant_types_supported":["authorization_code","refresh_token"],"id_token_signing_alg_values_supported":["ES256","RS256"],"scopes_supported":["openid","openid2","profile","email"],"acr_values_supported":["AAL1","AAL2"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"],"claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"response_modes_supported":["query"],"display_values_supported":["page"],"claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false},"schema_version":"oidc-V4","attribute_map":{"mapping_mode":"bind_all"},"connection_settings":{"pkce":"auto"}},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","enabled_clients":[],"realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"],"cross_app_access_resource_app":{"status":"enabled"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 644.449916ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"type":"back_channel","scope":"openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth"},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"],"cross_app_access_resource_app":{"status":"enabled"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 2.732062084s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"type":"back_channel","scope":"openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth"},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"],"cross_app_access_resource_app":{"status":"enabled"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 748.650792ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"type":"back_channel","scope":"openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"auto"},"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth"},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"],"cross_app_access_resource_app":{"status":"enabled"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 431.344458ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 413
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"cross_app_access_resource_app":{"status":"disabled"},"options":{"client_id":"123456","client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","authorization_endpoint":null,"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","type":"back_channel","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid profile"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"type":"back_channel","scope":"openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth"},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"],"cross_app_access_resource_app":{"status":"disabled"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 552.645375ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"type":"back_channel","scope":"openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth"},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"],"cross_app_access_resource_app":{"status":"disabled"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 941.664542ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"type":"back_channel","scope":"openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth"},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"],"cross_app_access_resource_app":{"status":"disabled"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 436.842958ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"type":"back_channel","scope":"openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth"},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"],"cross_app_access_resource_app":{"status":"disabled"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 441.884959ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 39
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"cross_app_access_resource_app":null}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"type":"back_channel","scope":"openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth"},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 382.841042ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 359
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"options":{"client_id":"123456","client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","authorization_endpoint":null,"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","type":"back_channel","userinfo_endpoint":null,"token_endpoint":null,"scope":"openid profile"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"type":"back_channel","scope":"openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth"},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 683.752417ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"type":"back_channel","scope":"openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth"},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 401.845292ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_RsufCMYIFGCvOth8","options":{"type":"back_channel","scope":"openid profile","issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","client_id":"123456","attribute_map":{"mapping_mode":"bind_all"},"client_secret":"123456","discovery_url":"https://api.login.yahoo.com/.well-known/openid-configuration","oidc_metadata":{"issuer":"https://api.login.yahoo.com","jwks_uri":"https://api.login.yahoo.com/openid/v1/certs","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","claims_supported":["aud","email","email_verified","birthdate","exp","family_name","given_name","iat","iss","locale","name","sub","auth_time"],"scopes_supported":["openid","openid2","profile","email"],"userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","acr_values_supported":["AAL1","AAL2"],"grant_types_supported":["authorization_code","refresh_token"],"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth","introspection_endpoint":"https://api.login.yahoo.com/oauth2/introspect","subject_types_supported":["public"],"display_values_supported":["page"],"response_modes_supported":["query"],"response_types_supported":["code","token","id_token","code token","code id_token","token id_token","code token id_token"],"token_revocation_endpoint":"https://api.login.yahoo.com/oauth2/revoke","claims_parameter_supported":false,"request_parameter_supported":false,"request_uri_parameter_supported":false,"require_request_uri_registration":false,"id_token_signing_alg_values_supported":["ES256","RS256"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post"]},"schema_version":"oidc-V4","token_endpoint":"https://api.login.yahoo.com/oauth2/get_token","userinfo_endpoint":"https://api.login.yahoo.com/openid/v1/userinfo","connection_settings":{"pkce":"disabled"},"authorization_endpoint":"https://api.login.yahoo.com/oauth2/request_auth"},"strategy":"oidc","name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"display_name":"Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp","realms":["Acceptance-Test-XAA-TestAccConnectionCrossAppAccessResourceApp"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 356.106709ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RsufCMYIFGCvOth8
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-07-24T09:56:03.716Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 448.9ms

--- a/test/data/recordings/TestAccConnectionOIDCMetadata.yaml
+++ b/test/data/recordings/TestAccConnectionOIDCMetadata.yaml
@@ -1,0 +1,138 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1725
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-OIDCMeta-TestAccConnectionOIDCMetadata","strategy":"samlp","cross_app_access_resource_app":{"status":"enabled"},"options":{"signingCert":"-----BEGIN CERTIFICATE-----\nMIIDCzCCAfOgAwIBAgIUCdRoetBaO+Fr+NdcNdtnL0slU0swDQYJKoZIhvcNAQEL\nBQAwFTETMBEGA1UEAwwKZXhhbXBsZS5jbzAeFw0yNjA3MjMxMDQyMjZaFw0zNjA3\nMjAxMDQyMjZaMBUxEzARBgNVBAMMCmV4YW1wbGUuY28wggEiMA0GCSqGSIb3DQEB\nAQUAA4IBDwAwggEKAoIBAQCvkWF+EDRDxldOx5rqvecWO1fDElU3qEArKzs05vSK\nV4wyndGBLtGcmPNMM3rftyHquGQHjFyxo9lv91xBSTv8vxPox6WbtcoDxRbItyco\ndfhp1cst6D2e7/HC6lttMeCH6lyN7VBWzz8+j7EKe7aW7x23f0WQFU5VbScgxnBY\n6terHOUdHSdS57YrCvyWXPtuQ1J9eJOuLsntRKtTorqWf833IYPC9UJQFWcj3H+A\nT1qayQFpCCcGTi8AY1QWb6soSqu31D1ntr5xQBygkZN2hqAHuoZvJce0ZKuOu57a\n33Zc6eniuVO51zgUlG+sW/g9tQyzLw/isIni9Uv1WphrAgMBAAGjUzBRMB0GA1Ud\nDgQWBBQl3+X4u7aRQRaRpPPMO2gypy6uPzAfBgNVHSMEGDAWgBQl3+X4u7aRQRaR\npPPMO2gypy6uPzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBt\n/MuP34GNq+orLEwDqBzDRQK0Ty4jSOM5ZGfdSBHZhypHWUcvQdGNkxeK9cu8WJC/\n8ulovvgnKyWVzVKezdhpCmNInldsuxWC2I9Wu0LB3Jr203BPFNcpAFE6c+aT6ASd\nGtuQ6kElsyfcwCJvIr9RzP2DSPftwCRgqTriJCLRmYf71eV5OFvhkCVQPU1H2Giw\nV1oF1EfQM54000xuVEUlhFlFQHmHmRfeX1Aqir8cXGefdxr3t6bAM3PgM93e/dET\nqzsMQBATo8yKgrirPzmNc5bxfhKS+3fpQOFON+tqsgnXnb9Hksd7zJ52TM5w3RyZ\n/OY2k3sWyAuCKbX1Em/h\n-----END CERTIFICATE-----\n","signInEndpoint":"https://saml.example.com/sso","oidc_metadata":{"authorization_endpoint":"https://idp.apitest-xaa.example.com/authorize","id_token_signing_alg_values_supported":["RS256"],"issuer":"https://idp.apitest-xaa.example.com","jwks_uri":"https://idp.apitest-xaa.example.com/jwks","response_types_supported":["code"],"subject_types_supported":["public"],"token_endpoint":"https://idp.apitest-xaa.example.com/token"}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_mNTZceGwlPxyG0h8","options":{"signingCert":"-----BEGIN CERTIFICATE-----\nMIIDCzCCAfOgAwIBAgIUCdRoetBaO+Fr+NdcNdtnL0slU0swDQYJKoZIhvcNAQEL\nBQAwFTETMBEGA1UEAwwKZXhhbXBsZS5jbzAeFw0yNjA3MjMxMDQyMjZaFw0zNjA3\nMjAxMDQyMjZaMBUxEzARBgNVBAMMCmV4YW1wbGUuY28wggEiMA0GCSqGSIb3DQEB\nAQUAA4IBDwAwggEKAoIBAQCvkWF+EDRDxldOx5rqvecWO1fDElU3qEArKzs05vSK\nV4wyndGBLtGcmPNMM3rftyHquGQHjFyxo9lv91xBSTv8vxPox6WbtcoDxRbItyco\ndfhp1cst6D2e7/HC6lttMeCH6lyN7VBWzz8+j7EKe7aW7x23f0WQFU5VbScgxnBY\n6terHOUdHSdS57YrCvyWXPtuQ1J9eJOuLsntRKtTorqWf833IYPC9UJQFWcj3H+A\nT1qayQFpCCcGTi8AY1QWb6soSqu31D1ntr5xQBygkZN2hqAHuoZvJce0ZKuOu57a\n33Zc6eniuVO51zgUlG+sW/g9tQyzLw/isIni9Uv1WphrAgMBAAGjUzBRMB0GA1Ud\nDgQWBBQl3+X4u7aRQRaRpPPMO2gypy6uPzAfBgNVHSMEGDAWgBQl3+X4u7aRQRaR\npPPMO2gypy6uPzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBt\n/MuP34GNq+orLEwDqBzDRQK0Ty4jSOM5ZGfdSBHZhypHWUcvQdGNkxeK9cu8WJC/\n8ulovvgnKyWVzVKezdhpCmNInldsuxWC2I9Wu0LB3Jr203BPFNcpAFE6c+aT6ASd\nGtuQ6kElsyfcwCJvIr9RzP2DSPftwCRgqTriJCLRmYf71eV5OFvhkCVQPU1H2Giw\nV1oF1EfQM54000xuVEUlhFlFQHmHmRfeX1Aqir8cXGefdxr3t6bAM3PgM93e/dET\nqzsMQBATo8yKgrirPzmNc5bxfhKS+3fpQOFON+tqsgnXnb9Hksd7zJ52TM5w3RyZ\n/OY2k3sWyAuCKbX1Em/h\n-----END CERTIFICATE-----\n","signInEndpoint":"https://saml.example.com/sso","oidc_metadata":{"authorization_endpoint":"https://idp.apitest-xaa.example.com/authorize","id_token_signing_alg_values_supported":["RS256"],"issuer":"https://idp.apitest-xaa.example.com","jwks_uri":"https://idp.apitest-xaa.example.com/jwks","response_types_supported":["code"],"subject_types_supported":["public"],"token_endpoint":"https://idp.apitest-xaa.example.com/token"},"assertion_decryption_settings":{"algorithm_profile":"v2026-1","algorithm_exceptions":[]},"expires":"2036-07-20T10:42:26.000Z","subject":{"commonName":"example.co"},"thumbprints":["560d54ca2b8ec192668e18a8d0bac5c8cd51e151"],"cert":"-----BEGIN CERTIFICATE-----\nMIIDCzCCAfOgAwIBAgIUCdRoetBaO+Fr+NdcNdtnL0slU0swDQYJKoZIhvcNAQEL\nBQAwFTETMBEGA1UEAwwKZXhhbXBsZS5jbzAeFw0yNjA3MjMxMDQyMjZaFw0zNjA3\nMjAxMDQyMjZaMBUxEzARBgNVBAMMCmV4YW1wbGUuY28wggEiMA0GCSqGSIb3DQEB\nAQUAA4IBDwAwggEKAoIBAQCvkWF+EDRDxldOx5rqvecWO1fDElU3qEArKzs05vSK\nV4wyndGBLtGcmPNMM3rftyHquGQHjFyxo9lv91xBSTv8vxPox6WbtcoDxRbItyco\ndfhp1cst6D2e7/HC6lttMeCH6lyN7VBWzz8+j7EKe7aW7x23f0WQFU5VbScgxnBY\n6terHOUdHSdS57YrCvyWXPtuQ1J9eJOuLsntRKtTorqWf833IYPC9UJQFWcj3H+A\nT1qayQFpCCcGTi8AY1QWb6soSqu31D1ntr5xQBygkZN2hqAHuoZvJce0ZKuOu57a\n33Zc6eniuVO51zgUlG+sW/g9tQyzLw/isIni9Uv1WphrAgMBAAGjUzBRMB0GA1Ud\nDgQWBBQl3+X4u7aRQRaRpPPMO2gypy6uPzAfBgNVHSMEGDAWgBQl3+X4u7aRQRaR\npPPMO2gypy6uPzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBt\n/MuP34GNq+orLEwDqBzDRQK0Ty4jSOM5ZGfdSBHZhypHWUcvQdGNkxeK9cu8WJC/\n8ulovvgnKyWVzVKezdhpCmNInldsuxWC2I9Wu0LB3Jr203BPFNcpAFE6c+aT6ASd\nGtuQ6kElsyfcwCJvIr9RzP2DSPftwCRgqTriJCLRmYf71eV5OFvhkCVQPU1H2Giw\nV1oF1EfQM54000xuVEUlhFlFQHmHmRfeX1Aqir8cXGefdxr3t6bAM3PgM93e/dET\nqzsMQBATo8yKgrirPzmNc5bxfhKS+3fpQOFON+tqsgnXnb9Hksd7zJ52TM5w3RyZ\n/OY2k3sWyAuCKbX1Em/h\n-----END CERTIFICATE-----\n"},"strategy":"samlp","name":"Acceptance-Test-OIDCMeta-TestAccConnectionOIDCMetadata","provisioning_ticket_url":"https://terraform-provider-auth0-dev.us.auth0.com/p/samlp/jSB28rCJtsw53Q37IjlLXVD5FHL8tbLt","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-OIDCMeta-TestAccConnectionOIDCMetadata"],"cross_app_access_resource_app":{"status":"enabled"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 1.951625292s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mNTZceGwlPxyG0h8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_mNTZceGwlPxyG0h8","options":{"cert":"-----BEGIN CERTIFICATE-----\nMIIDCzCCAfOgAwIBAgIUCdRoetBaO+Fr+NdcNdtnL0slU0swDQYJKoZIhvcNAQEL\nBQAwFTETMBEGA1UEAwwKZXhhbXBsZS5jbzAeFw0yNjA3MjMxMDQyMjZaFw0zNjA3\nMjAxMDQyMjZaMBUxEzARBgNVBAMMCmV4YW1wbGUuY28wggEiMA0GCSqGSIb3DQEB\nAQUAA4IBDwAwggEKAoIBAQCvkWF+EDRDxldOx5rqvecWO1fDElU3qEArKzs05vSK\nV4wyndGBLtGcmPNMM3rftyHquGQHjFyxo9lv91xBSTv8vxPox6WbtcoDxRbItyco\ndfhp1cst6D2e7/HC6lttMeCH6lyN7VBWzz8+j7EKe7aW7x23f0WQFU5VbScgxnBY\n6terHOUdHSdS57YrCvyWXPtuQ1J9eJOuLsntRKtTorqWf833IYPC9UJQFWcj3H+A\nT1qayQFpCCcGTi8AY1QWb6soSqu31D1ntr5xQBygkZN2hqAHuoZvJce0ZKuOu57a\n33Zc6eniuVO51zgUlG+sW/g9tQyzLw/isIni9Uv1WphrAgMBAAGjUzBRMB0GA1Ud\nDgQWBBQl3+X4u7aRQRaRpPPMO2gypy6uPzAfBgNVHSMEGDAWgBQl3+X4u7aRQRaR\npPPMO2gypy6uPzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBt\n/MuP34GNq+orLEwDqBzDRQK0Ty4jSOM5ZGfdSBHZhypHWUcvQdGNkxeK9cu8WJC/\n8ulovvgnKyWVzVKezdhpCmNInldsuxWC2I9Wu0LB3Jr203BPFNcpAFE6c+aT6ASd\nGtuQ6kElsyfcwCJvIr9RzP2DSPftwCRgqTriJCLRmYf71eV5OFvhkCVQPU1H2Giw\nV1oF1EfQM54000xuVEUlhFlFQHmHmRfeX1Aqir8cXGefdxr3t6bAM3PgM93e/dET\nqzsMQBATo8yKgrirPzmNc5bxfhKS+3fpQOFON+tqsgnXnb9Hksd7zJ52TM5w3RyZ\n/OY2k3sWyAuCKbX1Em/h\n-----END CERTIFICATE-----\n","expires":"2036-07-20T10:42:26.000Z","subject":{"commonName":"example.co"},"signingCert":"-----BEGIN CERTIFICATE-----\nMIIDCzCCAfOgAwIBAgIUCdRoetBaO+Fr+NdcNdtnL0slU0swDQYJKoZIhvcNAQEL\nBQAwFTETMBEGA1UEAwwKZXhhbXBsZS5jbzAeFw0yNjA3MjMxMDQyMjZaFw0zNjA3\nMjAxMDQyMjZaMBUxEzARBgNVBAMMCmV4YW1wbGUuY28wggEiMA0GCSqGSIb3DQEB\nAQUAA4IBDwAwggEKAoIBAQCvkWF+EDRDxldOx5rqvecWO1fDElU3qEArKzs05vSK\nV4wyndGBLtGcmPNMM3rftyHquGQHjFyxo9lv91xBSTv8vxPox6WbtcoDxRbItyco\ndfhp1cst6D2e7/HC6lttMeCH6lyN7VBWzz8+j7EKe7aW7x23f0WQFU5VbScgxnBY\n6terHOUdHSdS57YrCvyWXPtuQ1J9eJOuLsntRKtTorqWf833IYPC9UJQFWcj3H+A\nT1qayQFpCCcGTi8AY1QWb6soSqu31D1ntr5xQBygkZN2hqAHuoZvJce0ZKuOu57a\n33Zc6eniuVO51zgUlG+sW/g9tQyzLw/isIni9Uv1WphrAgMBAAGjUzBRMB0GA1Ud\nDgQWBBQl3+X4u7aRQRaRpPPMO2gypy6uPzAfBgNVHSMEGDAWgBQl3+X4u7aRQRaR\npPPMO2gypy6uPzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBt\n/MuP34GNq+orLEwDqBzDRQK0Ty4jSOM5ZGfdSBHZhypHWUcvQdGNkxeK9cu8WJC/\n8ulovvgnKyWVzVKezdhpCmNInldsuxWC2I9Wu0LB3Jr203BPFNcpAFE6c+aT6ASd\nGtuQ6kElsyfcwCJvIr9RzP2DSPftwCRgqTriJCLRmYf71eV5OFvhkCVQPU1H2Giw\nV1oF1EfQM54000xuVEUlhFlFQHmHmRfeX1Aqir8cXGefdxr3t6bAM3PgM93e/dET\nqzsMQBATo8yKgrirPzmNc5bxfhKS+3fpQOFON+tqsgnXnb9Hksd7zJ52TM5w3RyZ\n/OY2k3sWyAuCKbX1Em/h\n-----END CERTIFICATE-----\n","thumbprints":["560d54ca2b8ec192668e18a8d0bac5c8cd51e151"],"oidc_metadata":{"issuer":"https://idp.apitest-xaa.example.com","jwks_uri":"https://idp.apitest-xaa.example.com/jwks","token_endpoint":"https://idp.apitest-xaa.example.com/token","authorization_endpoint":"https://idp.apitest-xaa.example.com/authorize","subject_types_supported":["public"],"response_types_supported":["code"],"id_token_signing_alg_values_supported":["RS256"]},"signInEndpoint":"https://saml.example.com/sso","assertion_decryption_settings":{"algorithm_profile":"v2026-1","algorithm_exceptions":[]}},"strategy":"samlp","name":"Acceptance-Test-OIDCMeta-TestAccConnectionOIDCMetadata","provisioning_ticket_url":"https://terraform-provider-auth0-dev.us.auth0.com/p/samlp/jSB28rCJtsw53Q37IjlLXVD5FHL8tbLt","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-OIDCMeta-TestAccConnectionOIDCMetadata"],"cross_app_access_resource_app":{"status":"enabled"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 440.686042ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mNTZceGwlPxyG0h8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_mNTZceGwlPxyG0h8","options":{"cert":"-----BEGIN CERTIFICATE-----\nMIIDCzCCAfOgAwIBAgIUCdRoetBaO+Fr+NdcNdtnL0slU0swDQYJKoZIhvcNAQEL\nBQAwFTETMBEGA1UEAwwKZXhhbXBsZS5jbzAeFw0yNjA3MjMxMDQyMjZaFw0zNjA3\nMjAxMDQyMjZaMBUxEzARBgNVBAMMCmV4YW1wbGUuY28wggEiMA0GCSqGSIb3DQEB\nAQUAA4IBDwAwggEKAoIBAQCvkWF+EDRDxldOx5rqvecWO1fDElU3qEArKzs05vSK\nV4wyndGBLtGcmPNMM3rftyHquGQHjFyxo9lv91xBSTv8vxPox6WbtcoDxRbItyco\ndfhp1cst6D2e7/HC6lttMeCH6lyN7VBWzz8+j7EKe7aW7x23f0WQFU5VbScgxnBY\n6terHOUdHSdS57YrCvyWXPtuQ1J9eJOuLsntRKtTorqWf833IYPC9UJQFWcj3H+A\nT1qayQFpCCcGTi8AY1QWb6soSqu31D1ntr5xQBygkZN2hqAHuoZvJce0ZKuOu57a\n33Zc6eniuVO51zgUlG+sW/g9tQyzLw/isIni9Uv1WphrAgMBAAGjUzBRMB0GA1Ud\nDgQWBBQl3+X4u7aRQRaRpPPMO2gypy6uPzAfBgNVHSMEGDAWgBQl3+X4u7aRQRaR\npPPMO2gypy6uPzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBt\n/MuP34GNq+orLEwDqBzDRQK0Ty4jSOM5ZGfdSBHZhypHWUcvQdGNkxeK9cu8WJC/\n8ulovvgnKyWVzVKezdhpCmNInldsuxWC2I9Wu0LB3Jr203BPFNcpAFE6c+aT6ASd\nGtuQ6kElsyfcwCJvIr9RzP2DSPftwCRgqTriJCLRmYf71eV5OFvhkCVQPU1H2Giw\nV1oF1EfQM54000xuVEUlhFlFQHmHmRfeX1Aqir8cXGefdxr3t6bAM3PgM93e/dET\nqzsMQBATo8yKgrirPzmNc5bxfhKS+3fpQOFON+tqsgnXnb9Hksd7zJ52TM5w3RyZ\n/OY2k3sWyAuCKbX1Em/h\n-----END CERTIFICATE-----\n","expires":"2036-07-20T10:42:26.000Z","subject":{"commonName":"example.co"},"signingCert":"-----BEGIN CERTIFICATE-----\nMIIDCzCCAfOgAwIBAgIUCdRoetBaO+Fr+NdcNdtnL0slU0swDQYJKoZIhvcNAQEL\nBQAwFTETMBEGA1UEAwwKZXhhbXBsZS5jbzAeFw0yNjA3MjMxMDQyMjZaFw0zNjA3\nMjAxMDQyMjZaMBUxEzARBgNVBAMMCmV4YW1wbGUuY28wggEiMA0GCSqGSIb3DQEB\nAQUAA4IBDwAwggEKAoIBAQCvkWF+EDRDxldOx5rqvecWO1fDElU3qEArKzs05vSK\nV4wyndGBLtGcmPNMM3rftyHquGQHjFyxo9lv91xBSTv8vxPox6WbtcoDxRbItyco\ndfhp1cst6D2e7/HC6lttMeCH6lyN7VBWzz8+j7EKe7aW7x23f0WQFU5VbScgxnBY\n6terHOUdHSdS57YrCvyWXPtuQ1J9eJOuLsntRKtTorqWf833IYPC9UJQFWcj3H+A\nT1qayQFpCCcGTi8AY1QWb6soSqu31D1ntr5xQBygkZN2hqAHuoZvJce0ZKuOu57a\n33Zc6eniuVO51zgUlG+sW/g9tQyzLw/isIni9Uv1WphrAgMBAAGjUzBRMB0GA1Ud\nDgQWBBQl3+X4u7aRQRaRpPPMO2gypy6uPzAfBgNVHSMEGDAWgBQl3+X4u7aRQRaR\npPPMO2gypy6uPzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBt\n/MuP34GNq+orLEwDqBzDRQK0Ty4jSOM5ZGfdSBHZhypHWUcvQdGNkxeK9cu8WJC/\n8ulovvgnKyWVzVKezdhpCmNInldsuxWC2I9Wu0LB3Jr203BPFNcpAFE6c+aT6ASd\nGtuQ6kElsyfcwCJvIr9RzP2DSPftwCRgqTriJCLRmYf71eV5OFvhkCVQPU1H2Giw\nV1oF1EfQM54000xuVEUlhFlFQHmHmRfeX1Aqir8cXGefdxr3t6bAM3PgM93e/dET\nqzsMQBATo8yKgrirPzmNc5bxfhKS+3fpQOFON+tqsgnXnb9Hksd7zJ52TM5w3RyZ\n/OY2k3sWyAuCKbX1Em/h\n-----END CERTIFICATE-----\n","thumbprints":["560d54ca2b8ec192668e18a8d0bac5c8cd51e151"],"oidc_metadata":{"issuer":"https://idp.apitest-xaa.example.com","jwks_uri":"https://idp.apitest-xaa.example.com/jwks","token_endpoint":"https://idp.apitest-xaa.example.com/token","authorization_endpoint":"https://idp.apitest-xaa.example.com/authorize","subject_types_supported":["public"],"response_types_supported":["code"],"id_token_signing_alg_values_supported":["RS256"]},"signInEndpoint":"https://saml.example.com/sso","assertion_decryption_settings":{"algorithm_profile":"v2026-1","algorithm_exceptions":[]}},"strategy":"samlp","name":"Acceptance-Test-OIDCMeta-TestAccConnectionOIDCMetadata","provisioning_ticket_url":"https://terraform-provider-auth0-dev.us.auth0.com/p/samlp/jSB28rCJtsw53Q37IjlLXVD5FHL8tbLt","is_domain_connection":false,"show_as_button":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-OIDCMeta-TestAccConnectionOIDCMetadata"],"cross_app_access_resource_app":{"status":"enabled"}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 1.021972875s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_mNTZceGwlPxyG0h8
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-07-24T09:58:43.878Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 1.029014208s


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

Adds Cross-App Access (XAA) resource-application support across the client and connection resources. All fields are Early Access only.

- **`auth0_client`**: new `identity_assertion_authorization_grant` block that opts a client into the Identity Assertion Authorization Grant (ID-JAG) exchange used by XAA. Its required `active` sub-field toggles whether the client can exchange ID-JAGs for access tokens.
- **`auth0_connection`**: new `cross_app_access_resource_app` block letting a connection act as an XAA resource application, with a required `status` of `enabled` or `disabled`.
- **`auth0_connection`**: new `oidc_metadata` option (`oidc`, `okta`, `samlp` strategies) exposing the OIDC discovery document, which the provider never surfaced before.

Both blocks are Optional-only (not Computed) so that removing a block surfaces a diff; because the API drops `omitempty` fields, removal is applied via a raw `PATCH … null` before the typed update. `oidc_metadata` is Computed to absorb the server-populated discovery value, and uses `DiffSuppressFunc` to normalize JSON so the API-enriched superset does not produce perpetual drift.

New fields are also exposed on the corresponding `auth0_client` / `auth0_connection` data sources.

**Usage:**
```hcl
resource "auth0_client" "xaa_app" {
  name = "xaa-app"

  identity_assertion_authorization_grant {
    active = true
  }
}

resource "auth0_connection" "okta" {
  name     = "okta-xaa"
  strategy = "okta"

  cross_app_access_resource_app {
    status = "enabled"
  }
}
```

### 📚 References

- SDK v1: https://github.com/auth0/go-auth0/pull/839

### 🔬 Testing

- Acceptance tests cover create, toggle `active`/`status`, and true block removal for both new blocks, plus `oidc_metadata` create/read, each with recorded HTTP cassettes.
- Unit tests cover the flatten paths for both connection fields and the client block.
- Manually verified that removing a block produces a clean diff and that `oidc_metadata` no longer shows phantom drift on `oidc`/`okta` connections across repeated plans.

Run locally:
```bash
make test-acc FILTER="TestAccClientIdentityAssertionAuthorizationGrant|TestAccConnectionCrossAppAccessResourceApp|TestAccConnectionOIDCMetadata"
```

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->