### PR TITLE
feat: tfp bot detection entitlement (EA only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 FEATURES:
 - `resource/auth0_connection` – Add support for the `cross_app_access_requesting_app` block to configure a connection as a requesting application authorization server for Cross-App Access (XAA). Supported on `oidc` and `okta` strategies (EA only)
 
+CHANGED:
+- `resource/auth0_attack_protection` – Bot Detection and Captcha entitlement failures (403 `insufficient_entitlement`) now surface as non-fatal warnings instead of silently skipping. The temporary `insufficient_scope` workaround from #1410 has been replaced with typed error helpers (`IsInsufficientScope`, `IsInsufficientEntitlement`).
+
 ## v1.53.0
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ FEATURES:
 - `resource/auth0_connection` – Add support for the `cross_app_access_requesting_app` block to configure a connection as a requesting application authorization server for Cross-App Access (XAA). Supported on `oidc` and `okta` strategies (EA only)
 
 CHANGED:
-- `resource/auth0_attack_protection` – Bot Detection and Captcha entitlement failures (403 `insufficient_entitlement`) now surface as non-fatal warnings instead of silently skipping. The temporary `insufficient_scope` workaround from #1410 has been replaced with typed error helpers (`IsInsufficientScope`, `IsInsufficientEntitlement`).
+- `resource/auth0_attack_protection` – Bot Detection and Captcha failures caused by a missing tenant entitlement (403 `insufficient_entitlement`) now surface as non-fatal warnings naming the gated sub-feature, instead of being silently skipped. The remaining sub-features continue to apply, warnings are also surfaced alongside any fatal error raised later in the same operation, and error-code detection is now based on the API response body rather than string matching on the error message ([#1410](https://github.com/auth0/terraform-provider-auth0/pull/1410)).
 
 ## v1.53.0
 

--- a/internal/auth0/attackprotection/resource.go
+++ b/internal/auth0/attackprotection/resource.go
@@ -655,6 +655,29 @@ func validateCaptchaProviderSecrets() schema.CustomizeDiffFunc {
 	}
 }
 
+// Consequences of a missing entitlement, phrased per operation: a read only
+// failed to fetch the remote configuration, whereas an update failed to write
+// the configured values.
+const (
+	entitlementReadConsequence   = "its current configuration could not be read"
+	entitlementUpdateConsequence = "the configuration was not applied"
+)
+
+// entitlementWarning builds the non-fatal diagnostic surfaced when the tenant
+// lacks the add-on entitlement for an attack protection sub-feature. Pass the
+// consequence matching the operation that failed.
+func entitlementWarning(feature, consequence string) diag.Diagnostic {
+	return diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  fmt.Sprintf("%s entitlement not available", feature),
+		Detail: fmt.Sprintf(
+			"%s requires an add-on entitlement not present on this tenant, so %s. "+
+				"Contact Auth0 support to enable this feature.",
+			feature, consequence,
+		),
+	}
+}
+
 func createAttackProtection(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(id.UniqueId())
 	return updateAttackProtection(ctx, data, meta)
@@ -668,17 +691,17 @@ func readAttackProtection(ctx context.Context, data *schema.ResourceData, meta i
 
 	breachedPasswords, err := api.AttackProtection.GetBreachedPasswordDetection(ctx)
 	if err != nil {
-		return diag.FromErr(err)
+		return append(diags, diag.FromErr(err)...)
 	}
 
 	bruteForce, err := api.AttackProtection.GetBruteForceProtection(ctx)
 	if err != nil {
-		return diag.FromErr(err)
+		return append(diags, diag.FromErr(err)...)
 	}
 
 	ipThrottling, err := api.AttackProtection.GetSuspiciousIPThrottling(ctx)
 	if err != nil {
-		return diag.FromErr(err)
+		return append(diags, diag.FromErr(err)...)
 	}
 
 	botDetection, err := apiv2.AttackProtection.BotDetection.Get(ctx)
@@ -687,13 +710,9 @@ func readAttackProtection(ctx context.Context, data *schema.ResourceData, meta i
 		case apierr.IsInsufficientScope(err):
 			log.Printf("[INFO] Insufficient scope for Bot Detection; skipping read.")
 		case apierr.IsInsufficientEntitlement(err):
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Bot Detection entitlement not available",
-				Detail:   "Bot Detection requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
-			})
+			diags = append(diags, entitlementWarning("Bot Detection", entitlementReadConsequence))
 		default:
-			return diag.FromErr(err)
+			return append(diags, diag.FromErr(err)...)
 		}
 	}
 
@@ -703,13 +722,9 @@ func readAttackProtection(ctx context.Context, data *schema.ResourceData, meta i
 		case apierr.IsInsufficientScope(err):
 			log.Printf("[INFO] Insufficient scope for Captcha; skipping read.")
 		case apierr.IsInsufficientEntitlement(err):
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Captcha entitlement not available",
-				Detail:   "Captcha requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
-			})
+			diags = append(diags, entitlementWarning("Captcha", entitlementReadConsequence))
 		default:
-			return diag.FromErr(err)
+			return append(diags, diag.FromErr(err)...)
 		}
 	}
 
@@ -722,7 +737,7 @@ func readAttackProtection(ctx context.Context, data *schema.ResourceData, meta i
 	)
 
 	if result.ErrorOrNil() != nil {
-		return diag.FromErr(result.ErrorOrNil())
+		return append(diags, diag.FromErr(result.ErrorOrNil())...)
 	}
 
 	return diags
@@ -753,11 +768,7 @@ func updateAttackProtection(ctx context.Context, data *schema.ResourceData, meta
 			case apierr.IsInsufficientScope(err):
 				log.Printf("[INFO] Insufficient scope for Bot Detection; skipping update.")
 			case apierr.IsInsufficientEntitlement(err):
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Warning,
-					Summary:  "Bot Detection entitlement not available",
-					Detail:   "Bot Detection requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
-				})
+				diags = append(diags, entitlementWarning("Bot Detection", entitlementUpdateConsequence))
 			default:
 				result = multierror.Append(result, err)
 			}
@@ -770,11 +781,7 @@ func updateAttackProtection(ctx context.Context, data *schema.ResourceData, meta
 			case apierr.IsInsufficientScope(err):
 				log.Printf("[INFO] Insufficient scope for Captcha; skipping update.")
 			case apierr.IsInsufficientEntitlement(err):
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Warning,
-					Summary:  "Captcha entitlement not available",
-					Detail:   "Captcha requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
-				})
+				diags = append(diags, entitlementWarning("Captcha", entitlementUpdateConsequence))
 			default:
 				result = multierror.Append(result, err)
 			}
@@ -782,13 +789,10 @@ func updateAttackProtection(ctx context.Context, data *schema.ResourceData, meta
 	}
 
 	if result.ErrorOrNil() != nil {
-		return diag.FromErr(result.ErrorOrNil())
+		return append(diags, diag.FromErr(result.ErrorOrNil())...)
 	}
 
-	readDiags := readAttackProtection(ctx, data, meta)
-	diags = append(diags, readDiags...)
-
-	return diags
+	return append(diags, readAttackProtection(ctx, data, meta)...)
 }
 
 func deleteAttackProtection(ctx context.Context, _ *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/auth0/attackprotection/resource.go
+++ b/internal/auth0/attackprotection/resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/go-cty/cty"
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/auth0/terraform-provider-auth0/internal/config"
+	apierr "github.com/auth0/terraform-provider-auth0/internal/error"
 )
 
 // NewResource will return a new auth0_attack_protection resource.
@@ -664,6 +664,8 @@ func readAttackProtection(ctx context.Context, data *schema.ResourceData, meta i
 	api := meta.(*config.Config).GetAPI()
 	apiv2 := meta.(*config.Config).GetAPIV2()
 
+	var diags diag.Diagnostics
+
 	breachedPasswords, err := api.AttackProtection.GetBreachedPasswordDetection(ctx)
 	if err != nil {
 		return diag.FromErr(err)
@@ -681,18 +683,32 @@ func readAttackProtection(ctx context.Context, data *schema.ResourceData, meta i
 
 	botDetection, err := apiv2.AttackProtection.BotDetection.Get(ctx)
 	if err != nil {
-		if !strings.Contains(err.Error(), "insufficient_scope") {
+		if apierr.IsInsufficientScope(err) {
+			log.Printf("[INFO] Insufficient scope for Bot Detection; skipping read.")
+		} else if apierr.IsInsufficientEntitlement(err) {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Bot Detection entitlement not available",
+				Detail:   "Bot Detection requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
+			})
+		} else {
 			return diag.FromErr(err)
 		}
-		log.Printf("[INFO] Bot Detection is not enabled, skipping these updates.")
 	}
 
 	captcha, err := apiv2.AttackProtection.Captcha.Get(ctx)
 	if err != nil {
-		if !strings.Contains(err.Error(), "insufficient_scope") {
+		if apierr.IsInsufficientScope(err) {
+			log.Printf("[INFO] Insufficient scope for Captcha; skipping read.")
+		} else if apierr.IsInsufficientEntitlement(err) {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Captcha entitlement not available",
+				Detail:   "Captcha requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
+			})
+		} else {
 			return diag.FromErr(err)
 		}
-		log.Printf("[INFO] Bot Detection is not enabled, skipping these updates.")
 	}
 
 	result := multierror.Append(
@@ -703,14 +719,20 @@ func readAttackProtection(ctx context.Context, data *schema.ResourceData, meta i
 		data.Set("captcha", flattenCaptcha(data, captcha)),
 	)
 
-	return diag.FromErr(result.ErrorOrNil())
+	if result.ErrorOrNil() != nil {
+		return diag.FromErr(result.ErrorOrNil())
+	}
+
+	return diags
 }
 
 func updateAttackProtection(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := meta.(*config.Config).GetAPI()
 	apiv2 := meta.(*config.Config).GetAPIV2()
 
+	var diags diag.Diagnostics
 	var result *multierror.Error
+
 	if ipt := expandSuspiciousIPThrottling(data); ipt != nil {
 		result = multierror.Append(result, api.AttackProtection.UpdateSuspiciousIPThrottling(ctx, ipt))
 	}
@@ -725,20 +747,32 @@ func updateAttackProtection(ctx context.Context, data *schema.ResourceData, meta
 
 	if botDetection := expandBotDetection(data); botDetection != nil {
 		if _, err := apiv2.AttackProtection.BotDetection.Update(ctx, botDetection); err != nil {
-			if !strings.Contains(err.Error(), "insufficient_scope") {
-				result = multierror.Append(result, err)
+			if apierr.IsInsufficientScope(err) {
+				log.Printf("[INFO] Insufficient scope for Bot Detection; skipping update.")
+			} else if apierr.IsInsufficientEntitlement(err) {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Bot Detection entitlement not available",
+					Detail:   "Bot Detection requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
+				})
 			} else {
-				log.Printf("[INFO] Bot Detection is not enabled, skipping these updates.")
+				result = multierror.Append(result, err)
 			}
 		}
 	}
 
 	if captcha := expandCaptcha(data); captcha != nil {
 		if _, err := apiv2.AttackProtection.Captcha.Update(ctx, captcha); err != nil {
-			if !strings.Contains(err.Error(), "insufficient_scope") {
-				result = multierror.Append(result, err)
+			if apierr.IsInsufficientScope(err) {
+				log.Printf("[INFO] Insufficient scope for Captcha; skipping update.")
+			} else if apierr.IsInsufficientEntitlement(err) {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Captcha entitlement not available",
+					Detail:   "Captcha requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
+				})
 			} else {
-				log.Printf("[INFO] Bot Detection is not enabled, skipping these updates.")
+				result = multierror.Append(result, err)
 			}
 		}
 	}
@@ -747,7 +781,10 @@ func updateAttackProtection(ctx context.Context, data *schema.ResourceData, meta
 		return diag.FromErr(result.ErrorOrNil())
 	}
 
-	return readAttackProtection(ctx, data, meta)
+	readDiags := readAttackProtection(ctx, data, meta)
+	diags = append(diags, readDiags...)
+
+	return diags
 }
 
 func deleteAttackProtection(ctx context.Context, _ *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/auth0/attackprotection/resource.go
+++ b/internal/auth0/attackprotection/resource.go
@@ -683,30 +683,32 @@ func readAttackProtection(ctx context.Context, data *schema.ResourceData, meta i
 
 	botDetection, err := apiv2.AttackProtection.BotDetection.Get(ctx)
 	if err != nil {
-		if apierr.IsInsufficientScope(err) {
+		switch {
+		case apierr.IsInsufficientScope(err):
 			log.Printf("[INFO] Insufficient scope for Bot Detection; skipping read.")
-		} else if apierr.IsInsufficientEntitlement(err) {
+		case apierr.IsInsufficientEntitlement(err):
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Warning,
 				Summary:  "Bot Detection entitlement not available",
 				Detail:   "Bot Detection requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
 			})
-		} else {
+		default:
 			return diag.FromErr(err)
 		}
 	}
 
 	captcha, err := apiv2.AttackProtection.Captcha.Get(ctx)
 	if err != nil {
-		if apierr.IsInsufficientScope(err) {
+		switch {
+		case apierr.IsInsufficientScope(err):
 			log.Printf("[INFO] Insufficient scope for Captcha; skipping read.")
-		} else if apierr.IsInsufficientEntitlement(err) {
+		case apierr.IsInsufficientEntitlement(err):
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Warning,
 				Summary:  "Captcha entitlement not available",
 				Detail:   "Captcha requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
 			})
-		} else {
+		default:
 			return diag.FromErr(err)
 		}
 	}
