### PR TITLE
docs: promote session_transfer delegation on client to GA

### DIFF
--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -738,7 +738,7 @@ Optional:
 - `allow_refresh_token` (Boolean) Indicates whether the application is allowed to use a refresh token when using a session_transfer_token session.
 - `allowed_authentication_methods` (Set of String)
 - `can_create_session_transfer_token` (Boolean) Indicates whether the application(Native app) can use the Token Exchange endpoint to create a session_transfer_token
-- `delegation` (Block List, Max: 1) Configuration for delegation (impersonation) access using Session Transfer Tokens. (EA Only) (see [below for nested schema](#nestedblock--session_transfer--delegation))
+- `delegation` (Block List, Max: 1) Configuration for delegation (impersonation) access using Session Transfer Tokens. (see [below for nested schema](#nestedblock--session_transfer--delegation))
 - `enforce_cascade_revocation` (Boolean) Indicates whether revoking the parent Refresh Token that initiated a Native to Web flow and was used to issue a Session Transfer Token should trigger a cascade revocation affecting its dependent child entities. Usually configured in the native application.
 - `enforce_device_binding` (String) Configures the level of device binding enforced when a session_transfer_token is consumed. Can be one of `ip`, `asn` or `none`.
 - `enforce_online_refresh_tokens` (Boolean) Indicates whether Refresh Tokens created during a native-to-web session are tied to that session's lifetime. This determines if such refresh tokens should be automatically revoked when their corresponding sessions are. Usually configured in the web application.
@@ -748,8 +748,8 @@ Optional:
 
 Optional:
 
-- `allow_delegated_access` (Boolean) Indicates whether delegation (impersonation) access is allowed using Session Transfer Tokens. Defaults to `false`. (EA Only)
-- `enforce_device_binding` (String) Indicates the device binding enforcement for delegation (impersonation) access. If set to 'ip', device binding is enforced by IP. If set to 'asn', device binding is enforced by ASN. Defaults to `ip`. (EA Only)
+- `allow_delegated_access` (Boolean) Indicates whether delegation (impersonation) access is allowed using Session Transfer Tokens. Defaults to `false`.
+- `enforce_device_binding` (String) Indicates the device binding enforcement for delegation (impersonation) access. If set to 'ip', device binding is enforced by IP. If set to 'asn', device binding is enforced by ASN. Defaults to `ip`.
 
 
 

--- a/internal/auth0/client/resource.go
+++ b/internal/auth0/client/resource.go
@@ -1614,21 +1614,21 @@ func NewResource() *schema.Resource {
 							Type:        schema.TypeList,
 							Optional:    true,
 							MaxItems:    1,
-							Description: "Configuration for delegation (impersonation) access using Session Transfer Tokens. (EA Only)",
+							Description: "Configuration for delegation (impersonation) access using Session Transfer Tokens.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"allow_delegated_access": {
 										Type:        schema.TypeBool,
 										Optional:    true,
 										Computed:    true,
-										Description: "Indicates whether delegation (impersonation) access is allowed using Session Transfer Tokens. Defaults to `false`. (EA Only)",
+										Description: "Indicates whether delegation (impersonation) access is allowed using Session Transfer Tokens. Defaults to `false`.",
 									},
 									"enforce_device_binding": {
 										Type:         schema.TypeString,
 										Optional:     true,
 										Computed:     true,
 										ValidateFunc: validation.StringInSlice([]string{"ip", "asn"}, false),
-										Description:  "Indicates the device binding enforcement for delegation (impersonation) access. If set to 'ip', device binding is enforced by IP. If set to 'asn', device binding is enforced by ASN. Defaults to `ip`. (EA Only)",
+										Description:  "Indicates the device binding enforcement for delegation (impersonation) access. If set to 'ip', device binding is enforced by IP. If set to 'asn', device binding is enforced by ASN. Defaults to `ip`.",
 									},
 								},
 							},


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Promotes the `session_transfer.delegation` settings on `auth0_client` from Early Access to general availability.

The feature was shipped as Early Access in #1618. It is now generally available, with no logical changes required. This PR removes the "(EA Only)" marker from the user-facing descriptions.

- Drops "(EA Only)" from the `delegation` block description and from its `allow_delegated_access` and `enforce_device_binding` attributes.
- Regenerates the client resource documentation to match.

No schema, behavior, or API changes. Documentation and description copy only. The change flows through to the `auth0_client` and `auth0_clients` data sources automatically, since their schema is cloned from the resource.

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- Original EA implementation: #1618

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

No test changes. The feature's behavior is unchanged, so the existing `TestAccClientSessionTransfer` acceptance coverage from #1618 still applies.

Reviewers can confirm the doc regeneration is in sync:

```bash
make docs
git diff --exit-code docs/
```

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