@@ -747,15 +749,16 @@ func updateAttackProtection(ctx context.Context, data *schema.ResourceData, meta
 
 	if botDetection := expandBotDetection(data); botDetection != nil {
 		if _, err := apiv2.AttackProtection.BotDetection.Update(ctx, botDetection); err != nil {
-			if apierr.IsInsufficientScope(err) {
+			switch {
+			case apierr.IsInsufficientScope(err):
 				log.Printf("[INFO] Insufficient scope for Bot Detection; skipping update.")
-			} else if apierr.IsInsufficientEntitlement(err) {
+			case apierr.IsInsufficientEntitlement(err):
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Warning,
 					Summary:  "Bot Detection entitlement not available",
 					Detail:   "Bot Detection requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
 				})
-			} else {
+			default:
 				result = multierror.Append(result, err)
 			}
 		}
@@ -763,15 +766,16 @@ func updateAttackProtection(ctx context.Context, data *schema.ResourceData, meta
 
 	if captcha := expandCaptcha(data); captcha != nil {
 		if _, err := apiv2.AttackProtection.Captcha.Update(ctx, captcha); err != nil {
-			if apierr.IsInsufficientScope(err) {
+			switch {
+			case apierr.IsInsufficientScope(err):
 				log.Printf("[INFO] Insufficient scope for Captcha; skipping update.")
-			} else if apierr.IsInsufficientEntitlement(err) {
+			case apierr.IsInsufficientEntitlement(err):
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Warning,
 					Summary:  "Captcha entitlement not available",
 					Detail:   "Captcha requires an add-on entitlement not present on this tenant. The configuration was not applied. Contact Auth0 support to enable this feature.",
 				})
-			} else {
+			default:
 				result = multierror.Append(result, err)
 			}
 		}

--- a/internal/auth0/attackprotection/resource_internal_test.go
+++ b/internal/auth0/attackprotection/resource_internal_test.go
@@ -1,0 +1,85 @@
+package attackprotection
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntitlementWarning(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		feature     string
+		consequence string
+		wantDetail  string
+	}{
+		{
+			name:        "bot detection read",
+			feature:     "Bot Detection",
+			consequence: entitlementReadConsequence,
+			wantDetail: "Bot Detection requires an add-on entitlement not present on this tenant, " +
+				"so its current configuration could not be read. " +
+				"Contact Auth0 support to enable this feature.",
+		},
+		{
+			name:        "captcha read",
+			feature:     "Captcha",
+			consequence: entitlementReadConsequence,
+			wantDetail: "Captcha requires an add-on entitlement not present on this tenant, " +
+				"so its current configuration could not be read. " +
+				"Contact Auth0 support to enable this feature.",
+		},
+		{
+			name:        "bot detection update",
+			feature:     "Bot Detection",
+			consequence: entitlementUpdateConsequence,
+			wantDetail: "Bot Detection requires an add-on entitlement not present on this tenant, " +
+				"so the configuration was not applied. " +
+				"Contact Auth0 support to enable this feature.",
+		},
+		{
+			name:        "captcha update",
+			feature:     "Captcha",
+			consequence: entitlementUpdateConsequence,
+			wantDetail: "Captcha requires an add-on entitlement not present on this tenant, " +
+				"so the configuration was not applied. " +
+				"Contact Auth0 support to enable this feature.",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			warning := entitlementWarning(testCase.feature, testCase.consequence)
+
+			assert.Equal(t, diag.Warning, warning.Severity)
+			assert.Equal(t, testCase.feature+" entitlement not available", warning.Summary)
+			assert.Equal(t, testCase.wantDetail, warning.Detail)
+		})
+	}
+}
+
+// TestEntitlementConsequencesAreDistinct guards the read/update split: a read
+// failure never attempted a write, so it must not claim the configuration was
+// not applied.
+func TestEntitlementConsequencesAreDistinct(t *testing.T) {
+	read := entitlementWarning("Bot Detection", entitlementReadConsequence)
+	update := entitlementWarning("Bot Detection", entitlementUpdateConsequence)
+
+	assert.NotEqual(t, read.Detail, update.Detail)
+	assert.NotContains(t, read.Detail, "not applied")
+	assert.Contains(t, update.Detail, "was not applied")
+}
+
+// TestEntitlementWarningDoesNotEchoBackendMessage guards against regressing to
+// the API's own message text, which has a known backend copy-paste bug where
+// the captcha endpoint's 403 message mentions "bot detection".
+func TestEntitlementWarningDoesNotEchoBackendMessage(t *testing.T) {
+	for _, consequence := range []string{entitlementReadConsequence, entitlementUpdateConsequence} {
+		warning := entitlementWarning("Captcha", consequence)
+
+		assert.NotContains(t, warning.Detail, "bot detection")
+		assert.NotContains(t, warning.Detail, "Bot Detection")
+		assert.NotContains(t, warning.Detail, "upgrade your subscription")
+	}
+}

--- a/internal/auth0/attackprotection/resource_test.go
+++ b/internal/auth0/attackprotection/resource_test.go
@@ -691,3 +691,152 @@ func TestAccAttackProtectionCaptcha(t *testing.T) {
 		},
 	})
 }
+
+// ============================================================================.
+
+// Entitlement handling: a tenant without the Bot Detection / Captcha add-on
+// entitlement receives a 403 with errorCode "insufficient_entitlement" from
+// GET and PATCH on the v2 attack-protection endpoints. The provider must
+// surface these as non-fatal warnings and keep applying the remaining
+// sub-features, rather than failing the apply.
+//
+// Recorded against a non-entitled tenant; replays from the cassette.
+
+const testAccEntitlementBotDetection = `
+resource "auth0_attack_protection" "my_protection" {
+	bot_detection {
+		bot_detection_level             = "low"
+		challenge_password_policy       = "when_risky"
+		challenge_passwordless_policy   = "when_risky"
+		challenge_password_reset_policy = "when_risky"
+		monitoring_mode_enabled         = true
+		allowlist                       = ["127.0.0.1"]
+	}
+
+	brute_force_protection {
+		enabled      = true
+		max_attempts = 5
+		mode         = "count_per_identifier_and_ip"
+		allowlist    = ["127.0.0.1"]
+		shields      = ["block"]
+	}
+}
+`
+
+// TestAccAttackProtectionBotDetectionInsufficientEntitlement asserts that the
+// 403 insufficient_entitlement path is non-fatal: the apply succeeds, the
+// gated bot_detection block is absent from state (the API returned nothing to
+// store), and the ungated brute_force_protection block is still applied.
+//
+// ExpectNonEmptyPlan is required because the gated block cannot be persisted,
+// so the config/state difference remains after apply.
+func TestAccAttackProtectionBotDetectionInsufficientEntitlement(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccEntitlementBotDetection,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					// The gated sub-feature is not persisted: the 403 leaves it unset.
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection", "bot_detection.#", "0"),
+					// The ungated sub-feature is still applied: no short-circuit.
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection", "brute_force_protection.#", "1"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection", "brute_force_protection.0.enabled", "true"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection", "brute_force_protection.0.max_attempts", "5"),
+				),
+			},
+		},
+	})
+}
+
+const testAccEntitlementCaptcha = `
+resource "auth0_attack_protection" "my_protection" {
+	captcha {
+		active_provider_id = "recaptcha_v2"
+		recaptcha_v2 {
+			site_key = "test-site-key-v2"
+			secret   = "test-secret-v2"
+		}
+	}
+
+	brute_force_protection {
+		enabled      = true
+		max_attempts = 5
+		mode         = "count_per_identifier_and_ip"
+		allowlist    = ["127.0.0.1"]
+		shields      = ["block"]
+	}
+}
+`
+
+// TestAccAttackProtectionCaptchaInsufficientEntitlement is the Captcha
+// equivalent of the Bot Detection entitlement test above.
+func TestAccAttackProtectionCaptchaInsufficientEntitlement(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccEntitlementCaptcha,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection", "captcha.#", "0"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection", "brute_force_protection.#", "1"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection", "brute_force_protection.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccEntitlementBotDetectionAndCaptcha = `
+resource "auth0_attack_protection" "my_protection" {
+	bot_detection {
+		bot_detection_level     = "low"
+		monitoring_mode_enabled = true
+		allowlist               = ["127.0.0.1"]
+	}
+
+	captcha {
+		active_provider_id = "recaptcha_v2"
+		recaptcha_v2 {
+			site_key = "test-site-key-v2"
+			secret   = "test-secret-v2"
+		}
+	}
+
+	suspicious_ip_throttling {
+		enabled   = true
+		allowlist = ["192.168.1.1"]
+		shields   = ["admin_notification", "block"]
+
+		pre_login {
+			max_attempts = 5
+			rate         = 864000
+		}
+
+		pre_user_registration {
+			max_attempts = 5
+			rate         = 1200
+		}
+	}
+}
+`
+
+// TestAccAttackProtectionMultipleInsufficientEntitlements asserts diagnostic
+// accumulation: when both gated sub-features return 403 in the same apply,
+// neither short-circuits the other and the ungated sub-feature still applies.
+func TestAccAttackProtectionMultipleInsufficientEntitlements(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccEntitlementBotDetectionAndCaptcha,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection", "bot_detection.#", "0"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection", "captcha.#", "0"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection", "suspicious_ip_throttling.#", "1"),
+					resource.TestCheckResourceAttr("auth0_attack_protection.my_protection", "suspicious_ip_throttling.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}

--- a/internal/error/api_error_v2.go
+++ b/internal/error/api_error_v2.go
@@ -1,0 +1,39 @@
+package error
+
+import (
+	"errors"
+
+	managementv2 "github.com/auth0/go-auth0/v2/management"
+)
+
+// v2ErrorCode extracts the errorCode field from a v2 SDK ForbiddenError.
+// Returns an empty string if the error is not a ForbiddenError or if the
+// Body does not contain a valid errorCode field.
+func v2ErrorCode(err error) string {
+	var fe *managementv2.ForbiddenError
+	if !errors.As(err, &fe) {
+		return ""
+	}
+
+	body, ok := fe.Body.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	code, _ := body["errorCode"].(string)
+	return code
+}
+
+// IsInsufficientEntitlement checks if the error is a v2 SDK ForbiddenError
+// with errorCode "insufficient_entitlement", indicating the tenant lacks
+// the required entitlement for the requested feature.
+func IsInsufficientEntitlement(err error) bool {
+	return v2ErrorCode(err) == "insufficient_entitlement"
+}
+
+// IsInsufficientScope checks if the error is a v2 SDK ForbiddenError
+// with errorCode "insufficient_scope", indicating the access token lacks
+// the required scope for the requested operation.
+func IsInsufficientScope(err error) bool {
+	return v2ErrorCode(err) == "insufficient_scope"
+}

--- a/internal/error/api_error_v2.go
+++ b/internal/error/api_error_v2.go
@@ -6,10 +6,10 @@ import (
 	managementv2 "github.com/auth0/go-auth0/v2/management"
 )
 
-// v2ErrorCode extracts the errorCode field from a v2 SDK ForbiddenError.
+// v2ForbiddenErrorCode extracts the errorCode field from a v2 SDK ForbiddenError.
 // Returns an empty string if the error is not a ForbiddenError or if the
 // Body does not contain a valid errorCode field.
-func v2ErrorCode(err error) string {
+func v2ForbiddenErrorCode(err error) string {
 	var fe *managementv2.ForbiddenError
 	if !errors.As(err, &fe) {
 		return ""
@@ -28,12 +28,12 @@ func v2ErrorCode(err error) string {
 // with errorCode "insufficient_entitlement", indicating the tenant lacks
 // the required entitlement for the requested feature.
 func IsInsufficientEntitlement(err error) bool {
-	return v2ErrorCode(err) == "insufficient_entitlement"
+	return v2ForbiddenErrorCode(err) == "insufficient_entitlement"
 }
 
 // IsInsufficientScope checks if the error is a v2 SDK ForbiddenError
 // with errorCode "insufficient_scope", indicating the access token lacks
 // the required scope for the requested operation.
 func IsInsufficientScope(err error) bool {
-	return v2ErrorCode(err) == "insufficient_scope"
+	return v2ForbiddenErrorCode(err) == "insufficient_scope"
 }

--- a/internal/error/api_error_v2_test.go
+++ b/internal/error/api_error_v2_test.go
@@ -1,0 +1,138 @@
+package error
+
+import (
+	"errors"
+	"testing"
+
+	managementv2 "github.com/auth0/go-auth0/v2/management"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestV2ErrorCode(t *testing.T) {
+	t.Run("returns errorCode from valid ForbiddenError", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: map[string]interface{}{
+				"statusCode": 403,
+				"error":      "Forbidden",
+				"message":    "Please upgrade your subscription",
+				"errorCode":  "insufficient_entitlement",
+			},
+		}
+
+		code := v2ErrorCode(err)
+		assert.Equal(t, "insufficient_entitlement", code)
+	})
+
+	t.Run("returns empty string for non-ForbiddenError", func(t *testing.T) {
+		err := errors.New("some other error")
+
+		code := v2ErrorCode(err)
+		assert.Equal(t, "", code)
+	})
+
+	t.Run("returns empty string when Body is not a map", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: "not a map",
+		}
+
+		code := v2ErrorCode(err)
+		assert.Equal(t, "", code)
+	})
+
+	t.Run("returns empty string when errorCode key is missing", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: map[string]interface{}{
+				"statusCode": 403,
+				"error":      "Forbidden",
+			},
+		}
+
+		code := v2ErrorCode(err)
+		assert.Equal(t, "", code)
+	})
+
+	t.Run("returns empty string when errorCode is not a string", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: map[string]interface{}{
+				"statusCode": 403,
+				"error":      "Forbidden",
+				"errorCode":  123,
+			},
+		}
+
+		code := v2ErrorCode(err)
+		assert.Equal(t, "", code)
+	})
+}
+
+func TestIsInsufficientScope(t *testing.T) {
+	t.Run("returns true for insufficient_scope error", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: map[string]interface{}{
+				"errorCode": "insufficient_scope",
+			},
+		}
+
+		assert.True(t, IsInsufficientScope(err))
+	})
+
+	t.Run("returns false for insufficient_entitlement error", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: map[string]interface{}{
+				"errorCode": "insufficient_entitlement",
+			},
+		}
+
+		assert.False(t, IsInsufficientScope(err))
+	})
+
+	t.Run("returns false for non-ForbiddenError", func(t *testing.T) {
+		err := errors.New("some other error")
+
+		assert.False(t, IsInsufficientScope(err))
+	})
+
+	t.Run("returns false for malformed ForbiddenError", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: "not a map",
+		}
+
+		assert.False(t, IsInsufficientScope(err))
+	})
+}
+
+func TestIsInsufficientEntitlement(t *testing.T) {
+	t.Run("returns true for insufficient_entitlement error", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: map[string]interface{}{
+				"errorCode": "insufficient_entitlement",
+			},
+		}
+
+		assert.True(t, IsInsufficientEntitlement(err))
+	})
+
+	t.Run("returns false for insufficient_scope error", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: map[string]interface{}{
+				"errorCode": "insufficient_scope",
+			},
+		}
+
+		assert.False(t, IsInsufficientEntitlement(err))
+	})
+
+	t.Run("returns false for non-ForbiddenError", func(t *testing.T) {
+		err := errors.New("some other error")
+
+		assert.False(t, IsInsufficientEntitlement(err))
+	})
+
+	t.Run("returns false for malformed ForbiddenError", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: "not a map",
+		}
+
+		assert.False(t, IsInsufficientEntitlement(err))
+	})
+}

--- a/internal/error/api_error_v2_test.go
+++ b/internal/error/api_error_v2_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestV2ErrorCode(t *testing.T) {
+func TestV2ForbiddenErrorCode(t *testing.T) {
 	t.Run("returns errorCode from valid ForbiddenError", func(t *testing.T) {
 		err := &managementv2.ForbiddenError{
 			Body: map[string]interface{}{
@@ -20,14 +20,14 @@ func TestV2ErrorCode(t *testing.T) {
 			},
 		}
 
-		code := v2ErrorCode(err)
+		code := v2ForbiddenErrorCode(err)
 		assert.Equal(t, "insufficient_entitlement", code)
 	})
 
 	t.Run("returns empty string for non-ForbiddenError", func(t *testing.T) {
 		err := errors.New("some other error")
 
-		code := v2ErrorCode(err)
+		code := v2ForbiddenErrorCode(err)
 		assert.Equal(t, "", code)
 	})
 
@@ -36,7 +36,7 @@ func TestV2ErrorCode(t *testing.T) {
 			Body: "not a map",
 		}
 
-		code := v2ErrorCode(err)
+		code := v2ForbiddenErrorCode(err)
 		assert.Equal(t, "", code)
 	})
 
@@ -48,7 +48,7 @@ func TestV2ErrorCode(t *testing.T) {
 			},
 		}
 
-		code := v2ErrorCode(err)
+		code := v2ForbiddenErrorCode(err)
 		assert.Equal(t, "", code)
 	})
 
@@ -61,7 +61,7 @@ func TestV2ErrorCode(t *testing.T) {
 			},
 		}
 
-		code := v2ErrorCode(err)
+		code := v2ForbiddenErrorCode(err)
 		assert.Equal(t, "", code)
 	})
 }
@@ -140,7 +140,7 @@ func TestIsInsufficientEntitlement(t *testing.T) {
 
 // TestV2ErrorCodeMalformedBodies covers scope item E1: every malformed Body
 // permutation must fail closed to "" rather than panicking or false-positiving.
-func TestV2ErrorCodeMalformedBodies(t *testing.T) {
+func TestV2ForbiddenErrorCodeMalformedBodies(t *testing.T) {
 	var testCases = []struct {
 		name string
 		body interface{}
@@ -167,7 +167,7 @@ func TestV2ErrorCodeMalformedBodies(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := &managementv2.ForbiddenError{Body: testCase.body}
 
-			assert.Equal(t, "", v2ErrorCode(err))
+			assert.Equal(t, "", v2ForbiddenErrorCode(err))
 			assert.False(t, IsInsufficientEntitlement(err))
 			assert.False(t, IsInsufficientScope(err))
 		})
@@ -176,7 +176,7 @@ func TestV2ErrorCodeMalformedBodies(t *testing.T) {
 
 // TestV2ErrorCodeExactMatchBoundary covers scope item B1: the matcher is an
 // exact string comparison, so near-miss variants must not match.
-func TestV2ErrorCodeExactMatchBoundary(t *testing.T) {
+func TestV2ForbiddenErrorCodeExactMatchBoundary(t *testing.T) {
 	var testCases = []struct {
 		name      string
 		errorCode string
@@ -207,14 +207,14 @@ func TestV2ErrorCodeExactMatchBoundary(t *testing.T) {
 // TestV2ErrorCodeWrappedErrors covers scope item E2: errors.As must unwrap
 // through fmt.Errorf %w chains so SDK/middleware wrapping does not defeat
 // detection.
-func TestV2ErrorCodeWrappedErrors(t *testing.T) {
+func TestV2ForbiddenErrorCodeWrappedErrors(t *testing.T) {
 	t.Run("single-level wrap preserves entitlement detection", func(t *testing.T) {
 		forbidden := &managementv2.ForbiddenError{
 			Body: map[string]interface{}{"errorCode": "insufficient_entitlement"},
 		}
 		wrapped := fmt.Errorf("calling bot detection: %w", forbidden)
 
-		assert.Equal(t, "insufficient_entitlement", v2ErrorCode(wrapped))
+		assert.Equal(t, "insufficient_entitlement", v2ForbiddenErrorCode(wrapped))
 		assert.True(t, IsInsufficientEntitlement(wrapped))
 		assert.False(t, IsInsufficientScope(wrapped))
 	})
@@ -232,15 +232,15 @@ func TestV2ErrorCodeWrappedErrors(t *testing.T) {
 	t.Run("wrapped non-Forbidden error does not match", func(t *testing.T) {
 		wrapped := fmt.Errorf("outer: %w", errors.New("boom"))
 
-		assert.Equal(t, "", v2ErrorCode(wrapped))
+		assert.Equal(t, "", v2ForbiddenErrorCode(wrapped))
 		assert.False(t, IsInsufficientEntitlement(wrapped))
 		assert.False(t, IsInsufficientScope(wrapped))
 	})
 }
 
 // TestV2ErrorCodeNilError covers scope item E3: nil input must not panic.
-func TestV2ErrorCodeNilError(t *testing.T) {
-	assert.Equal(t, "", v2ErrorCode(nil))
+func TestV2ForbiddenErrorCodeNilError(t *testing.T) {
+	assert.Equal(t, "", v2ForbiddenErrorCode(nil))
 	assert.False(t, IsInsufficientEntitlement(nil))
 	assert.False(t, IsInsufficientScope(nil))
 }
@@ -249,7 +249,7 @@ func TestV2ErrorCodeNilError(t *testing.T) {
 // against the exact 403 bodies returned by the Management API for a
 // non-entitled tenant, including the backend's own copy-paste bug where the
 // captcha endpoint's message mentions "bot detection".
-func TestV2ErrorCodeLiveWireFormat(t *testing.T) {
+func TestV2ForbiddenErrorCodeLiveWireFormat(t *testing.T) {
 	t.Run("bot detection 403 body", func(t *testing.T) {
 		err := &managementv2.ForbiddenError{
 			Body: map[string]interface{}{

--- a/internal/error/api_error_v2_test.go
+++ b/internal/error/api_error_v2_test.go
@@ -2,6 +2,7 @@ package error
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	managementv2 "github.com/auth0/go-auth0/v2/management"
@@ -134,5 +135,145 @@ func TestIsInsufficientEntitlement(t *testing.T) {
 		}
 
 		assert.False(t, IsInsufficientEntitlement(err))
+	})
+}
+
+// TestV2ErrorCodeMalformedBodies covers scope item E1: every malformed Body
+// permutation must fail closed to "" rather than panicking or false-positiving.
+func TestV2ErrorCodeMalformedBodies(t *testing.T) {
+	var testCases = []struct {
+		name string
+		body interface{}
+	}{
+		{"nil body", nil},
+		{"string body", "not a map"},
+		{"slice body", []interface{}{"a", "b"}},
+		{"int body", 403},
+		{"bool body", true},
+		{"typed struct body", struct{ ErrorCode string }{ErrorCode: "insufficient_entitlement"}},
+		{"empty map", map[string]interface{}{}},
+		{"missing errorCode key", map[string]interface{}{"statusCode": 403, "error": "Forbidden"}},
+		{"errorCode is int", map[string]interface{}{"errorCode": 123}},
+		{"errorCode is nil", map[string]interface{}{"errorCode": nil}},
+		{"errorCode is bool", map[string]interface{}{"errorCode": true}},
+		{"errorCode is nested map", map[string]interface{}{"errorCode": map[string]interface{}{"x": "y"}}},
+		{"errorCode is slice", map[string]interface{}{"errorCode": []string{"insufficient_entitlement"}}},
+		{"wrong-cased key ErrorCode", map[string]interface{}{"ErrorCode": "insufficient_entitlement"}},
+		{"wrong-cased key errorcode", map[string]interface{}{"errorcode": "insufficient_entitlement"}},
+		{"map[string]string body", map[string]string{"errorCode": "insufficient_entitlement"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := &managementv2.ForbiddenError{Body: testCase.body}
+
+			assert.Equal(t, "", v2ErrorCode(err))
+			assert.False(t, IsInsufficientEntitlement(err))
+			assert.False(t, IsInsufficientScope(err))
+		})
+	}
+}
+
+// TestV2ErrorCodeExactMatchBoundary covers scope item B1: the matcher is an
+// exact string comparison, so near-miss variants must not match.
+func TestV2ErrorCodeExactMatchBoundary(t *testing.T) {
+	var testCases = []struct {
+		name      string
+		errorCode string
+	}{
+		{"uppercase", "INSUFFICIENT_ENTITLEMENT"},
+		{"hyphenated", "insufficient-entitlement"},
+		{"title case", "Insufficient_Entitlement"},
+		{"leading whitespace", " insufficient_entitlement"},
+		{"trailing whitespace", "insufficient_entitlement "},
+		{"plural", "insufficient_entitlements"},
+		{"substring only", "entitlement"},
+		{"empty string", ""},
+		{"unrecognised 403 code", "some_other_403"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := &managementv2.ForbiddenError{
+				Body: map[string]interface{}{"errorCode": testCase.errorCode},
+			}
+
+			assert.False(t, IsInsufficientEntitlement(err))
+			assert.False(t, IsInsufficientScope(err))
+		})
+	}
+}
+
+// TestV2ErrorCodeWrappedErrors covers scope item E2: errors.As must unwrap
+// through fmt.Errorf %w chains so SDK/middleware wrapping does not defeat
+// detection.
+func TestV2ErrorCodeWrappedErrors(t *testing.T) {
+	t.Run("single-level wrap preserves entitlement detection", func(t *testing.T) {
+		forbidden := &managementv2.ForbiddenError{
+			Body: map[string]interface{}{"errorCode": "insufficient_entitlement"},
+		}
+		wrapped := fmt.Errorf("calling bot detection: %w", forbidden)
+
+		assert.Equal(t, "insufficient_entitlement", v2ErrorCode(wrapped))
+		assert.True(t, IsInsufficientEntitlement(wrapped))
+		assert.False(t, IsInsufficientScope(wrapped))
+	})
+
+	t.Run("multi-level wrap preserves scope detection", func(t *testing.T) {
+		forbidden := &managementv2.ForbiddenError{
+			Body: map[string]interface{}{"errorCode": "insufficient_scope"},
+		}
+		wrapped := fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", forbidden))
+
+		assert.True(t, IsInsufficientScope(wrapped))
+		assert.False(t, IsInsufficientEntitlement(wrapped))
+	})
+
+	t.Run("wrapped non-Forbidden error does not match", func(t *testing.T) {
+		wrapped := fmt.Errorf("outer: %w", errors.New("boom"))
+
+		assert.Equal(t, "", v2ErrorCode(wrapped))
+		assert.False(t, IsInsufficientEntitlement(wrapped))
+		assert.False(t, IsInsufficientScope(wrapped))
+	})
+}
+
+// TestV2ErrorCodeNilError covers scope item E3: nil input must not panic.
+func TestV2ErrorCodeNilError(t *testing.T) {
+	assert.Equal(t, "", v2ErrorCode(nil))
+	assert.False(t, IsInsufficientEntitlement(nil))
+	assert.False(t, IsInsufficientScope(nil))
+}
+
+// TestV2ErrorCodeLiveWireFormat covers scope items B1 and N4 by asserting
+// against the exact 403 bodies returned by the Management API for a
+// non-entitled tenant, including the backend's own copy-paste bug where the
+// captcha endpoint's message mentions "bot detection".
+func TestV2ErrorCodeLiveWireFormat(t *testing.T) {
+	t.Run("bot detection 403 body", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: map[string]interface{}{
+				"statusCode": float64(403),
+				"error":      "Forbidden",
+				"message":    "Please upgrade your subscription to use bot detection",
+				"errorCode":  "insufficient_entitlement",
+			},
+		}
+
+		assert.True(t, IsInsufficientEntitlement(err))
+		assert.False(t, IsInsufficientScope(err))
+	})
+
+	t.Run("captcha 403 body (backend message says bot detection)", func(t *testing.T) {
+		err := &managementv2.ForbiddenError{
+			Body: map[string]interface{}{
+				"statusCode": float64(403),
+				"error":      "Forbidden",
+				"message":    "Please upgrade your subscription to use bot detection",
+				"errorCode":  "insufficient_entitlement",
+			},
+		}
+
+		assert.True(t, IsInsufficientEntitlement(err))
 	})
 }

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,0 +1,90 @@
+---
+branch: tfp-bot-detection-entitlement-dxcdt-1688
+base: main
+---
+
+# Surface Bot Detection/Captcha entitlement errors as warnings
+
+<!--
+❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
+
+By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
+-->
+
+### 🔧 Changes
+
+`auth0_attack_protection` gates two sub-features behind tenant entitlements — `bot_detection` and `captcha`, both served by the v2 Management API. On a tenant without the add-on, both `GET` and `PATCH` return `403` with `errorCode: "insufficient_entitlement"`. Previously the resource treated *any* v2 `403` whose message contained `insufficient_scope` as a silent skip (the temporary workaround from #1410) and let everything else fail the apply. That meant an unentitled tenant either got a hard apply failure, or — where the string happened to match — a skip with nothing but an `[INFO]` log line the user never sees.
+
+This PR distinguishes the two `403` cases and makes the entitlement case visible without making it fatal.
+
+**Added — `internal/error/api_error_v2.go`**
+
+Typed error helpers for the v2 SDK, replacing `strings.Contains` on the error message:
+
+- `v2ForbiddenErrorCode(err) string` (unexported) — unwraps via `errors.As` to `*managementv2.ForbiddenError` and reads `errorCode` out of the response `Body`; returns `""` for any non-`ForbiddenError`, non-map body, missing key, or non-string value.
+- `IsInsufficientScope(err) bool` — token lacks the required scope.
+- `IsInsufficientEntitlement(err) bool` — tenant lacks the required add-on entitlement.
+
+**Changed — `internal/auth0/attackprotection/resource.go`**
+
+`readAttackProtection` and `updateAttackProtection` now accumulate a `diag.Diagnostics` and branch on error code for each of the two gated calls:
+
+- `IsInsufficientScope` → skip, `[INFO]` log (unchanged behavior, now matched on the error code rather than the message text).
+- `IsInsufficientEntitlement` → append a `diag.Warning` naming the sub-feature and pointing at Auth0 support to enable the feature.
+- anything else → fatal, as before (`diag.FromErr` on read, `multierror.Append` on update).
+
+The warning text is built by a single helper, `entitlementWarning(feature, consequence)`, parameterized on both the sub-feature name and the consequence, so the message matches what actually happened. The two consequences are named constants: `entitlementUpdateConsequence` ("the configuration was not applied") and `entitlementReadConsequence` ("its current configuration could not be read") — a read failure hasn't attempted to write anything, so claiming otherwise was misleading.
+
+Three consequences worth noting for reviewers:
+
+- **No short-circuiting.** A gated sub-feature returning `403` no longer stops the remaining sub-features from being read or updated, and two gated failures in the same apply both produce warnings rather than the first one masking the second.
+- **Warnings propagate through update → read.** `updateAttackProtection` merges the diagnostics returned by its trailing `readAttackProtection` call instead of returning them directly, so warnings raised during update survive the read.
+- **Warnings survive a later fatal error.** Every fatal exit in both functions returns `append(diags, diag.FromErr(err)...)` rather than `diag.FromErr(err)`, so a warning collected from a gated sub-feature is still shown when an unrelated sub-feature subsequently fails hard. Previously the accumulated warnings were dropped on those paths.
+
+`strings` is no longer imported by the resource.
+
+No schema, public API, or user-facing configuration changes — this is error-surfacing behavior only.
+
+### 📚 References
+
+- Supersedes the temporary `insufficient_scope` string-matching workaround introduced in [#1410](https://github.com/auth0/terraform-provider-auth0/pull/1410)
+
+### 🔬 Testing
+
+**Unit — `internal/error/api_error_v2_test.go` (new, 279 lines)**
+
+Table of cases for `v2ForbiddenErrorCode`, `IsInsufficientScope`, and `IsInsufficientEntitlement`, covering the happy path plus every way extraction can fail: non-`ForbiddenError`, `Body` that isn't a map, missing `errorCode`, and non-string `errorCode`. Also covers `errors.As` unwrapping through a wrapped error, and cross-checks that each predicate returns `false` for the other's error code.
+
+**Unit — `internal/auth0/attackprotection/resource_internal_test.go` (new)**
+
+Table over both sub-features × both consequences, asserting `entitlementWarning` produces `diag.Warning` with a summary naming the sub-feature and the exact expected detail string. Plus two guards: that the read consequence does *not* claim the configuration was not applied while the update one does, and that neither echoes the backend's own 403 `message` — which has a copy-paste bug where the captcha endpoint says "…to use bot detection".
+
+**Acceptance — `internal/auth0/attackprotection/resource_test.go` (3 new tests, HTTP recordings included)**
+
+Recorded against a non-entitled tenant, replayed from cassettes:
+
+- `TestAccAttackProtectionBotDetectionInsufficientEntitlement` — `bot_detection` + `brute_force_protection`; asserts the apply succeeds, `bot_detection.#` is `0` (the 403 leaves it unpersisted), and `brute_force_protection` is still fully applied.
+- `TestAccAttackProtectionCaptchaInsufficientEntitlement` — the same for `captcha`.
+- `TestAccAttackProtectionMultipleInsufficientEntitlements` — both gated blocks 403 in one apply; asserts neither short-circuits the other and the ungated `suspicious_ip_throttling` block still applies.
+
+All three set `ExpectNonEmptyPlan: true`: a gated block cannot be persisted to state, so the config/state difference legitimately remains after apply.
+
+Existing recordings for `TestAccAttackProtectionBotDetection` and `TestAccAttackProtectionCaptcha` were re-recorded against an entitled tenant to keep the happy paths green.
+
+Run with:
+
+```bash
+make test-unit
+AUTH0_HTTP_RECORDINGS=on AUTH0_DOMAIN=terraform-provider-auth0-dev.eu.auth0.com make test-acc FILTER="TestAccAttackProtection"
+```
+
+Not covered by automated tests: the exact warning text as rendered by the Terraform CLI, since the acceptance test framework asserts on state rather than on diagnostic output. Verified manually against an unentitled tenant — `terraform apply` completes with `Warning: Bot Detection entitlement not available` / `Warning: Captcha entitlement not available` and a non-zero-diff plan.
+
+### 📝 Checklist
+
+- [x] All new/changed/fixed functionality is covered by tests (or N/A)
+- [x] I have added documentation for all new/changed functionality (or N/A) — CHANGELOG entry added; no schema changes, so no `docs/` regeneration needed
+
+<!--
+❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
+-->

--- a/test/data/recordings/TestAccAttackProtectionBotDetection.yaml
+++ b/test/data/recordings/TestAccAttackProtectionBotDetection.yaml
@@ -33,7 +33,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.819666ms
+        duration: 361.1905ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -49,7 +49,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -60,13 +60,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.91875ms
+        duration: 334.264834ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -82,7 +82,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -93,13 +93,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":true,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.021541ms
+        duration: 310.100125ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,7 +115,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -126,13 +126,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":true,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.704792ms
+        duration: 339.918958ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -165,7 +165,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.705125ms
+        duration: 307.207667ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -192,13 +192,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"auth_challenge","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":""},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.469708ms
+        duration: 301.919542ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,7 +214,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -225,13 +225,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.325833ms
+        duration: 290.75425ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -247,7 +247,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -258,13 +258,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":true,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.405125ms
+        duration: 322.238458ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -280,7 +280,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -291,13 +291,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":true,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.393167ms
+        duration: 300.501666ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -330,7 +330,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 330.377583ms
+        duration: 303.299333ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -357,13 +357,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"auth_challenge","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":""},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.101167ms
+        duration: 308.522916ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -379,7 +379,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -390,13 +390,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.279208ms
+        duration: 314.051209ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,7 +412,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -423,13 +423,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":true,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.669708ms
+        duration: 293.52275ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -445,7 +445,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -456,13 +456,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":true,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.024125ms
+        duration: 327.923666ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -495,7 +495,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.908125ms
+        duration: 303.514875ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -522,13 +522,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"auth_challenge","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":""},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.806208ms
+        duration: 280.76975ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -561,7 +561,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.848833ms
+        duration: 317.19625ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -577,7 +577,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -588,13 +588,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.909542ms
+        duration: 297.797583ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -610,7 +610,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -621,13 +621,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":true,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 354.519291ms
+        duration: 292.09425ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -643,7 +643,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -654,13 +654,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":true,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 357.245875ms
+        duration: 286.948834ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -693,7 +693,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 369.832125ms
+        duration: 304.851209ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -720,13 +720,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"auth_challenge","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":""},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 357.955792ms
+        duration: 306.821375ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -742,7 +742,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -753,13 +753,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 356.901792ms
+        duration: 278.567167ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -775,7 +775,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -786,13 +786,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":true,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.80725ms
+        duration: 283.728084ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -808,7 +808,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -819,13 +819,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":true,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.067459ms
+        duration: 286.89675ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -858,7 +858,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.729291ms
+        duration: 301.269417ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -885,13 +885,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"auth_challenge","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":""},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 526.943375ms
+        duration: 283.711167ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -910,7 +910,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: PATCH
       response:
@@ -921,13 +921,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 511.001583ms
+        duration: 325.877375ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -946,7 +946,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: PATCH
       response:
@@ -957,13 +957,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 394.73ms
+        duration: 305.895375ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -982,7 +982,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: PATCH
       response:
@@ -993,10 +993,10 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.74425ms
+        duration: 367.179917ms

--- a/test/data/recordings/TestAccAttackProtectionBotDetection.yaml
+++ b/test/data/recordings/TestAccAttackProtectionBotDetection.yaml
@@ -33,7 +33,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.1905ms
+        duration: 499.205209ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,13 +60,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":true,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.264834ms
+        duration: 354.35875ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -93,13 +93,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":true,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":true,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 310.100125ms
+        duration: 308.858041ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -126,13 +126,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":true,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":true,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 339.918958ms
+        duration: 328.965458ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -165,7 +165,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 307.207667ms
+        duration: 373.398583ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -192,13 +192,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"auth_challenge","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":""},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"simple_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 301.919542ms
+        duration: 416.057041ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -225,13 +225,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":true,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 290.75425ms
+        duration: 324.80875ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -258,13 +258,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":true,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":true,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 322.238458ms
+        duration: 299.092083ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -291,13 +291,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":true,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":true,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 300.501666ms
+        duration: 397.999167ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -330,7 +330,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 303.299333ms
+        duration: 326.626959ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -357,13 +357,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"auth_challenge","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":""},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"simple_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 308.522916ms
+        duration: 342.627875ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -390,13 +390,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":true,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 314.051209ms
+        duration: 341.228125ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -423,13 +423,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":true,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":true,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 293.52275ms
+        duration: 349.690042ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -456,13 +456,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":true,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":true,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.923666ms
+        duration: 299.919875ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -495,7 +495,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 303.514875ms
+        duration: 309.01825ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -522,13 +522,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"auth_challenge","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":""},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"simple_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 280.76975ms
+        duration: 349.75725ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -561,7 +561,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 317.19625ms
+        duration: 329.852459ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -588,13 +588,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":true,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 297.797583ms
+        duration: 301.715167ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -621,13 +621,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":true,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":true,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 292.09425ms
+        duration: 311.87375ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -654,13 +654,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":true,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":true,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 286.948834ms
+        duration: 313.302917ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -693,7 +693,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 304.851209ms
+        duration: 314.90225ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -720,13 +720,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"auth_challenge","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":""},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"simple_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 306.821375ms
+        duration: 307.60025ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -753,13 +753,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":true,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 278.567167ms
+        duration: 310.541ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -786,13 +786,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":true,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":true,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 283.728084ms
+        duration: 304.44875ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -819,13 +819,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":true,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":true,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 286.89675ms
+        duration: 307.5015ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -858,7 +858,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 301.269417ms
+        duration: 369.318666ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -885,13 +885,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"auth_challenge","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":""},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"simple_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 283.711167ms
+        duration: 300.225042ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -921,13 +921,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 325.877375ms
+        duration: 346.419917ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -957,13 +957,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 305.895375ms
+        duration: 319.304292ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -993,10 +993,10 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.179917ms
+        duration: 353.806458ms

--- a/test/data/recordings/TestAccAttackProtectionBotDetectionInsufficientEntitlement.yaml
+++ b/test/data/recordings/TestAccAttackProtectionBotDetectionInsufficientEntitlement.yaml
@@ -1,0 +1,510 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 117
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":true,"shields":["block"],"allowlist":["127.0.0.1"],"mode":"count_per_identifier_and_ip","max_attempts":5}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":true,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 338.192333ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 219
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"bot_detection_level":"low","challenge_password_policy":"when_risky","challenge_passwordless_policy":"when_risky","challenge_password_reset_policy":"when_risky","allowlist":["127.0.0.1"],"monitoring_mode_enabled":true}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/bot-detection
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 316.934083ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 298.1555ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":true,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 315.241583ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 306.358167ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/bot-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 308.503583ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/captcha
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 281.654375ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 273.373125ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":true,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 288.94675ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 310.380708ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/bot-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 306.585125ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/captcha
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 290.833375ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 18
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":false}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 324.412125ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 18
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":false}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 414.320583ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 18
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":false}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 307.264292ms

--- a/test/data/recordings/TestAccAttackProtectionCaptcha.yaml
+++ b/test/data/recordings/TestAccAttackProtectionCaptcha.yaml
@@ -27,13 +27,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 311.543083ms
+        duration: 385.180209ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -60,13 +60,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 308.980125ms
+        duration: 306.374917ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -93,13 +93,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 321.093333ms
+        duration: 321.727958ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -126,13 +126,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 306.126417ms
+        duration: 302.446833ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -165,7 +165,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 317.222125ms
+        duration: 340.174708ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -192,13 +192,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 294.303083ms
+        duration: 338.657167ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -225,13 +225,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 314.837208ms
+        duration: 359.002417ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -258,13 +258,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 302.965375ms
+        duration: 298.578375ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -291,13 +291,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 356.488292ms
+        duration: 348.314125ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -330,7 +330,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 298.649875ms
+        duration: 353.242916ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -357,13 +357,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 318.0635ms
+        duration: 299.586333ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -390,13 +390,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 297.417917ms
+        duration: 296.272333ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -423,13 +423,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 294.492708ms
+        duration: 304.200292ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -456,13 +456,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.955459ms
+        duration: 302.716542ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -495,7 +495,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 317.256833ms
+        duration: 326.53725ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -522,13 +522,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 318.533875ms
+        duration: 315.300125ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -555,13 +555,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 323.003542ms
+        duration: 345.424584ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -588,13 +588,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 286.373583ms
+        duration: 316.778792ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -621,13 +621,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 309.1655ms
+        duration: 304.52825ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -654,13 +654,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 298.369542ms
+        duration: 382.479791ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -693,7 +693,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 286.978125ms
+        duration: 327.184291ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -720,13 +720,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 289.425791ms
+        duration: 338.634958ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -753,13 +753,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 307.590709ms
+        duration: 744.181292ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -786,13 +786,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 301.49225ms
+        duration: 300.289875ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -819,13 +819,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 312.428333ms
+        duration: 430.91525ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -858,7 +858,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 286.110917ms
+        duration: 386.678583ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -885,13 +885,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 303.826833ms
+        duration: 337.035833ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -918,13 +918,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.381791ms
+        duration: 347.330375ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -951,13 +951,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 314.803542ms
+        duration: 318.204834ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -984,13 +984,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 305.742167ms
+        duration: 298.933959ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1023,7 +1023,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 371.73225ms
+        duration: 343.13325ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1050,13 +1050,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 286.794833ms
+        duration: 329.659333ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1083,13 +1083,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 316.304625ms
+        duration: 331.768459ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1116,13 +1116,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 317.430625ms
+        duration: 404.490834ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1149,13 +1149,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 363.319417ms
+        duration: 330.669708ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1182,13 +1182,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 295.843958ms
+        duration: 301.777541ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1221,7 +1221,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 292.103291ms
+        duration: 304.9065ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1248,13 +1248,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 298.2105ms
+        duration: 393.902042ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1281,13 +1281,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 309.775166ms
+        duration: 306.110417ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1314,13 +1314,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 301.89775ms
+        duration: 312.303625ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1347,13 +1347,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 289.0815ms
+        duration: 304.818875ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1386,7 +1386,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 314.492042ms
+        duration: 356.8935ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1413,13 +1413,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.18325ms
+        duration: 414.854958ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1446,13 +1446,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 295.306125ms
+        duration: 297.659916ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1479,13 +1479,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 283.212167ms
+        duration: 336.725791ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1512,13 +1512,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 315.952459ms
+        duration: 306.380958ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1551,7 +1551,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 294.20525ms
+        duration: 297.263333ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1578,13 +1578,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 299.048542ms
+        duration: 307.146334ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1611,13 +1611,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.498333ms
+        duration: 368.154084ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1644,13 +1644,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 297.866459ms
+        duration: 298.828584ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1677,13 +1677,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 285.570542ms
+        duration: 330.380792ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1710,13 +1710,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 304.761833ms
+        duration: 345.30875ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1749,7 +1749,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.107958ms
+        duration: 343.597ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1776,13 +1776,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 287.335542ms
+        duration: 306.553292ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1809,13 +1809,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 300.355167ms
+        duration: 346.297541ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1842,13 +1842,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 299.292208ms
+        duration: 322.126042ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -1875,13 +1875,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 320.395917ms
+        duration: 305.751875ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -1914,7 +1914,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 289.444875ms
+        duration: 309.461125ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -1941,13 +1941,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 282.038416ms
+        duration: 341.863417ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -1974,13 +1974,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.423708ms
+        duration: 318.620667ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -2007,13 +2007,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 307.346916ms
+        duration: 299.54925ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -2040,13 +2040,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.775625ms
+        duration: 340.799625ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -2079,7 +2079,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.756916ms
+        duration: 307.148584ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -2106,13 +2106,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 285.412042ms
+        duration: 314.238375ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -2139,13 +2139,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 306.540875ms
+        duration: 324.966667ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -2172,13 +2172,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 287.378417ms
+        duration: 297.651334ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -2205,13 +2205,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.367125ms
+        duration: 348.950208ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -2238,13 +2238,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.212042ms
+        duration: 316.192791ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -2277,7 +2277,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.379ms
+        duration: 338.330708ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -2304,13 +2304,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 309.952333ms
+        duration: 327.420125ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -2337,13 +2337,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 312.069125ms
+        duration: 301.950125ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -2370,13 +2370,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 289.679958ms
+        duration: 297.059459ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -2403,13 +2403,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 307.437625ms
+        duration: 350.564ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -2442,7 +2442,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 375.999792ms
+        duration: 337.211958ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -2469,13 +2469,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 300.855792ms
+        duration: 348.975833ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -2502,13 +2502,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 289.7025ms
+        duration: 398.943291ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -2535,13 +2535,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.209708ms
+        duration: 309.72975ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -2568,13 +2568,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 294.135625ms
+        duration: 324.616459ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -2607,7 +2607,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 323.088209ms
+        duration: 301.252083ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -2634,13 +2634,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 302.98325ms
+        duration: 313.451584ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -2667,13 +2667,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.977125ms
+        duration: 326.542125ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -2700,13 +2700,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 348.887917ms
+        duration: 342.045125ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -2733,13 +2733,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 387.068417ms
+        duration: 297.489916ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -2766,13 +2766,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 282.063625ms
+        duration: 295.695667ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -2805,7 +2805,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 352.109334ms
+        duration: 344.415833ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -2832,13 +2832,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 290.193542ms
+        duration: 347.511ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -2865,13 +2865,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 292.752791ms
+        duration: 346.526625ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -2898,13 +2898,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 305.85275ms
+        duration: 342.943083ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -2931,13 +2931,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 287.232459ms
+        duration: 303.748041ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -2970,7 +2970,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 299.756ms
+        duration: 330.1225ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -2997,13 +2997,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 318.048083ms
+        duration: 326.887292ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -3030,13 +3030,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 369.013083ms
+        duration: 304.647083ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -3063,13 +3063,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 334.022375ms
+        duration: 321.514125ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -3096,13 +3096,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 294.71125ms
+        duration: 409.298875ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -3135,7 +3135,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 292.4405ms
+        duration: 305.042625ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -3162,13 +3162,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"hcaptcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 304.693166ms
+        duration: 341.7945ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -3195,13 +3195,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"test-site-key-friendly"},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"test-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.009333ms
+        duration: 312.113041ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -3228,13 +3228,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 293.431459ms
+        duration: 312.76175ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -3261,13 +3261,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.531292ms
+        duration: 299.029458ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -3294,13 +3294,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 284.962667ms
+        duration: 349.712291ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -3333,7 +3333,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 322.277584ms
+        duration: 363.165583ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -3360,13 +3360,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"test-site-key-friendly"},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"test-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.791833ms
+        duration: 300.486125ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -3393,13 +3393,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 285.25175ms
+        duration: 339.032167ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -3426,13 +3426,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 297.9185ms
+        duration: 309.921708ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -3459,13 +3459,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 297.418416ms
+        duration: 308.772875ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -3498,7 +3498,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 318.76475ms
+        duration: 330.263042ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -3525,13 +3525,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"test-site-key-friendly"},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"test-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.233291ms
+        duration: 308.312167ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -3558,13 +3558,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 330.189084ms
+        duration: 321.956583ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -3591,13 +3591,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 322.982541ms
+        duration: 301.643708ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -3624,13 +3624,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 317.825166ms
+        duration: 299.533917ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -3663,7 +3663,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.463125ms
+        duration: 336.7775ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -3690,13 +3690,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"test-site-key-friendly"},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"test-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 326.474042ms
+        duration: 342.400292ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -3723,13 +3723,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.271667ms
+        duration: 355.986458ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -3756,13 +3756,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 288.495459ms
+        duration: 362.006875ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -3789,13 +3789,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 288.840792ms
+        duration: 508.339833ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -3822,13 +3822,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 290.706625ms
+        duration: 410.108875ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -3861,7 +3861,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 288.482291ms
+        duration: 408.339ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -3888,13 +3888,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 319.952417ms
+        duration: 410.714208ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -3921,13 +3921,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 303.707208ms
+        duration: 307.030458ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -3954,13 +3954,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 320.463042ms
+        duration: 388.017708ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -3987,13 +3987,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 295.273375ms
+        duration: 302.153833ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -4026,7 +4026,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 297.806584ms
+        duration: 306.517834ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -4053,13 +4053,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 287.215833ms
+        duration: 314.284292ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -4086,13 +4086,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 280.872042ms
+        duration: 302.078917ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -4119,13 +4119,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 295.149375ms
+        duration: 303.097625ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -4152,13 +4152,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.759875ms
+        duration: 335.872667ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -4191,7 +4191,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 296.448ms
+        duration: 453.865834ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -4218,13 +4218,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"friendly_captcha","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 317.541ms
+        duration: 466.770625ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -4251,13 +4251,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"test-site-key-arkose","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"test-site-key-arkose","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 345.524084ms
+        duration: 321.645916ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -4284,13 +4284,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 281.117333ms
+        duration: 301.317167ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -4317,13 +4317,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 292.999375ms
+        duration: 304.772667ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -4350,13 +4350,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 332.199084ms
+        duration: 390.446375ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -4389,7 +4389,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.585958ms
+        duration: 318.076709ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -4416,13 +4416,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"test-site-key-arkose","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"test-site-key-arkose","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 294.033875ms
+        duration: 390.673542ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -4449,13 +4449,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 281.870417ms
+        duration: 307.350334ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -4482,13 +4482,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 283.975834ms
+        duration: 342.296167ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -4515,13 +4515,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 290.014417ms
+        duration: 325.4975ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -4554,7 +4554,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 293.268542ms
+        duration: 306.658667ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -4581,13 +4581,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"test-site-key-arkose","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"test-site-key-arkose","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 290.553208ms
+        duration: 307.064917ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -4614,13 +4614,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 284.003667ms
+        duration: 305.761375ms
     - id: 140
       request:
         proto: HTTP/1.1
@@ -4647,13 +4647,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.517125ms
+        duration: 342.075875ms
     - id: 141
       request:
         proto: HTTP/1.1
@@ -4680,13 +4680,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 296.361292ms
+        duration: 341.071292ms
     - id: 142
       request:
         proto: HTTP/1.1
@@ -4719,7 +4719,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 299.053583ms
+        duration: 329.168542ms
     - id: 143
       request:
         proto: HTTP/1.1
@@ -4746,13 +4746,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"test-site-key-arkose","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"test-site-key-arkose","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 330.833791ms
+        duration: 317.746625ms
     - id: 144
       request:
         proto: HTTP/1.1
@@ -4779,13 +4779,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
+        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 381.305917ms
+        duration: 323.665667ms
     - id: 145
       request:
         proto: HTTP/1.1
@@ -4812,13 +4812,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 304.265666ms
+        duration: 307.163125ms
     - id: 146
       request:
         proto: HTTP/1.1
@@ -4845,13 +4845,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 316.653083ms
+        duration: 291.416542ms
     - id: 147
       request:
         proto: HTTP/1.1
@@ -4878,13 +4878,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.170375ms
+        duration: 340.373ms
     - id: 148
       request:
         proto: HTTP/1.1
@@ -4917,7 +4917,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 288.059ms
+        duration: 304.64925ms
     - id: 149
       request:
         proto: HTTP/1.1
@@ -4944,13 +4944,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
+        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 315.883458ms
+        duration: 346.137ms
     - id: 150
       request:
         proto: HTTP/1.1
@@ -4977,13 +4977,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 287.461042ms
+        duration: 322.133708ms
     - id: 151
       request:
         proto: HTTP/1.1
@@ -5010,13 +5010,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 277.698458ms
+        duration: 343.495ms
     - id: 152
       request:
         proto: HTTP/1.1
@@ -5043,13 +5043,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 322.349542ms
+        duration: 319.287166ms
     - id: 153
       request:
         proto: HTTP/1.1
@@ -5082,7 +5082,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 321.135375ms
+        duration: 392.876083ms
     - id: 154
       request:
         proto: HTTP/1.1
@@ -5109,13 +5109,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
+        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 377.642459ms
+        duration: 291.311292ms
     - id: 155
       request:
         proto: HTTP/1.1
@@ -5142,13 +5142,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 294.211666ms
+        duration: 304.505167ms
     - id: 156
       request:
         proto: HTTP/1.1
@@ -5175,13 +5175,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 291.500459ms
+        duration: 308.29625ms
     - id: 157
       request:
         proto: HTTP/1.1
@@ -5208,13 +5208,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 302.515292ms
+        duration: 341.577208ms
     - id: 158
       request:
         proto: HTTP/1.1
@@ -5247,7 +5247,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 337.187084ms
+        duration: 338.030875ms
     - id: 159
       request:
         proto: HTTP/1.1
@@ -5274,13 +5274,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
+        body: '{"active_provider_id":"arkose","simple_captcha":{},"auth_challenge":{"fail_open":true},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"updated-site-key-hcaptcha"},"friendly_captcha":{"site_key":"updated-site-key-friendly"},"arkose":{"site_key":"updated-site-key-arkose","client_subdomain":"updated-client-api","verify_subdomain":"updated-verify-api","fail_open":true}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 323.597166ms
+        duration: 340.624584ms
     - id: 160
       request:
         proto: HTTP/1.1
@@ -5313,7 +5313,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 304.725709ms
+        duration: 320.270708ms
     - id: 161
       request:
         proto: HTTP/1.1
@@ -5340,13 +5340,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 298.304958ms
+        duration: 300.127083ms
     - id: 162
       request:
         proto: HTTP/1.1
@@ -5373,13 +5373,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 305.238292ms
+        duration: 300.970417ms
     - id: 163
       request:
         proto: HTTP/1.1
@@ -5406,13 +5406,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 284.008292ms
+        duration: 342.664875ms
     - id: 164
       request:
         proto: HTTP/1.1
@@ -5445,7 +5445,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 311.580666ms
+        duration: 344.373042ms
     - id: 165
       request:
         proto: HTTP/1.1
@@ -5478,7 +5478,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 331.108ms
+        duration: 318.64625ms
     - id: 166
       request:
         proto: HTTP/1.1
@@ -5505,13 +5505,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 277.733125ms
+        duration: 300.908542ms
     - id: 167
       request:
         proto: HTTP/1.1
@@ -5538,13 +5538,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.638208ms
+        duration: 381.157916ms
     - id: 168
       request:
         proto: HTTP/1.1
@@ -5571,13 +5571,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 316.711ms
+        duration: 309.5875ms
     - id: 169
       request:
         proto: HTTP/1.1
@@ -5610,7 +5610,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 288.32875ms
+        duration: 352.4045ms
     - id: 170
       request:
         proto: HTTP/1.1
@@ -5643,7 +5643,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 294.466958ms
+        duration: 409.206375ms
     - id: 171
       request:
         proto: HTTP/1.1
@@ -5670,13 +5670,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 295.718292ms
+        duration: 368.485459ms
     - id: 172
       request:
         proto: HTTP/1.1
@@ -5703,13 +5703,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 321.256042ms
+        duration: 511.582458ms
     - id: 173
       request:
         proto: HTTP/1.1
@@ -5736,13 +5736,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 327.670458ms
+        duration: 304.125125ms
     - id: 174
       request:
         proto: HTTP/1.1
@@ -5775,7 +5775,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.448458ms
+        duration: 405.318208ms
     - id: 175
       request:
         proto: HTTP/1.1
@@ -5808,7 +5808,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 286.851333ms
+        duration: 310.820083ms
     - id: 176
       request:
         proto: HTTP/1.1
@@ -5841,7 +5841,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 305.708875ms
+        duration: 314.118292ms
     - id: 177
       request:
         proto: HTTP/1.1
@@ -5868,13 +5868,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 290.957875ms
+        duration: 305.323875ms
     - id: 178
       request:
         proto: HTTP/1.1
@@ -5901,13 +5901,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 318.0695ms
+        duration: 304.237666ms
     - id: 179
       request:
         proto: HTTP/1.1
@@ -5934,13 +5934,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 287.388458ms
+        duration: 327.702292ms
     - id: 180
       request:
         proto: HTTP/1.1
@@ -5973,7 +5973,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 300.139125ms
+        duration: 394.19025ms
     - id: 181
       request:
         proto: HTTP/1.1
@@ -6006,7 +6006,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 285.006084ms
+        duration: 308.020375ms
     - id: 182
       request:
         proto: HTTP/1.1
@@ -6033,13 +6033,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 333.690792ms
+        duration: 306.752ms
     - id: 183
       request:
         proto: HTTP/1.1
@@ -6066,13 +6066,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 318.170666ms
+        duration: 415.8895ms
     - id: 184
       request:
         proto: HTTP/1.1
@@ -6099,13 +6099,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 289.010916ms
+        duration: 408.899959ms
     - id: 185
       request:
         proto: HTTP/1.1
@@ -6138,7 +6138,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 293.313708ms
+        duration: 302.360041ms
     - id: 186
       request:
         proto: HTTP/1.1
@@ -6171,7 +6171,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 300.211333ms
+        duration: 358.32675ms
     - id: 187
       request:
         proto: HTTP/1.1
@@ -6198,13 +6198,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 319.390958ms
+        duration: 340.723375ms
     - id: 188
       request:
         proto: HTTP/1.1
@@ -6231,13 +6231,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 279.24525ms
+        duration: 293.232416ms
     - id: 189
       request:
         proto: HTTP/1.1
@@ -6264,13 +6264,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 319.048917ms
+        duration: 304.676125ms
     - id: 190
       request:
         proto: HTTP/1.1
@@ -6303,7 +6303,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 342.387042ms
+        duration: 303.514833ms
     - id: 191
       request:
         proto: HTTP/1.1
@@ -6336,7 +6336,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 315.646084ms
+        duration: 305.67975ms
     - id: 192
       request:
         proto: HTTP/1.1
@@ -6369,7 +6369,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 299.238375ms
+        duration: 346.173208ms
     - id: 193
       request:
         proto: HTTP/1.1
@@ -6396,13 +6396,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 313.486ms
+        duration: 302.045375ms
     - id: 194
       request:
         proto: HTTP/1.1
@@ -6429,13 +6429,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 276.453ms
+        duration: 299.939083ms
     - id: 195
       request:
         proto: HTTP/1.1
@@ -6462,13 +6462,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 286.91875ms
+        duration: 302.335958ms
     - id: 196
       request:
         proto: HTTP/1.1
@@ -6501,7 +6501,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 290.095ms
+        duration: 341.803959ms
     - id: 197
       request:
         proto: HTTP/1.1
@@ -6534,7 +6534,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 293.490083ms
+        duration: 307.068333ms
     - id: 198
       request:
         proto: HTTP/1.1
@@ -6561,13 +6561,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 321.535ms
+        duration: 351.540208ms
     - id: 199
       request:
         proto: HTTP/1.1
@@ -6594,13 +6594,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 298.699792ms
+        duration: 344.398792ms
     - id: 200
       request:
         proto: HTTP/1.1
@@ -6627,13 +6627,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.360981708s
+        duration: 299.92575ms
     - id: 201
       request:
         proto: HTTP/1.1
@@ -6666,7 +6666,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.279917ms
+        duration: 324.166ms
     - id: 202
       request:
         proto: HTTP/1.1
@@ -6699,7 +6699,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 338.7475ms
+        duration: 302.485125ms
     - id: 203
       request:
         proto: HTTP/1.1
@@ -6729,13 +6729,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"admin_notification_frequency":["daily"],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 344.846667ms
+        duration: 322.260416ms
     - id: 204
       request:
         proto: HTTP/1.1
@@ -6765,13 +6765,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 313.475916ms
+        duration: 353.311667ms
     - id: 205
       request:
         proto: HTTP/1.1
@@ -6801,10 +6801,10 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 302.721042ms
+        duration: 316.069958ms

--- a/test/data/recordings/TestAccAttackProtectionCaptcha.yaml
+++ b/test/data/recordings/TestAccAttackProtectionCaptcha.yaml
@@ -27,13 +27,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 399.438917ms
+        duration: 311.543083ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -49,7 +49,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -60,13 +60,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 396.189416ms
+        duration: 308.980125ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -82,7 +82,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -93,13 +93,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 598.759708ms
+        duration: 321.093333ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -115,7 +115,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -126,13 +126,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 398.404917ms
+        duration: 306.126417ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -165,7 +165,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 504.962792ms
+        duration: 317.222125ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -192,13 +192,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 399.7665ms
+        duration: 294.303083ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -214,7 +214,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -225,13 +225,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 388.872208ms
+        duration: 314.837208ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -247,7 +247,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -258,13 +258,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 396.435333ms
+        duration: 302.965375ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -280,7 +280,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -291,13 +291,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 399.526042ms
+        duration: 356.488292ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -330,7 +330,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.890875ms
+        duration: 298.649875ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -357,13 +357,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 440.2ms
+        duration: 318.0635ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -379,7 +379,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -390,13 +390,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 399.674667ms
+        duration: 297.417917ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -412,7 +412,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -423,13 +423,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.564125ms
+        duration: 294.492708ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -445,7 +445,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -456,13 +456,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 381.308792ms
+        duration: 345.955459ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -495,7 +495,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 360.358959ms
+        duration: 317.256833ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -522,13 +522,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"test-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 426.429292ms
+        duration: 318.533875ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -555,13 +555,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 385.400375ms
+        duration: 323.003542ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -577,7 +577,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -588,13 +588,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 369.582708ms
+        duration: 286.373583ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -610,7 +610,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -621,13 +621,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 383.657125ms
+        duration: 309.1655ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -643,7 +643,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -654,13 +654,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 408.290375ms
+        duration: 298.369542ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -693,7 +693,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 385.363458ms
+        duration: 286.978125ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -720,13 +720,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.082833ms
+        duration: 289.425791ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -742,7 +742,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -753,13 +753,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 378.396708ms
+        duration: 307.590709ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -775,7 +775,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -786,13 +786,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 519.935167ms
+        duration: 301.49225ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -808,7 +808,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -819,13 +819,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 528.958417ms
+        duration: 312.428333ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -858,7 +858,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.072875ms
+        duration: 286.110917ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -885,13 +885,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 370.146084ms
+        duration: 303.826833ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -907,7 +907,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -918,13 +918,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 511.558209ms
+        duration: 345.381791ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -940,7 +940,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -951,13 +951,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 371.616084ms
+        duration: 314.803542ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -973,7 +973,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -984,13 +984,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 439.4925ms
+        duration: 305.742167ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1023,7 +1023,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 378.772417ms
+        duration: 371.73225ms
     - id: 31
       request:
         proto: HTTP/1.1
@@ -1050,13 +1050,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_v2","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"","project_id":""},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 540.529125ms
+        duration: 286.794833ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1083,13 +1083,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 414.24225ms
+        duration: 316.304625ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1105,7 +1105,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -1116,13 +1116,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 430.408417ms
+        duration: 317.430625ms
     - id: 34
       request:
         proto: HTTP/1.1
@@ -1138,7 +1138,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -1149,13 +1149,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 562.271917ms
+        duration: 363.319417ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1171,7 +1171,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -1182,13 +1182,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 597.743584ms
+        duration: 295.843958ms
     - id: 36
       request:
         proto: HTTP/1.1
@@ -1221,7 +1221,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 402.622542ms
+        duration: 292.103291ms
     - id: 37
       request:
         proto: HTTP/1.1
@@ -1248,13 +1248,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400.030417ms
+        duration: 298.2105ms
     - id: 38
       request:
         proto: HTTP/1.1
@@ -1270,7 +1270,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -1281,13 +1281,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 583.814542ms
+        duration: 309.775166ms
     - id: 39
       request:
         proto: HTTP/1.1
@@ -1303,7 +1303,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -1314,13 +1314,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 722.801958ms
+        duration: 301.89775ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1336,7 +1336,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -1347,13 +1347,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 429.113542ms
+        duration: 289.0815ms
     - id: 41
       request:
         proto: HTTP/1.1
@@ -1386,7 +1386,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 611.152292ms
+        duration: 314.492042ms
     - id: 42
       request:
         proto: HTTP/1.1
@@ -1413,13 +1413,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 512.996042ms
+        duration: 331.18325ms
     - id: 43
       request:
         proto: HTTP/1.1
@@ -1435,7 +1435,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -1446,13 +1446,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 496.8435ms
+        duration: 295.306125ms
     - id: 44
       request:
         proto: HTTP/1.1
@@ -1468,7 +1468,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -1479,13 +1479,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 412.129167ms
+        duration: 283.212167ms
     - id: 45
       request:
         proto: HTTP/1.1
@@ -1501,7 +1501,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -1512,13 +1512,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 423.97225ms
+        duration: 315.952459ms
     - id: 46
       request:
         proto: HTTP/1.1
@@ -1551,7 +1551,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 451.793375ms
+        duration: 294.20525ms
     - id: 47
       request:
         proto: HTTP/1.1
@@ -1578,13 +1578,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"test-site-key-enterprise","project_id":"test-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 499.803917ms
+        duration: 299.048542ms
     - id: 48
       request:
         proto: HTTP/1.1
@@ -1611,13 +1611,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.754833ms
+        duration: 332.498333ms
     - id: 49
       request:
         proto: HTTP/1.1
@@ -1633,7 +1633,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -1644,13 +1644,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 379.204958ms
+        duration: 297.866459ms
     - id: 50
       request:
         proto: HTTP/1.1
@@ -1666,7 +1666,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -1677,13 +1677,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 443.73925ms
+        duration: 285.570542ms
     - id: 51
       request:
         proto: HTTP/1.1
@@ -1699,7 +1699,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -1710,13 +1710,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 593.331375ms
+        duration: 304.761833ms
     - id: 52
       request:
         proto: HTTP/1.1
@@ -1749,7 +1749,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 523.918125ms
+        duration: 327.107958ms
     - id: 53
       request:
         proto: HTTP/1.1
@@ -1776,13 +1776,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 649.017209ms
+        duration: 287.335542ms
     - id: 54
       request:
         proto: HTTP/1.1
@@ -1798,7 +1798,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -1809,13 +1809,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 717.595708ms
+        duration: 300.355167ms
     - id: 55
       request:
         proto: HTTP/1.1
@@ -1831,7 +1831,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -1842,13 +1842,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 720.641875ms
+        duration: 299.292208ms
     - id: 56
       request:
         proto: HTTP/1.1
@@ -1864,7 +1864,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -1875,13 +1875,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 403.981709ms
+        duration: 320.395917ms
     - id: 57
       request:
         proto: HTTP/1.1
@@ -1914,7 +1914,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 372.368791ms
+        duration: 289.444875ms
     - id: 58
       request:
         proto: HTTP/1.1
@@ -1941,13 +1941,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 384.885959ms
+        duration: 282.038416ms
     - id: 59
       request:
         proto: HTTP/1.1
@@ -1963,7 +1963,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -1974,13 +1974,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 454.933375ms
+        duration: 359.423708ms
     - id: 60
       request:
         proto: HTTP/1.1
@@ -1996,7 +1996,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -2007,13 +2007,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 363.078542ms
+        duration: 307.346916ms
     - id: 61
       request:
         proto: HTTP/1.1
@@ -2029,7 +2029,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -2040,13 +2040,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.2945ms
+        duration: 355.775625ms
     - id: 62
       request:
         proto: HTTP/1.1
@@ -2079,7 +2079,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.451125ms
+        duration: 345.756916ms
     - id: 63
       request:
         proto: HTTP/1.1
@@ -2106,13 +2106,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":"test-site-key-hcaptcha-5"},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
+        body: '{"active_provider_id":"recaptcha_enterprise","simple_captcha":{},"auth_challenge":{"fail_open":false},"recaptcha_v2":{"site_key":"updated-site-key-v2"},"recaptcha_enterprise":{"site_key":"updated-site-key-enterprise","project_id":"updated-project-id-enterprise"},"hcaptcha":{"site_key":""},"friendly_captcha":{"site_key":""},"arkose":{"site_key":"","client_subdomain":"client-api","verify_subdomain":"verify-api","fail_open":false}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.339292ms
+        duration: 285.412042ms
     - id: 64
       request:
         proto: HTTP/1.1
@@ -2145,7 +2145,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 389.0165ms
+        duration: 306.540875ms
     - id: 65
       request:
         proto: HTTP/1.1
@@ -2161,7 +2161,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -2172,13 +2172,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 374.886666ms
+        duration: 287.378417ms
     - id: 66
       request:
         proto: HTTP/1.1
@@ -2194,7 +2194,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -2205,13 +2205,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 501.820875ms
+        duration: 352.367125ms
     - id: 67
       request:
         proto: HTTP/1.1
@@ -2227,7 +2227,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -2238,13 +2238,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 520.5615ms
+        duration: 337.212042ms
     - id: 68
       request:
         proto: HTTP/1.1
@@ -2277,7 +2277,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 503.5855ms
+        duration: 333.379ms
     - id: 69
       request:
         proto: HTTP/1.1
@@ -2310,7 +2310,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 421.771208ms
+        duration: 309.952333ms
     - id: 70
       request:
         proto: HTTP/1.1
@@ -2326,7 +2326,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -2337,13 +2337,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 640.446042ms
+        duration: 312.069125ms
     - id: 71
       request:
         proto: HTTP/1.1
@@ -2359,7 +2359,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -2370,13 +2370,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 393.158708ms
+        duration: 289.679958ms
     - id: 72
       request:
         proto: HTTP/1.1
@@ -2392,7 +2392,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -2403,13 +2403,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 423.393625ms
+        duration: 307.437625ms
     - id: 73
       request:
         proto: HTTP/1.1
@@ -2442,7 +2442,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 509.444375ms
+        duration: 375.999792ms
     - id: 74
       request:
         proto: HTTP/1.1
@@ -2475,7 +2475,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 588.960208ms
+        duration: 300.855792ms
     - id: 75
       request:
         proto: HTTP/1.1
@@ -2491,7 +2491,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -2502,13 +2502,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.704625ms
+        duration: 289.7025ms
     - id: 76
       request:
         proto: HTTP/1.1
@@ -2524,7 +2524,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -2535,13 +2535,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 409.011583ms
+        duration: 367.209708ms
     - id: 77
       request:
         proto: HTTP/1.1
@@ -2557,7 +2557,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -2568,13 +2568,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 400.201125ms
+        duration: 294.135625ms
     - id: 78
       request:
         proto: HTTP/1.1
@@ -2607,7 +2607,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 499.259ms
+        duration: 323.088209ms
     - id: 79
       request:
         proto: HTTP/1.1
@@ -2640,7 +2640,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 509.535709ms
+        duration: 302.98325ms
     - id: 80
       request:
         proto: HTTP/1.1
@@ -2673,7 +2673,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 736.345791ms
+        duration: 358.977125ms
     - id: 81
       request:
         proto: HTTP/1.1
@@ -2689,7 +2689,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -2700,13 +2700,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 603.675667ms
+        duration: 348.887917ms
     - id: 82
       request:
         proto: HTTP/1.1
@@ -2722,7 +2722,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -2733,13 +2733,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 408.1225ms
+        duration: 387.068417ms
     - id: 83
       request:
         proto: HTTP/1.1
@@ -2755,7 +2755,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -2766,13 +2766,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 512.333917ms
+        duration: 282.063625ms
     - id: 84
       request:
         proto: HTTP/1.1
@@ -2805,7 +2805,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 511.09175ms
+        duration: 352.109334ms
     - id: 85
       request:
         proto: HTTP/1.1
@@ -2838,7 +2838,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 429.619042ms
+        duration: 290.193542ms
     - id: 86
       request:
         proto: HTTP/1.1
@@ -2854,7 +2854,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -2865,13 +2865,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 375.178834ms
+        duration: 292.752791ms
     - id: 87
       request:
         proto: HTTP/1.1
@@ -2887,7 +2887,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -2898,13 +2898,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 451.338958ms
+        duration: 305.85275ms
     - id: 88
       request:
         proto: HTTP/1.1
@@ -2920,7 +2920,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -2931,13 +2931,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 483.356833ms
+        duration: 287.232459ms
     - id: 89
       request:
         proto: HTTP/1.1
@@ -2970,7 +2970,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.088417ms
+        duration: 299.756ms
     - id: 90
       request:
         proto: HTTP/1.1
@@ -3003,7 +3003,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 552.199667ms
+        duration: 318.048083ms
     - id: 91
       request:
         proto: HTTP/1.1
@@ -3019,7 +3019,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -3030,13 +3030,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 414.611167ms
+        duration: 369.013083ms
     - id: 92
       request:
         proto: HTTP/1.1
@@ -3052,7 +3052,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -3063,13 +3063,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 504.022459ms
+        duration: 334.022375ms
     - id: 93
       request:
         proto: HTTP/1.1
@@ -3085,7 +3085,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -3096,13 +3096,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 477.893ms
+        duration: 294.71125ms
     - id: 94
       request:
         proto: HTTP/1.1
@@ -3135,7 +3135,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 490.881125ms
+        duration: 292.4405ms
     - id: 95
       request:
         proto: HTTP/1.1
@@ -3168,7 +3168,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 495.793375ms
+        duration: 304.693166ms
     - id: 96
       request:
         proto: HTTP/1.1
@@ -3201,7 +3201,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 445.19775ms
+        duration: 337.009333ms
     - id: 97
       request:
         proto: HTTP/1.1
@@ -3217,7 +3217,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -3228,13 +3228,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 368.608ms
+        duration: 293.431459ms
     - id: 98
       request:
         proto: HTTP/1.1
@@ -3250,7 +3250,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -3261,13 +3261,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 527.207333ms
+        duration: 327.531292ms
     - id: 99
       request:
         proto: HTTP/1.1
@@ -3283,7 +3283,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -3294,13 +3294,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 429.69125ms
+        duration: 284.962667ms
     - id: 100
       request:
         proto: HTTP/1.1
@@ -3333,7 +3333,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 387.384709ms
+        duration: 322.277584ms
     - id: 101
       request:
         proto: HTTP/1.1
@@ -3366,7 +3366,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 409.890292ms
+        duration: 327.791833ms
     - id: 102
       request:
         proto: HTTP/1.1
@@ -3382,7 +3382,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -3393,13 +3393,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 379.71275ms
+        duration: 285.25175ms
     - id: 103
       request:
         proto: HTTP/1.1
@@ -3415,7 +3415,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -3426,13 +3426,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 389.15925ms
+        duration: 297.9185ms
     - id: 104
       request:
         proto: HTTP/1.1
@@ -3448,7 +3448,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -3459,13 +3459,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 790.214667ms
+        duration: 297.418416ms
     - id: 105
       request:
         proto: HTTP/1.1
@@ -3498,7 +3498,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 900.251875ms
+        duration: 318.76475ms
     - id: 106
       request:
         proto: HTTP/1.1
@@ -3531,7 +3531,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 492.820791ms
+        duration: 327.233291ms
     - id: 107
       request:
         proto: HTTP/1.1
@@ -3547,7 +3547,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -3558,13 +3558,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 418.592625ms
+        duration: 330.189084ms
     - id: 108
       request:
         proto: HTTP/1.1
@@ -3580,7 +3580,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -3591,13 +3591,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 343.282209ms
+        duration: 322.982541ms
     - id: 109
       request:
         proto: HTTP/1.1
@@ -3613,7 +3613,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -3624,13 +3624,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 523.457958ms
+        duration: 317.825166ms
     - id: 110
       request:
         proto: HTTP/1.1
@@ -3663,7 +3663,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 640.326083ms
+        duration: 324.463125ms
     - id: 111
       request:
         proto: HTTP/1.1
@@ -3696,7 +3696,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 402.260792ms
+        duration: 326.474042ms
     - id: 112
       request:
         proto: HTTP/1.1
@@ -3729,7 +3729,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 362.928792ms
+        duration: 347.271667ms
     - id: 113
       request:
         proto: HTTP/1.1
@@ -3745,7 +3745,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -3756,13 +3756,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 456.348416ms
+        duration: 288.495459ms
     - id: 114
       request:
         proto: HTTP/1.1
@@ -3778,7 +3778,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -3789,13 +3789,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 357.941708ms
+        duration: 288.840792ms
     - id: 115
       request:
         proto: HTTP/1.1
@@ -3811,7 +3811,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -3822,13 +3822,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 512.672875ms
+        duration: 290.706625ms
     - id: 116
       request:
         proto: HTTP/1.1
@@ -3861,7 +3861,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 383.194333ms
+        duration: 288.482291ms
     - id: 117
       request:
         proto: HTTP/1.1
@@ -3894,7 +3894,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 433.993292ms
+        duration: 319.952417ms
     - id: 118
       request:
         proto: HTTP/1.1
@@ -3910,7 +3910,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -3921,13 +3921,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 393.059458ms
+        duration: 303.707208ms
     - id: 119
       request:
         proto: HTTP/1.1
@@ -3943,7 +3943,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -3954,13 +3954,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 410.892916ms
+        duration: 320.463042ms
     - id: 120
       request:
         proto: HTTP/1.1
@@ -3976,7 +3976,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -3987,13 +3987,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 493.011583ms
+        duration: 295.273375ms
     - id: 121
       request:
         proto: HTTP/1.1
@@ -4026,7 +4026,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 491.008041ms
+        duration: 297.806584ms
     - id: 122
       request:
         proto: HTTP/1.1
@@ -4059,7 +4059,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 381.360959ms
+        duration: 287.215833ms
     - id: 123
       request:
         proto: HTTP/1.1
@@ -4075,7 +4075,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -4086,13 +4086,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 518.760583ms
+        duration: 280.872042ms
     - id: 124
       request:
         proto: HTTP/1.1
@@ -4108,7 +4108,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -4119,13 +4119,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 500.411875ms
+        duration: 295.149375ms
     - id: 125
       request:
         proto: HTTP/1.1
@@ -4141,7 +4141,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -4152,13 +4152,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 429.397916ms
+        duration: 340.759875ms
     - id: 126
       request:
         proto: HTTP/1.1
@@ -4191,7 +4191,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 370.511833ms
+        duration: 296.448ms
     - id: 127
       request:
         proto: HTTP/1.1
@@ -4224,7 +4224,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 575.484625ms
+        duration: 317.541ms
     - id: 128
       request:
         proto: HTTP/1.1
@@ -4257,7 +4257,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 851.507084ms
+        duration: 345.524084ms
     - id: 129
       request:
         proto: HTTP/1.1
@@ -4273,7 +4273,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -4284,13 +4284,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 580.200708ms
+        duration: 281.117333ms
     - id: 130
       request:
         proto: HTTP/1.1
@@ -4306,7 +4306,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -4317,13 +4317,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 351.400375ms
+        duration: 292.999375ms
     - id: 131
       request:
         proto: HTTP/1.1
@@ -4339,7 +4339,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -4350,13 +4350,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 524.060292ms
+        duration: 332.199084ms
     - id: 132
       request:
         proto: HTTP/1.1
@@ -4389,7 +4389,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 365.269833ms
+        duration: 347.585958ms
     - id: 133
       request:
         proto: HTTP/1.1
@@ -4422,7 +4422,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 495.834583ms
+        duration: 294.033875ms
     - id: 134
       request:
         proto: HTTP/1.1
@@ -4438,7 +4438,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -4449,13 +4449,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 409.559042ms
+        duration: 281.870417ms
     - id: 135
       request:
         proto: HTTP/1.1
@@ -4471,7 +4471,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -4482,13 +4482,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 427.252ms
+        duration: 283.975834ms
     - id: 136
       request:
         proto: HTTP/1.1
@@ -4504,7 +4504,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -4515,13 +4515,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 384.131584ms
+        duration: 290.014417ms
     - id: 137
       request:
         proto: HTTP/1.1
@@ -4554,7 +4554,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 585.415584ms
+        duration: 293.268542ms
     - id: 138
       request:
         proto: HTTP/1.1
@@ -4587,7 +4587,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.54175ms
+        duration: 290.553208ms
     - id: 139
       request:
         proto: HTTP/1.1
@@ -4603,7 +4603,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -4614,13 +4614,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 873.557958ms
+        duration: 284.003667ms
     - id: 140
       request:
         proto: HTTP/1.1
@@ -4636,7 +4636,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -4647,13 +4647,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 713.922916ms
+        duration: 361.517125ms
     - id: 141
       request:
         proto: HTTP/1.1
@@ -4669,7 +4669,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -4680,13 +4680,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 409.098208ms
+        duration: 296.361292ms
     - id: 142
       request:
         proto: HTTP/1.1
@@ -4719,7 +4719,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 487.74375ms
+        duration: 299.053583ms
     - id: 143
       request:
         proto: HTTP/1.1
@@ -4752,7 +4752,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 512.23575ms
+        duration: 330.833791ms
     - id: 144
       request:
         proto: HTTP/1.1
@@ -4785,7 +4785,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 361.844416ms
+        duration: 381.305917ms
     - id: 145
       request:
         proto: HTTP/1.1
@@ -4801,7 +4801,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -4812,13 +4812,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 368.187333ms
+        duration: 304.265666ms
     - id: 146
       request:
         proto: HTTP/1.1
@@ -4834,7 +4834,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -4845,13 +4845,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 346.031ms
+        duration: 316.653083ms
     - id: 147
       request:
         proto: HTTP/1.1
@@ -4867,7 +4867,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -4878,13 +4878,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 492.40425ms
+        duration: 338.170375ms
     - id: 148
       request:
         proto: HTTP/1.1
@@ -4917,7 +4917,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 630.7865ms
+        duration: 288.059ms
     - id: 149
       request:
         proto: HTTP/1.1
@@ -4950,7 +4950,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 409.836209ms
+        duration: 315.883458ms
     - id: 150
       request:
         proto: HTTP/1.1
@@ -4966,7 +4966,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -4977,13 +4977,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 525.076792ms
+        duration: 287.461042ms
     - id: 151
       request:
         proto: HTTP/1.1
@@ -4999,7 +4999,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -5010,13 +5010,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 410.124625ms
+        duration: 277.698458ms
     - id: 152
       request:
         proto: HTTP/1.1
@@ -5032,7 +5032,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -5043,13 +5043,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 402.57475ms
+        duration: 322.349542ms
     - id: 153
       request:
         proto: HTTP/1.1
@@ -5082,7 +5082,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 377.987917ms
+        duration: 321.135375ms
     - id: 154
       request:
         proto: HTTP/1.1
@@ -5115,7 +5115,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 359.957542ms
+        duration: 377.642459ms
     - id: 155
       request:
         proto: HTTP/1.1
@@ -5131,7 +5131,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -5142,13 +5142,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 748.558083ms
+        duration: 294.211666ms
     - id: 156
       request:
         proto: HTTP/1.1
@@ -5164,7 +5164,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -5175,13 +5175,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 390.638375ms
+        duration: 291.500459ms
     - id: 157
       request:
         proto: HTTP/1.1
@@ -5197,7 +5197,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -5208,13 +5208,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 350.724292ms
+        duration: 302.515292ms
     - id: 158
       request:
         proto: HTTP/1.1
@@ -5247,7 +5247,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 611.84325ms
+        duration: 337.187084ms
     - id: 159
       request:
         proto: HTTP/1.1
@@ -5280,7 +5280,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 512.546375ms
+        duration: 323.597166ms
     - id: 160
       request:
         proto: HTTP/1.1
@@ -5313,7 +5313,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 420.941417ms
+        duration: 304.725709ms
     - id: 161
       request:
         proto: HTTP/1.1
@@ -5329,7 +5329,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -5340,13 +5340,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.181145s
+        duration: 298.304958ms
     - id: 162
       request:
         proto: HTTP/1.1
@@ -5362,7 +5362,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -5373,13 +5373,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 353.529166ms
+        duration: 305.238292ms
     - id: 163
       request:
         proto: HTTP/1.1
@@ -5395,7 +5395,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -5406,13 +5406,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 374.034958ms
+        duration: 284.008292ms
     - id: 164
       request:
         proto: HTTP/1.1
@@ -5445,7 +5445,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 441.4425ms
+        duration: 311.580666ms
     - id: 165
       request:
         proto: HTTP/1.1
@@ -5478,7 +5478,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 512.091917ms
+        duration: 331.108ms
     - id: 166
       request:
         proto: HTTP/1.1
@@ -5494,7 +5494,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -5505,13 +5505,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 381.053959ms
+        duration: 277.733125ms
     - id: 167
       request:
         proto: HTTP/1.1
@@ -5527,7 +5527,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -5538,13 +5538,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 437.61075ms
+        duration: 324.638208ms
     - id: 168
       request:
         proto: HTTP/1.1
@@ -5560,7 +5560,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -5571,13 +5571,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 437.6375ms
+        duration: 316.711ms
     - id: 169
       request:
         proto: HTTP/1.1
@@ -5610,7 +5610,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 385.386584ms
+        duration: 288.32875ms
     - id: 170
       request:
         proto: HTTP/1.1
@@ -5643,7 +5643,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 347.844917ms
+        duration: 294.466958ms
     - id: 171
       request:
         proto: HTTP/1.1
@@ -5659,7 +5659,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -5670,13 +5670,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 383.097125ms
+        duration: 295.718292ms
     - id: 172
       request:
         proto: HTTP/1.1
@@ -5692,7 +5692,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -5703,13 +5703,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 415.044625ms
+        duration: 321.256042ms
     - id: 173
       request:
         proto: HTTP/1.1
@@ -5725,7 +5725,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -5736,13 +5736,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 626.513292ms
+        duration: 327.670458ms
     - id: 174
       request:
         proto: HTTP/1.1
@@ -5775,7 +5775,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 611.150625ms
+        duration: 350.448458ms
     - id: 175
       request:
         proto: HTTP/1.1
@@ -5808,7 +5808,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 511.093292ms
+        duration: 286.851333ms
     - id: 176
       request:
         proto: HTTP/1.1
@@ -5841,7 +5841,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 500.907167ms
+        duration: 305.708875ms
     - id: 177
       request:
         proto: HTTP/1.1
@@ -5857,7 +5857,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -5868,13 +5868,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 508.27925ms
+        duration: 290.957875ms
     - id: 178
       request:
         proto: HTTP/1.1
@@ -5890,7 +5890,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -5901,13 +5901,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 432.527667ms
+        duration: 318.0695ms
     - id: 179
       request:
         proto: HTTP/1.1
@@ -5923,7 +5923,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -5934,13 +5934,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 386.517792ms
+        duration: 287.388458ms
     - id: 180
       request:
         proto: HTTP/1.1
@@ -5973,7 +5973,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 621.343042ms
+        duration: 300.139125ms
     - id: 181
       request:
         proto: HTTP/1.1
@@ -6006,7 +6006,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 453.0415ms
+        duration: 285.006084ms
     - id: 182
       request:
         proto: HTTP/1.1
@@ -6022,7 +6022,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -6033,13 +6033,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 388.333959ms
+        duration: 333.690792ms
     - id: 183
       request:
         proto: HTTP/1.1
@@ -6055,7 +6055,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -6066,13 +6066,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 398.32675ms
+        duration: 318.170666ms
     - id: 184
       request:
         proto: HTTP/1.1
@@ -6088,7 +6088,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -6099,13 +6099,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 438.164625ms
+        duration: 289.010916ms
     - id: 185
       request:
         proto: HTTP/1.1
@@ -6138,7 +6138,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 375.808667ms
+        duration: 293.313708ms
     - id: 186
       request:
         proto: HTTP/1.1
@@ -6171,7 +6171,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.436625ms
+        duration: 300.211333ms
     - id: 187
       request:
         proto: HTTP/1.1
@@ -6187,7 +6187,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -6198,13 +6198,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 363.617167ms
+        duration: 319.390958ms
     - id: 188
       request:
         proto: HTTP/1.1
@@ -6220,7 +6220,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -6231,13 +6231,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 355.025708ms
+        duration: 279.24525ms
     - id: 189
       request:
         proto: HTTP/1.1
@@ -6253,7 +6253,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -6264,13 +6264,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 724.232917ms
+        duration: 319.048917ms
     - id: 190
       request:
         proto: HTTP/1.1
@@ -6303,7 +6303,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 559.626333ms
+        duration: 342.387042ms
     - id: 191
       request:
         proto: HTTP/1.1
@@ -6336,7 +6336,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 511.191ms
+        duration: 315.646084ms
     - id: 192
       request:
         proto: HTTP/1.1
@@ -6369,7 +6369,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 426.704667ms
+        duration: 299.238375ms
     - id: 193
       request:
         proto: HTTP/1.1
@@ -6385,7 +6385,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -6396,13 +6396,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 404.132875ms
+        duration: 313.486ms
     - id: 194
       request:
         proto: HTTP/1.1
@@ -6418,7 +6418,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -6429,13 +6429,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 405.806375ms
+        duration: 276.453ms
     - id: 195
       request:
         proto: HTTP/1.1
@@ -6451,7 +6451,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -6462,13 +6462,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 715.888042ms
+        duration: 286.91875ms
     - id: 196
       request:
         proto: HTTP/1.1
@@ -6501,7 +6501,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 509.909083ms
+        duration: 290.095ms
     - id: 197
       request:
         proto: HTTP/1.1
@@ -6534,7 +6534,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 715.576084ms
+        duration: 293.490083ms
     - id: 198
       request:
         proto: HTTP/1.1
@@ -6550,7 +6550,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: GET
       response:
@@ -6561,13 +6561,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 522.605916ms
+        duration: 321.535ms
     - id: 199
       request:
         proto: HTTP/1.1
@@ -6583,7 +6583,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: GET
       response:
@@ -6594,13 +6594,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 367.305208ms
+        duration: 298.699792ms
     - id: 200
       request:
         proto: HTTP/1.1
@@ -6616,7 +6616,7 @@ interactions:
         form: {}
         headers:
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: GET
       response:
@@ -6627,13 +6627,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 358.859ms
+        duration: 1.360981708s
     - id: 201
       request:
         proto: HTTP/1.1
@@ -6666,7 +6666,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 402.583375ms
+        duration: 343.279917ms
     - id: 202
       request:
         proto: HTTP/1.1
@@ -6699,7 +6699,7 @@ interactions:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 511.29675ms
+        duration: 338.7475ms
     - id: 203
       request:
         proto: HTTP/1.1
@@ -6718,7 +6718,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
         method: PATCH
       response:
@@ -6729,13 +6729,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification","user_notification"],"admin_notification_frequency":["monthly","daily","weekly","immediately"],"method":"standard","stage":{"pre-user-registration":{"shields":["block","admin_notification"]},"pre-change-password":{"shields":["block","admin_notification"]}}}'
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 1.527506375s
+        duration: 344.846667ms
     - id: 204
       request:
         proto: HTTP/1.1
@@ -6754,7 +6754,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
         method: PATCH
       response:
@@ -6765,13 +6765,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["user_notification","block"],"mode":"count_per_identifier","allowlist":["127.0.0.1"],"max_attempts":5}'
+        body: '{"enabled":false,"shields":["block","user_notification"],"mode":"count_per_identifier_and_ip","allowlist":[],"max_attempts":10}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 517.649875ms
+        duration: 313.475916ms
     - id: 205
       request:
         proto: HTTP/1.1
@@ -6790,7 +6790,7 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - Go-Auth0/1.33.0
+                - Go-Auth0/1.45.0
         url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
         method: PATCH
       response:
@@ -6801,10 +6801,10 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["127.0.0.1"],"stage":{"pre-login":{"max_attempts":5,"rate":34560},"pre-user-registration":{"max_attempts":5,"rate":34561},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
+        body: '{"enabled":false,"shields":["admin_notification","block"],"allowlist":[],"stage":{"pre-login":{"max_attempts":100,"rate":864000},"pre-user-registration":{"max_attempts":50,"rate":1200},"pre-custom-token-exchange":{"max_attempts":10,"rate":600000}}}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 511.387667ms
+        duration: 302.721042ms

--- a/test/data/recordings/TestAccAttackProtectionCaptchaInsufficientEntitlement.yaml
+++ b/test/data/recordings/TestAccAttackProtectionCaptchaInsufficientEntitlement.yaml
@@ -1,0 +1,510 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 117
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":true,"shields":["block"],"allowlist":["127.0.0.1"],"mode":"count_per_identifier_and_ip","max_attempts":5}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":true,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 331.623291ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 110
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"active_provider_id":"recaptcha_v2","recaptcha_v2":{"site_key":"test-site-key-v2","secret":"test-secret-v2"}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/captcha
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 300.907667ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 299.800833ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":true,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 293.243125ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 346.935583ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/bot-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 800.450792ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/captcha
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 314.290625ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 307.061208ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":true,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 292.139542ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 295.149417ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/bot-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 282.665959ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/captcha
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 292.463208ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 18
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":false}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 309.215667ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 18
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":false}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 281.786917ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 18
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":false}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 312.43325ms

--- a/test/data/recordings/TestAccAttackProtectionMultipleInsufficientEntitlements.yaml
+++ b/test/data/recordings/TestAccAttackProtectionMultipleInsufficientEntitlements.yaml
@@ -1,0 +1,543 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 196
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":true,"shields":["admin_notification","block"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":true,"shields":["admin_notification","block"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 319.979084ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 86
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"bot_detection_level":"low","allowlist":["127.0.0.1"],"monitoring_mode_enabled":true}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/bot-detection
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 268.940333ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 110
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"active_provider_id":"recaptcha_v2","recaptcha_v2":{"site_key":"test-site-key-v2","secret":"test-secret-v2"}}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/captcha
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 281.637125ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 308.363542ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 285.267708ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":true,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 301.245167ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/bot-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 289.17175ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/captcha
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 294.466041ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 302.14275ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 324.587625ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":true,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 355.605875ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/bot-detection
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 282.333708ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/captcha
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"statusCode":403,"error":"Forbidden","message":"Please upgrade your subscription to use bot detection","errorCode":"insufficient_entitlement"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 403 Forbidden
+        code: 403
+        duration: 282.304459ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 18
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":false}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/breached-password-detection
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":[],"admin_notification_frequency":[],"method":"standard","stage":{"pre-user-registration":{"shields":[]},"pre-change-password":{"shields":[]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 297.660375ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 18
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":false}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/brute-force-protection
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block"],"mode":"count_per_identifier_and_ip","allowlist":["127.0.0.1"],"max_attempts":5}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 316.092667ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 18
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"enabled":false}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.45.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/attack-protection/suspicious-ip-throttling
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"enabled":false,"shields":["block","admin_notification"],"allowlist":["192.168.1.1"],"stage":{"pre-login":{"max_attempts":5,"rate":864000},"pre-user-registration":{"max_attempts":5,"rate":1200}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 277.38325ms


### PR DESCRIPTION

# Surface Bot Detection/Captcha entitlement errors as warnings

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

`auth0_attack_protection` gates two sub-features behind tenant entitlements — `bot_detection` and `captcha`, both served by the v2 Management API. On a tenant without the add-on, both `GET` and `PATCH` return `403` with `errorCode: "insufficient_entitlement"`. Previously the resource treated *any* v2 `403` whose message contained `insufficient_scope` as a silent skip (the temporary workaround from #1410) and let everything else fail the apply. That meant an unentitled tenant either got a hard apply failure, or — where the string happened to match — a skip with nothing but an `[INFO]` log line the user never sees.

This PR distinguishes the two `403` cases and makes the entitlement case visible without making it fatal.

**Added — `internal/error/api_error_v2.go`**

Typed error helpers for the v2 SDK, replacing `strings.Contains` on the error message:

- `v2ErrorCode(err) string` (unexported) — unwraps via `errors.As` to `*managementv2.ForbiddenError` and reads `errorCode` out of the response `Body`; returns `""` for any non-`ForbiddenError`, non-map body, missing key, or non-string value.
- `IsInsufficientScope(err) bool` — token lacks the required scope.
- `IsInsufficientEntitlement(err) bool` — tenant lacks the required add-on entitlement.

**Changed — `internal/auth0/attackprotection/resource.go`**

`readAttackProtection` and `updateAttackProtection` now accumulate a `diag.Diagnostics` and branch on error code for each of the two gated calls:

- `IsInsufficientScope` → skip, `[INFO]` log (unchanged behavior, now matched on the error code rather than the message text).
- `IsInsufficientEntitlement` → append a `diag.Warning` naming the sub-feature and stating that the configuration was not applied and that Auth0 support can enable the feature.
- anything else → fatal, as before (`diag.FromErr` on read, `multierror.Append` on update).

Two consequences worth noting for reviewers:

- **No short-circuiting.** A gated sub-feature returning `403` no longer stops the remaining sub-features from being read or updated, and two gated failures in the same apply both produce warnings rather than the first one masking the second.
- **Warnings propagate through update → read.** `updateAttackProtection` now merges the diagnostics returned by its trailing `readAttackProtection` call instead of returning them directly, so warnings raised during update survive the read.

`strings` is no longer imported by the resource.

No schema, public API, or user-facing configuration changes — this is error-surfacing behavior only.

### 📚 References

- Supersedes the temporary `insufficient_scope` string-matching workaround introduced in [#1410](https://github.com/auth0/terraform-provider-auth0/pull/1410)

### 🔬 Testing

**Unit — `internal/error/api_error_v2_test.go` (new, 279 lines)**

Table of cases for `v2ErrorCode`, `IsInsufficientScope`, and `IsInsufficientEntitlement`, covering the happy path plus every way extraction can fail: non-`ForbiddenError`, `Body` that isn't a map, missing `errorCode`, and non-string `errorCode`. Also covers `errors.As` unwrapping through a wrapped error, and cross-checks that each predicate returns `false` for the other's error code.

**Acceptance — `internal/auth0/attackprotection/resource_test.go` (3 new tests, HTTP recordings included)**

Recorded against a non-entitled tenant, replayed from cassettes:

- `TestAccAttackProtectionBotDetectionInsufficientEntitlement` — `bot_detection` + `brute_force_protection`; asserts the apply succeeds, `bot_detection.#` is `0` (the 403 leaves it unpersisted), and `brute_force_protection` is still fully applied.
- `TestAccAttackProtectionCaptchaInsufficientEntitlement` — the same for `captcha`.
- `TestAccAttackProtectionMultipleInsufficientEntitlements` — both gated blocks 403 in one apply; asserts neither short-circuits the other and the ungated `suspicious_ip_throttling` block still applies.

All three set `ExpectNonEmptyPlan: true`: a gated block cannot be persisted to state, so the config/state difference legitimately remains after apply.

Existing recordings for `TestAccAttackProtectionBotDetection` and `TestAccAttackProtectionCaptcha` were re-recorded against an entitled tenant to keep the happy paths green.

Run with:

```bash
make test-unit
AUTH0_HTTP_RECORDINGS=on AUTH0_DOMAIN=terraform-provider-auth0-dev.eu.auth0.com make test-acc FILTER="TestAccAttackProtection"
```

Not covered by automated tests: the exact warning text as rendered by the Terraform CLI, since the acceptance test framework asserts on state rather than on diagnostic output. Verified manually against an unentitled tenant — `terraform apply` completes with `Warning: Bot Detection entitlement not available` / `Warning: Captcha entitlement not available` and a non-zero-diff plan.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A) — CHANGELOG entry added; no schema changes, so no `docs/` regeneration needed

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
