### PR TITLE
fix: add name to modify creds apply diff check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ BUG FIXES:
 - `resource/auth0_connection` – Fix updates failing with `cannot patch unique property on email attribute` on `auth0` connections whose `options.attributes.email.unique` is `false`. The Management API reads a missing `unique` as `true`, so any change to an unrelated option was rejected ([#1669](https://github.com/auth0/terraform-provider-auth0/pull/1669))
 
 
+BUG FIXES:
+- `resource/auth0_client_credentials` – Include `name` when matching added/removed `private_key_jwt` credentials during diff classification, so credentials that differ only by name are no longer incorrectly treated as the same credential
+
 ## v1.54.0
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ BUG FIXES:
 
 BUG FIXES:
 - `resource/auth0_client_credentials` – Include `name` when matching added/removed `private_key_jwt` credentials during diff classification, so credentials that differ only by name are no longer incorrectly treated as the same credential
+- `resource/auth0_client_credentials` – Detach a renamed credential before creating its replacement when the two share the same public key, even with slot/pool headroom, so the apply no longer fails with `credentials contains public keys that already exist in client`
 
 ## v1.54.0
 

--- a/internal/auth0/client/resource_credentials.go
+++ b/internal/auth0/client/resource_credentials.go
@@ -335,10 +335,35 @@ const maxSlotCredentials = 2
 // the pool can hold, so headroom in a slot does not imply headroom in the pool.
 const maxPoolCredentials = 4
 
+// credentialKeysMatch reports whether the removed and added credential entries
+// carry the same public key: either their pem strings are byte-identical, or
+// the removed entry has no pem in state (e.g. it was adopted from a
+// CLI-created credential) and the added entry's key thumbprint matches the
+// removed entry's key_id.
+func credentialKeysMatch(removeMap, addMap map[string]interface{}) bool {
+	addPEM, _ := addMap["pem"].(string)
+	if addPEM == "" {
+		return false
+	}
+
+	rmPEM, _ := removeMap["pem"].(string)
+	if rmPEM == addPEM {
+		return true
+	}
+
+	rmKeyID, _ := removeMap["key_id"].(string)
+	if rmPEM == "" && rmKeyID != "" {
+		return jwkThumbprint(addPEM) == rmKeyID
+	}
+	return false
+}
+
 // planCredentialRotation orders a credential change into steps, pairing each
 // removal with an addition. While both the slot and the pool have headroom it
 // adds first, so a usable credential stays attached throughout the swap. Once
-// either container is full it removes first, so neither count overshoots.
+// either container is full, or the paired removal and addition share the same
+// public key, it removes first, so neither count overshoots and the create is
+// never rejected as a duplicate key.
 func planCredentialRotation(diff credentialDiff, attachedCount, poolCount int) []rotationStep {
 	rotationSteps := make([]rotationStep, 0, len(diff.toRemove)+len(diff.toAdd))
 
@@ -358,8 +383,13 @@ func planCredentialRotation(diff credentialDiff, attachedCount, poolCount int) [
 		removal, hasID := newRemoval(diff.toRemove[i])
 		addition := newAddition(diff.toAdd[i])
 
-		if attachedCount < maxSlotCredentials && poolCount < maxPoolCredentials {
-			// Room in both containers, so the slot is never left empty.
+		removeMap, _ := diff.toRemove[i].(map[string]interface{})
+		addMap, _ := diff.toAdd[i].(map[string]interface{})
+		colliding := hasID && credentialKeysMatch(removeMap, addMap)
+
+		if attachedCount < maxSlotCredentials && poolCount < maxPoolCredentials && !colliding {
+			// Room in both containers, and no key collision, so the slot is
+			// never left empty.
 			rotationSteps = append(rotationSteps, addition)
 			attachedCount++
 			poolCount++
@@ -369,11 +399,9 @@ func planCredentialRotation(diff credentialDiff, attachedCount, poolCount int) [
 				poolCount--
 			}
 		} else {
-			// One container is full. Removing frees an entry in both, so the
-			// addition that follows fits.
-			// At capacity, or the pair's public key collides: remove first so
-			// the create is never rejected as a duplicate, and the count never
-			// overshoots the cap.
+			// One container is full, or the pair's public key collides: remove
+			// first so the create is never rejected as a duplicate, and the
+			// count never overshoots the cap.
 			if hasID {
 				rotationSteps = append(rotationSteps, removal)
 				attachedCount--
@@ -427,7 +455,6 @@ func classifyCredentialChanges(toAdd, toRemove []interface{}) credentialDiff {
 	usedRemoveIndexes := make(map[int]bool)
 	for _, addedCred := range toAdd {
 		addMap := addedCred.(map[string]interface{})
-		addPEM, _ := addMap["pem"].(string)
 		addAlgo, _ := addMap["algorithm"].(string)
 		addExpiry, _ := addMap["expires_at"].(string)
 
@@ -440,20 +467,12 @@ func classifyCredentialChanges(toAdd, toRemove []interface{}) credentialDiff {
 			rmPEM, _ := rmMap["pem"].(string)
 			rmAlgo, _ := rmMap["algorithm"].(string)
 			rmID, _ := rmMap["id"].(string)
-			rmKeyID, _ := rmMap["key_id"].(string)
 
 			if rmID == "" {
 				continue
 			}
 
-			var pemMatch bool
-			if rmPEM == addPEM {
-				pemMatch = true
-			} else if rmPEM == "" && rmKeyID != "" && addPEM != "" {
-				pemMatch = jwkThumbprint(addPEM) == rmKeyID
-			}
-
-			if pemMatch && rmAlgo == addAlgo && addMap["name"] == rmMap["name"] {
+			if credentialKeysMatch(rmMap, addMap) && rmAlgo == addAlgo && addMap["name"] == rmMap["name"] {
 				rmParseExpiry, _ := rmMap["parse_expiry_from_cert"].(bool)
 				if rmParseExpiry && rmPEM != "" {
 					continue

--- a/internal/auth0/client/resource_credentials.go
+++ b/internal/auth0/client/resource_credentials.go
@@ -342,9 +342,6 @@ const maxPoolCredentials = 4
 // removed entry's key_id.
 func credentialKeysMatch(removeMap, addMap map[string]interface{}) bool {
 	addPEM, _ := addMap["pem"].(string)
-	if addPEM == "" {
-		return false
-	}
 
 	rmPEM, _ := removeMap["pem"].(string)
 	if rmPEM == addPEM {
@@ -352,7 +349,7 @@ func credentialKeysMatch(removeMap, addMap map[string]interface{}) bool {
 	}
 
 	rmKeyID, _ := removeMap["key_id"].(string)
-	if rmPEM == "" && rmKeyID != "" {
+	if rmPEM == "" && rmKeyID != "" && addPEM != "" {
 		return jwkThumbprint(addPEM) == rmKeyID
 	}
 	return false

--- a/internal/auth0/client/resource_credentials.go
+++ b/internal/auth0/client/resource_credentials.go
@@ -371,6 +371,9 @@ func planCredentialRotation(diff credentialDiff, attachedCount, poolCount int) [
 		} else {
 			// One container is full. Removing frees an entry in both, so the
 			// addition that follows fits.
+			// At capacity, or the pair's public key collides: remove first so
+			// the create is never rejected as a duplicate, and the count never
+			// overshoots the cap.
 			if hasID {
 				rotationSteps = append(rotationSteps, removal)
 				attachedCount--

--- a/internal/auth0/client/resource_credentials.go
+++ b/internal/auth0/client/resource_credentials.go
@@ -450,7 +450,7 @@ func classifyCredentialChanges(toAdd, toRemove []interface{}) credentialDiff {
 				pemMatch = jwkThumbprint(addPEM) == rmKeyID
 			}
 
-			if pemMatch && rmAlgo == addAlgo {
+			if pemMatch && rmAlgo == addAlgo && addMap["name"] == rmMap["name"] {
 				rmParseExpiry, _ := rmMap["parse_expiry_from_cert"].(bool)
 				if rmParseExpiry && rmPEM != "" {
 					continue

--- a/internal/auth0/client/resource_credentials_internal_test.go
+++ b/internal/auth0/client/resource_credentials_internal_test.go
@@ -115,10 +115,10 @@ func highestAttachedCount(rotationSteps []rotationStep, startingCount int) int {
 }
 
 func TestPlanCredentialRotation(t *testing.T) {
-	// removedCred/addedCred and the removals/additions builders below give every
-	// entry an explicit pem (and key_id, for a removal), so a case controls
-	// exactly whether credentialKeysMatch sees a collision instead of leaving it
-	// to fall out of both sides omitting pem.
+	// The removedCred/addedCred types and the removals/additions builders below
+	// give every entry an explicit pem (and key_id, for a removal), so a case
+	// controls exactly whether credentialKeysMatch sees a collision instead of
+	// leaving it to fall out of both sides omitting pem.
 	type removedCred struct {
 		id, pem, keyID string
 	}
@@ -169,16 +169,16 @@ func TestPlanCredentialRotation(t *testing.T) {
 			name: "full pool removes first even when the slot has room",
 			// The remaining pool records belong to other features. Creating first
 			// fails with "A client can have a maximum of 4 credentials".
-			toRemove: removals(removedCred{id: "old-1", pem: "pem-old-1"}),
-			toAdd:    additions(addedCred{name: "new-1", pem: "pem-new-1"}),
+			toRemove:      removals(removedCred{id: "old-1", pem: "pem-old-1"}),
+			toAdd:         additions(addedCred{name: "new-1", pem: "pem-new-1"}),
 			attachedCount: 1, poolCount: maxPoolCredentials,
 			expectedSteps:  "-old-1 +new-1",
 			expectedReason: "both counts are consulted, not just the slot",
 		},
 		{
-			name:     "room in both containers and different keys adds first",
-			toRemove: removals(removedCred{id: "old-1", pem: "pem-old-1"}),
-			toAdd:    additions(addedCred{name: "new-1", pem: "pem-new-1"}),
+			name:          "room in both containers and different keys adds first",
+			toRemove:      removals(removedCred{id: "old-1", pem: "pem-old-1"}),
+			toAdd:         additions(addedCred{name: "new-1", pem: "pem-new-1"}),
 			attachedCount: 1, poolCount: maxPoolCredentials - 1,
 			expectedSteps:  "+new-1 -old-1",
 			expectedReason: "a usable credential stays attached throughout the swap",
@@ -188,8 +188,8 @@ func TestPlanCredentialRotation(t *testing.T) {
 			// Same headroom as the case above, but the pair shares a key. The
 			// collision must override the headroom-driven add-first ordering, or
 			// the create is rejected as a duplicate key.
-			toRemove: removals(removedCred{id: "old-1", pem: "shared-pem"}),
-			toAdd:    additions(addedCred{name: "new-1", pem: "shared-pem"}),
+			toRemove:      removals(removedCred{id: "old-1", pem: "shared-pem"}),
+			toAdd:         additions(addedCred{name: "new-1", pem: "shared-pem"}),
 			attachedCount: 1, poolCount: maxPoolCredentials - 1,
 			expectedSteps:  "-old-1 +new-1",
 			expectedReason: "a same-key pair removes first even with headroom",
@@ -229,7 +229,7 @@ func TestPlanCredentialRotation(t *testing.T) {
 				removedCred{id: "old-1", pem: "pem-old-1"},
 				removedCred{id: "old-2", pem: "pem-old-2"},
 			),
-			toAdd: additions(addedCred{name: "new-1", pem: "pem-new-1"}),
+			toAdd:         additions(addedCred{name: "new-1", pem: "pem-new-1"}),
 			attachedCount: maxSlotCredentials, poolCount: 2,
 			expectedSteps: "-old-1 +new-1 -old-2",
 		},

--- a/internal/auth0/client/resource_credentials_internal_test.go
+++ b/internal/auth0/client/resource_credentials_internal_test.go
@@ -249,6 +249,98 @@ func credentialsDataWithState(t *testing.T, attributes map[string]interface{}) *
 	return data
 }
 
+func TestPlanCredentialRotation_HeadroomButSameKeyRemovesFirst(t *testing.T) {
+	// A 1-for-1 rename (or algorithm change) on a client holding a single
+	// credential, where the new entry carries the SAME public key as the one
+	// being replaced. Despite headroom below the cap, the removal must go
+	// first: the API rejects creating a credential whose key already exists
+	// on the client, so add-first would 400.
+	diff := credentialDiff{
+		toRemove: []interface{}{
+			map[string]interface{}{"id": "old-1", "pem": "same-pem", "key_id": "kid-1"},
+		},
+		toAdd: []interface{}{
+			map[string]interface{}{"name": "new-1", "pem": "same-pem"},
+		},
+	}
+
+	const startingAttachedCount = 1
+	rotationSteps := planCredentialRotation(diff, startingAttachedCount)
+
+	require.Len(t, rotationSteps, 2)
+	assert.Equal(t, detachAndDelete, rotationSteps[0].kind)
+	assert.Equal(t, "old-1", rotationSteps[0].credentialID)
+	assert.Equal(t, createAndAttach, rotationSteps[1].kind)
+	assert.Equal(t, "new-1", rotationSteps[1].newCredential["name"])
+}
+
+func TestPlanCredentialRotation_HeadroomButSameKeyViaThumbprintRemovesFirst(t *testing.T) {
+	// Same as above, but the removed credential has no PEM in state (e.g. it
+	// was adopted from a CLI-created credential) and the match is made via
+	// JWK thumbprint against key_id instead of a literal PEM comparison.
+	spkiPEM, _, _ := generateTestRSAPEMs(t)
+	kid := jwkThumbprint(spkiPEM)
+	require.NotEmpty(t, kid)
+
+	diff := credentialDiff{
+		toRemove: []interface{}{
+			map[string]interface{}{"id": "old-1", "pem": "", "key_id": kid},
+		},
+		toAdd: []interface{}{
+			map[string]interface{}{"name": "new-1", "pem": spkiPEM},
+		},
+	}
+
+	rotationSteps := planCredentialRotation(diff, 1)
+
+	require.Len(t, rotationSteps, 2)
+	assert.Equal(t, detachAndDelete, rotationSteps[0].kind)
+	assert.Equal(t, createAndAttach, rotationSteps[1].kind)
+}
+
+func TestPlanCredentialRotation_HeadroomDifferentKeyAddsFirst(t *testing.T) {
+	// Sanity check that the collision guard doesn't over-trigger: a genuine
+	// key rotation (different PEM, no key_id match) on a single-credential
+	// client should still add-first as before.
+	diff := credentialDiff{
+		toRemove: []interface{}{
+			map[string]interface{}{"id": "old-1", "pem": "old-pem", "key_id": "kid-old"},
+		},
+		toAdd: []interface{}{
+			map[string]interface{}{"name": "new-1", "pem": "new-pem"},
+		},
+	}
+
+	rotationSteps := planCredentialRotation(diff, 1)
+
+	require.Len(t, rotationSteps, 2)
+	assert.Equal(t, createAndAttach, rotationSteps[0].kind)
+	assert.Equal(t, detachAndDelete, rotationSteps[1].kind)
+}
+
+func TestPlanCredentialRotation_HandlesUnevenAndPureChanges(t *testing.T) {
+	pureAdditionSteps := planCredentialRotation(credentialDiff{
+		toAdd: []interface{}{map[string]interface{}{"name": "new-1"}},
+	}, 0)
+	require.Len(t, pureAdditionSteps, 1)
+	assert.Equal(t, createAndAttach, pureAdditionSteps[0].kind)
+
+	pureRemovalSteps := planCredentialRotation(credentialDiff{
+		toRemove: []interface{}{map[string]interface{}{"id": "old-1"}},
+	}, 1)
+	require.Len(t, pureRemovalSteps, 1)
+	assert.Equal(t, detachAndDelete, pureRemovalSteps[0].kind)
+
+	// More removals than additions, starting at capacity: one interleaved pair
+	// (remove-first), then a trailing removal.
+	moreRemovalsThanAdditionsSteps := planCredentialRotation(credentialDiff{
+		toRemove: []interface{}{
+			map[string]interface{}{"id": "old-1"},
+			map[string]interface{}{"id": "old-2"},
+		},
+	})
+}
+
 func TestStateCredentialIDs_ReadsOnlyTheRequestedSlot(t *testing.T) {
 	data := credentialsDataWithState(t, map[string]interface{}{
 		"private_key_jwt": []interface{}{

--- a/internal/auth0/client/resource_credentials_internal_test.go
+++ b/internal/auth0/client/resource_credentials_internal_test.go
@@ -115,17 +115,28 @@ func highestAttachedCount(rotationSteps []rotationStep, startingCount int) int {
 }
 
 func TestPlanCredentialRotation(t *testing.T) {
-	removals := func(ids ...string) []interface{} {
-		entries := make([]interface{}, 0, len(ids))
-		for _, id := range ids {
-			entries = append(entries, map[string]interface{}{"id": id})
+	// removedCred/addedCred and the removals/additions builders below give every
+	// entry an explicit pem (and key_id, for a removal), so a case controls
+	// exactly whether credentialKeysMatch sees a collision instead of leaving it
+	// to fall out of both sides omitting pem.
+	type removedCred struct {
+		id, pem, keyID string
+	}
+	type addedCred struct {
+		name, pem string
+	}
+
+	removals := func(creds ...removedCred) []interface{} {
+		entries := make([]interface{}, 0, len(creds))
+		for _, c := range creds {
+			entries = append(entries, map[string]interface{}{"id": c.id, "pem": c.pem, "key_id": c.keyID})
 		}
 		return entries
 	}
-	additions := func(names ...string) []interface{} {
-		entries := make([]interface{}, 0, len(names))
-		for _, name := range names {
-			entries = append(entries, map[string]interface{}{"name": name})
+	additions := func(creds ...addedCred) []interface{} {
+		entries := make([]interface{}, 0, len(creds))
+		for _, c := range creds {
+			entries = append(entries, map[string]interface{}{"name": c.name, "pem": c.pem})
 		}
 		return entries
 	}
@@ -141,8 +152,16 @@ func TestPlanCredentialRotation(t *testing.T) {
 	}{
 		{
 			name: "swap of two at the slot cap removes before each add",
-			// Adding first here would ask the slot to hold 3.
-			toRemove: removals("old-1", "old-2"), toAdd: additions("new-1", "new-2"),
+			// Adding first here would ask the slot to hold 3. Neither pair shares a
+			// key, so this is the cap forcing remove-first, not a collision.
+			toRemove: removals(
+				removedCred{id: "old-1", pem: "pem-old-1"},
+				removedCred{id: "old-2", pem: "pem-old-2"},
+			),
+			toAdd: additions(
+				addedCred{name: "new-1", pem: "pem-new-1"},
+				addedCred{name: "new-2", pem: "pem-new-2"},
+			),
 			attachedCount: maxSlotCredentials, poolCount: 2,
 			expectedSteps: "-old-1 +new-1 -old-2 +new-2",
 		},
@@ -150,44 +169,83 @@ func TestPlanCredentialRotation(t *testing.T) {
 			name: "full pool removes first even when the slot has room",
 			// The remaining pool records belong to other features. Creating first
 			// fails with "A client can have a maximum of 4 credentials".
-			toRemove: removals("old-1"), toAdd: additions("new-1"),
+			toRemove: removals(removedCred{id: "old-1", pem: "pem-old-1"}),
+			toAdd:    additions(addedCred{name: "new-1", pem: "pem-new-1"}),
 			attachedCount: 1, poolCount: maxPoolCredentials,
 			expectedSteps:  "-old-1 +new-1",
 			expectedReason: "both counts are consulted, not just the slot",
 		},
 		{
-			name:     "room in both containers adds first",
-			toRemove: removals("old-1"), toAdd: additions("new-1"),
+			name:     "room in both containers and different keys adds first",
+			toRemove: removals(removedCred{id: "old-1", pem: "pem-old-1"}),
+			toAdd:    additions(addedCred{name: "new-1", pem: "pem-new-1"}),
 			attachedCount: 1, poolCount: maxPoolCredentials - 1,
 			expectedSteps:  "+new-1 -old-1",
 			expectedReason: "a usable credential stays attached throughout the swap",
 		},
 		{
+			name: "room in both containers but the same pem removes first",
+			// Same headroom as the case above, but the pair shares a key. The
+			// collision must override the headroom-driven add-first ordering, or
+			// the create is rejected as a duplicate key.
+			toRemove: removals(removedCred{id: "old-1", pem: "shared-pem"}),
+			toAdd:    additions(addedCred{name: "new-1", pem: "shared-pem"}),
+			attachedCount: 1, poolCount: maxPoolCredentials - 1,
+			expectedSteps:  "-old-1 +new-1",
+			expectedReason: "a same-key pair removes first even with headroom",
+		},
+		{
+			name: "mixed pairs: the matching pair removes first, the mismatched pair still adds first",
+			// Two independent pairs with headroom throughout: the first pair
+			// shares a key and must remove first despite the headroom, the second
+			// pair doesn't and adds first as usual. Each pair's ordering is
+			// decided on its own, not by whatever the previous pair did.
+			toRemove: removals(
+				removedCred{id: "old-1", pem: "shared-pem"},
+				removedCred{id: "old-2", pem: "pem-old-2"},
+			),
+			toAdd: additions(
+				addedCred{name: "new-1", pem: "shared-pem"},
+				addedCred{name: "new-2", pem: "pem-new-2"},
+			),
+			attachedCount: 1, poolCount: 1,
+			expectedSteps:  "-old-1 +new-1 +new-2 -old-2",
+			expectedReason: "collision is decided per pair, independent of neighboring pairs",
+		},
+		{
 			name:          "pure addition",
-			toAdd:         additions("new-1"),
+			toAdd:         additions(addedCred{name: "new-1", pem: "pem-new-1"}),
 			expectedSteps: "+new-1",
 		},
 		{
 			name:          "pure removal",
-			toRemove:      removals("old-1"),
+			toRemove:      removals(removedCred{id: "old-1", pem: "pem-old-1"}),
 			attachedCount: 1, poolCount: 1,
 			expectedSteps: "-old-1",
 		},
 		{
-			name:     "more removals than additions pairs one, then trails the rest",
-			toRemove: removals("old-1", "old-2"), toAdd: additions("new-1"),
+			name: "more removals than additions pairs one, then trails the rest",
+			toRemove: removals(
+				removedCred{id: "old-1", pem: "pem-old-1"},
+				removedCred{id: "old-2", pem: "pem-old-2"},
+			),
+			toAdd: additions(addedCred{name: "new-1", pem: "pem-new-1"}),
 			attachedCount: maxSlotCredentials, poolCount: 2,
 			expectedSteps: "-old-1 +new-1 -old-2",
 		},
 		{
 			name:     "more additions than removals pairs one, then trails the rest",
-			toRemove: removals("old-1"), toAdd: additions("new-1", "new-2"),
+			toRemove: removals(removedCred{id: "old-1", pem: "pem-old-1"}),
+			toAdd: additions(
+				addedCred{name: "new-1", pem: "pem-new-1"},
+				addedCred{name: "new-2", pem: "pem-new-2"},
+			),
 			attachedCount: 1, poolCount: 1,
 			expectedSteps: "+new-1 -old-1 +new-2",
 		},
 		{
 			name:          "a removal without an ID is skipped",
-			toRemove:      removals(""),
+			toRemove:      removals(removedCred{id: "", pem: "pem-old-1"}),
 			attachedCount: 1, poolCount: 1,
 			expectedSteps: "",
 		},

--- a/internal/auth0/client/resource_credentials_internal_test.go
+++ b/internal/auth0/client/resource_credentials_internal_test.go
@@ -265,7 +265,8 @@ func TestPlanCredentialRotation_HeadroomButSameKeyRemovesFirst(t *testing.T) {
 	}
 
 	const startingAttachedCount = 1
-	rotationSteps := planCredentialRotation(diff, startingAttachedCount)
+	const startingPoolCount = 1
+	rotationSteps := planCredentialRotation(diff, startingAttachedCount, startingPoolCount)
 
 	require.Len(t, rotationSteps, 2)
 	assert.Equal(t, detachAndDelete, rotationSteps[0].kind)
@@ -291,7 +292,7 @@ func TestPlanCredentialRotation_HeadroomButSameKeyViaThumbprintRemovesFirst(t *t
 		},
 	}
 
-	rotationSteps := planCredentialRotation(diff, 1)
+	rotationSteps := planCredentialRotation(diff, 1, 1)
 
 	require.Len(t, rotationSteps, 2)
 	assert.Equal(t, detachAndDelete, rotationSteps[0].kind)
@@ -311,7 +312,7 @@ func TestPlanCredentialRotation_HeadroomDifferentKeyAddsFirst(t *testing.T) {
 		},
 	}
 
-	rotationSteps := planCredentialRotation(diff, 1)
+	rotationSteps := planCredentialRotation(diff, 1, 1)
 
 	require.Len(t, rotationSteps, 2)
 	assert.Equal(t, createAndAttach, rotationSteps[0].kind)
@@ -321,13 +322,13 @@ func TestPlanCredentialRotation_HeadroomDifferentKeyAddsFirst(t *testing.T) {
 func TestPlanCredentialRotation_HandlesUnevenAndPureChanges(t *testing.T) {
 	pureAdditionSteps := planCredentialRotation(credentialDiff{
 		toAdd: []interface{}{map[string]interface{}{"name": "new-1"}},
-	}, 0)
+	}, 0, 0)
 	require.Len(t, pureAdditionSteps, 1)
 	assert.Equal(t, createAndAttach, pureAdditionSteps[0].kind)
 
 	pureRemovalSteps := planCredentialRotation(credentialDiff{
 		toRemove: []interface{}{map[string]interface{}{"id": "old-1"}},
-	}, 1)
+	}, 1, 1)
 	require.Len(t, pureRemovalSteps, 1)
 	assert.Equal(t, detachAndDelete, pureRemovalSteps[0].kind)
 
@@ -338,7 +339,17 @@ func TestPlanCredentialRotation_HandlesUnevenAndPureChanges(t *testing.T) {
 			map[string]interface{}{"id": "old-1"},
 			map[string]interface{}{"id": "old-2"},
 		},
-	})
+		toAdd: []interface{}{
+			map[string]interface{}{"name": "new-1"},
+		},
+	}, maxSlotCredentials, 2)
+	require.Len(t, moreRemovalsThanAdditionsSteps, 3)
+	assert.Equal(t, detachAndDelete, moreRemovalsThanAdditionsSteps[0].kind)
+	assert.Equal(t, "old-1", moreRemovalsThanAdditionsSteps[0].credentialID)
+	assert.Equal(t, createAndAttach, moreRemovalsThanAdditionsSteps[1].kind)
+	assert.Equal(t, "new-1", moreRemovalsThanAdditionsSteps[1].newCredential["name"])
+	assert.Equal(t, detachAndDelete, moreRemovalsThanAdditionsSteps[2].kind)
+	assert.Equal(t, "old-2", moreRemovalsThanAdditionsSteps[2].credentialID)
 }
 
 func TestStateCredentialIDs_ReadsOnlyTheRequestedSlot(t *testing.T) {

--- a/internal/auth0/client/resource_credentials_internal_test.go
+++ b/internal/auth0/client/resource_credentials_internal_test.go
@@ -564,6 +564,101 @@ func TestCredentialChanges_IgnoresUnchangedSetOnUnrelatedApply(t *testing.T) {
 		"an unchanged credential set must not create a duplicate credential")
 }
 
+// The ESD-65375 bug itself: a rename (name changes, key material does not) must
+// surface as a real add/remove pair for planCredentialRotation to act on, not
+// be paired away by classifyCredentialChanges and silently dropped.
+func TestCredentialChanges_RenameWithLiteralPEMMatchSurfacesAddRemovePair(t *testing.T) {
+	_, _, certPEM := generateTestRSAPEMs(t)
+
+	data := diffData(t,
+		map[string]interface{}{
+			"client_id":             "test-client-id",
+			"authentication_method": "private_key_jwt",
+			"private_key_jwt": pkjwtBlock(map[string]interface{}{
+				"id": "cred-pkjwt", "name": "A", "credential_type": "public_key",
+				"pem": certPEM, "algorithm": "RS256",
+			}),
+		},
+		map[string]interface{}{
+			"client_id":             "test-client-id",
+			"authentication_method": "private_key_jwt",
+			"private_key_jwt": pkjwtBlock(map[string]interface{}{
+				"name": "B", "credential_type": "public_key", "pem": certPEM, "algorithm": "RS256",
+			}),
+		},
+	)
+
+	diff := credentialChanges(data, "private_key_jwt.0.credentials")
+
+	require.Len(t, diff.toAdd, 1, "the renamed entry must surface as a real addition")
+	require.Len(t, diff.toRemove, 1, "the stale entry must surface as a real removal")
+	assert.Equal(t, "cred-pkjwt", diff.toRemove[0].(map[string]interface{})["id"])
+	assert.Equal(t, "B", diff.toAdd[0].(map[string]interface{})["name"])
+}
+
+// Same bug, but via the thumbprint path: the removed entry's pem is blank in
+// state (e.g. adopted from a CLI-created credential), so the match against the
+// renamed addition can only be made through key_id/jwkThumbprint.
+func TestCredentialChanges_RenameWithThumbprintMatchOnEmptyPEMSurfacesAddRemovePair(t *testing.T) {
+	spkiPEM, _, _ := generateTestRSAPEMs(t)
+	kid := jwkThumbprint(spkiPEM)
+	require.NotEmpty(t, kid)
+
+	data := diffData(t,
+		map[string]interface{}{
+			"client_id":             "test-client-id",
+			"authentication_method": "private_key_jwt",
+			"private_key_jwt": pkjwtBlock(map[string]interface{}{
+				"id": "cred-pkjwt", "name": "A", "credential_type": "public_key",
+				"pem": "", "key_id": kid, "algorithm": "RS256",
+			}),
+		},
+		map[string]interface{}{
+			"client_id":             "test-client-id",
+			"authentication_method": "private_key_jwt",
+			"private_key_jwt": pkjwtBlock(map[string]interface{}{
+				"name": "B", "credential_type": "public_key", "pem": spkiPEM, "algorithm": "RS256",
+			}),
+		},
+	)
+
+	diff := credentialChanges(data, "private_key_jwt.0.credentials")
+
+	require.Len(t, diff.toAdd, 1, "the renamed entry must surface as a real addition")
+	require.Len(t, diff.toRemove, 1, "the stale entry must surface as a real removal")
+	assert.Equal(t, "cred-pkjwt", diff.toRemove[0].(map[string]interface{})["id"])
+	assert.Equal(t, "B", diff.toAdd[0].(map[string]interface{})["name"])
+}
+
+// No-regression case: identical name and PEM must still cancel out to an empty
+// diff, matching the existing cancel-and-do-nothing behaviour.
+func TestCredentialChanges_SameNameAndPEMProducesEmptyDiff(t *testing.T) {
+	_, _, certPEM := generateTestRSAPEMs(t)
+
+	data := diffData(t,
+		map[string]interface{}{
+			"client_id":             "test-client-id",
+			"authentication_method": "private_key_jwt",
+			"private_key_jwt": pkjwtBlock(map[string]interface{}{
+				"id": "cred-pkjwt", "name": "A", "credential_type": "public_key",
+				"pem": certPEM, "algorithm": "RS256",
+			}),
+		},
+		map[string]interface{}{
+			"client_id":             "test-client-id",
+			"authentication_method": "private_key_jwt",
+			"private_key_jwt": pkjwtBlock(map[string]interface{}{
+				"name": "A", "credential_type": "public_key", "pem": certPEM, "algorithm": "RS256",
+			}),
+		},
+	)
+
+	diff := credentialChanges(data, "private_key_jwt.0.credentials")
+
+	assert.Empty(t, diff.toAdd, "nothing changed, so nothing should be added")
+	assert.Empty(t, diff.toRemove, "nothing changed, so nothing should be removed")
+}
+
 func TestFilterOwnedCredentials(t *testing.T) {
 	spkiPEM, _, _ := generateTestRSAPEMs(t)
 	ownKeyID := jwkThumbprint(spkiPEM)

--- a/internal/auth0/client/resource_credentials_test.go
+++ b/internal/auth0/client/resource_credentials_test.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 
 	"github.com/auth0/terraform-provider-auth0/internal/acctest"
@@ -514,6 +516,169 @@ func TestAccClientCredentialsPrivateKeyJWTFullRotation(t *testing.T) {
 						"name": "Testing Credentials 4",
 					}),
 				),
+			},
+		},
+	})
+}
+
+const testAccCreateCredentialForRenameSameKeyRegression = `
+resource "auth0_client" "my_client" {
+	name     = "Acceptance Test - Client Credentials - {{.testName}}"
+	app_type = "non_interactive"
+
+	jwt_configuration {
+		alg = "RS256"
+	}
+}
+
+resource "auth0_client_credentials" "test" {
+	client_id             = auth0_client.my_client.id
+	authentication_method = "private_key_jwt"
+
+	private_key_jwt {
+		credentials {
+			name                   = "Credential A"
+			credential_type        = "public_key"
+			algorithm              = "RS256"
+			parse_expiry_from_cert = false
+			expires_at             = "2096-05-13T09:33:13.000Z"
+			pem                    = <<EOF
+%s
+EOF
+		}
+	}
+}
+`
+
+const testAccRenameCredentialSameKeyRegression = `
+resource "auth0_client" "my_client" {
+	name     = "Acceptance Test - Client Credentials - {{.testName}}"
+	app_type = "non_interactive"
+
+	jwt_configuration {
+		alg = "RS256"
+	}
+}
+
+resource "auth0_client_credentials" "test" {
+	client_id             = auth0_client.my_client.id
+	authentication_method = "private_key_jwt"
+
+	private_key_jwt {
+		credentials {
+			name                   = "Credential B"
+			credential_type        = "public_key"
+			algorithm              = "RS256"
+			parse_expiry_from_cert = false
+			expires_at             = "2096-05-13T09:33:13.000Z"
+			pem                    = <<EOF
+%s
+EOF
+		}
+	}
+}
+`
+
+// findCredentialSetAttr locates the sole "private_key_jwt.0.credentials.<hash>.<attr>"
+// entry for a TypeSet with exactly one credential and returns its value. The hash
+// segment isn't predictable across applies, so callers can't address it by index.
+func findCredentialSetAttr(s *terraform.State, resourceName, attr string) (string, error) {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return "", fmt.Errorf("resource %s not found in state", resourceName)
+	}
+
+	prefix := "private_key_jwt.0.credentials."
+	suffix := "." + attr
+	for key, value := range rs.Primary.Attributes {
+		if strings.HasPrefix(key, prefix) && strings.HasSuffix(key, suffix) {
+			return value, nil
+		}
+	}
+
+	return "", fmt.Errorf("no %s.*%s attribute found on %s", prefix, suffix, resourceName)
+}
+
+// TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates is the regression
+// test for TFP-ESD-65375: renaming a private_key_jwt credential while keeping its
+// PEM identical must surface as a real plan change and a real detach+create
+// rotation against the live API, not be paired away into an empty diff by
+// classifyCredentialChanges. It also covers the single-credential slot/pool
+// collision this rotation exercises: with only one of two attached slots and one
+// of four pool slots used, the planner has headroom to add before removing, so
+// without planCredentialRotation's same-key collision guard this would 400 with
+// "credentials contains public keys that already exist in client" instead of
+// rotating cleanly.
+func TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates(t *testing.T) {
+	credsCert, err := os.ReadFile("./../../../test/data/creds-cert-2.pem")
+	require.NoError(t, err)
+
+	var originalCredentialID, originalKeyID string
+
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(acctest.ParseTestName(testAccCreateCredentialForRenameSameKeyRegression, t.Name()), credsCert),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("auth0_client_credentials.test", "private_key_jwt.0.credentials.*", map[string]string{
+						"name": "Credential A",
+					}),
+					func(s *terraform.State) error {
+						id, err := findCredentialSetAttr(s, "auth0_client_credentials.test", "id")
+						if err != nil {
+							return err
+						}
+						originalCredentialID = id
+
+						keyID, err := findCredentialSetAttr(s, "auth0_client_credentials.test", "key_id")
+						if err != nil {
+							return err
+						}
+						originalKeyID = keyID
+
+						return nil
+					},
+				),
+			},
+			{
+				Config: fmt.Sprintf(acctest.ParseTestName(testAccRenameCredentialSameKeyRegression, t.Name()), credsCert),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("auth0_client_credentials.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client_credentials.test", "private_key_jwt.0.credentials.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("auth0_client_credentials.test", "private_key_jwt.0.credentials.*", map[string]string{
+						"name": "Credential B",
+					}),
+					func(s *terraform.State) error {
+						id, err := findCredentialSetAttr(s, "auth0_client_credentials.test", "id")
+						if err != nil {
+							return err
+						}
+						if id == originalCredentialID {
+							return fmt.Errorf("expected the rename to detach the old credential and attach a new one, got the same credential ID %q as before the rename", id)
+						}
+
+						keyID, err := findCredentialSetAttr(s, "auth0_client_credentials.test", "key_id")
+						if err != nil {
+							return err
+						}
+						if keyID != originalKeyID {
+							return fmt.Errorf("expected the rotated credential to carry the same public key (key_id %q), got %q", originalKeyID, keyID)
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				// Confirms the rotation converged: re-applying the same config
+				// produces no further plan changes.
+				Config:   fmt.Sprintf(acctest.ParseTestName(testAccRenameCredentialSameKeyRegression, t.Name()), credsCert),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/test/data/recordings/TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates.yaml
+++ b/test/data/recordings/TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates.yaml
@@ -1,0 +1,1212 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 227
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","app_type":"non_interactive","jwt_configuration":{"alg":"RS256"},"token_endpoint_auth_method":"client_secret_post"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 683.66625ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 317.451666ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417?fields=client_id&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 438.975958ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2109
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Credential A","credential_type":"public_key","pem":"-----BEGIN CERTIFICATE-----\nMIIFZDCCA0wCCQDNZ2SmDG1sdTANBgkqhkiG9w0BAQsFADB0MQswCQYDVQQGEwJl\nczESMBAGA1UECAwJQmFyY2Vsb25hMRIwEAYDVQQHDAlCYXJjZWxvbmExDTALBgNV\nBAoMBE9rdGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxvcGVyIEV4\ncGVyaWVuY2UwHhcNMjMwNTE2MTEyOTA4WhcNMzMwNTEzMTEyOTA4WjB0MQswCQYD\nVQQGEwJlczESMBAGA1UECAwJQmFyY2Vsb25hMRIwEAYDVQQHDAlCYXJjZWxvbmEx\nDTALBgNVBAoMBE9rdGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxv\ncGVyIEV4cGVyaWVuY2UwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDs\nY0FIvVc7gPj3aCMG5kGzYW0lD6tBnaRBdXxTsagaowKjOHc3BkbjXzavdWe1bxVN\nKtI3Itak2G/FqdL7Oh+EU+dgwnE82vlxH4J0V25Y0Bc5rQmfWlRUPOkPvnnOTx2w\n+aSZgo+3QqK9aVoKvAmuG+xXbYgXRWNDlU3sljtsa+aACSyqLNFwEoFfTIZMryb5\nZv69Jc/vMEDweQbgrCEFzFmCqNGp5gVY3Bo/1BnayusP1j7xRd7NjAGl4X36X4F9\n5ARKlh/YM+MnCfQqnSYROJKndiV/MoFnaRPSSJ8wEX3cGFZzT9O9JfdgU4CMhd4b\nb4la0gpWAjADvIIQURk2P0SEokfHv5BRRk82+6BpsvSHb79RagFT2/CYfEMIrmB7\nBUNrQOO3aJF6ZViPVoP47DvOj50Lg6WSNX/1mCzxg2s4qZpqpKHhjng/xuqpG4HP\nqaNPROFxHnxtrx0vd9FtlY9+itmUxMy3usW2g+psGgNkEYF0xIR0hQKD15iOyeQh\nrnCLXTJd0PW5v6vPhDo3vWQm7jtIENjbbvdkTdyVbLMpn4+LnOGyE3Hzw66GW6ty\njdw9So6jlDGTQACapXd3eFczN3zPinapdnMz5m/21YoYoMjmNvYuCYS2MHrnBZZJ\n9RaJOfFj6E/8VyqWyC31SLTjyDEvwmJPJu3V+ZSy+QIDAQABMA0GCSqGSIb3DQEB\nCwUAA4ICAQAmhys6SSJLclpnq0GwiU2zQCYE/zFtalDTMclXXa8KJK7lsRZXccMu\nzawDjKtZ8H2C+RqF7e9bCGXtTTEpP65Oz9vXiLjCCS/GoC67AOlWNGIhBnQkoY1s\nTlJ+4kuBKXEXbYObyvh/ZgpYXXdNtDJ4VTP5NfdzlVI+aeI7HYvpSN2w4SvKvtWq\nLIQvlDUjwnELZ7gp9AJHUE+xfR9VIZ6ycd2n+k9lWSrzP8zhTrNe7N5++vzVitw3\nvNnJDPD9oa5PKQDJC64YLOHSSTCFLkNSwU3LjV+k8kfhlDW6zDJNx9pLDRf4vRN9\nmmxlWpfg71DHcB6ZUf10hmalLAq8F9acv3k7w0tQYh2M/f2Rfji76Wb2T+tLS0ve\n6wkxgrP1pNRWX1OeWpIJoEZGyFZd5ZrV99djN3N09gfORXWhAyQXzJz6A5Xg3m1f\nru1Dbr41GYY/77B1m6S5HtSTf/KpvW2EnISnL7pz0c4K5A1ZH0DBZhbFL/Fbvghz\nYqOj0xiWNk/RfmEVaYF7mquEMYzAzr8Ma9Ivj73bHV0SgtunOKehUlvjOKf7n+lX\ngpPrAm1Sgm0ao259gYOM7wsNkPDlsTxsnFOFnuJgAyPxWAZF0k8Z/jXWlbudD6b8\nzTeW4JXOP2p9PaUJB3asHy2CoUMkAh7mGOPPJD0y0deabEfo5+dE5A==\n-----END CERTIFICATE-----\n\n","alg":"RS256","parse_expiry_from_cert":false,"expires_at":"2096-05-13T09:33:13Z"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 275
+        uncompressed: false
+        body: '{"id":"cred_fNYVZtDT5757Z2m3VtWupp","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Credential A","created_at":"2026-08-13T04:50:59.112Z","updated_at":"2026-08-13T04:50:59.112Z","expires_at":"2096-05-13T09:33:13.000Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 519.464583ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417?fields=client_id%2Capp_type&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 429.202125ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 143
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_fNYVZtDT5757Z2m3VtWupp"}]}},"token_endpoint_auth_method":null}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_fNYVZtDT5757Z2m3VtWupp"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 435.821625ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_fNYVZtDT5757Z2m3VtWupp"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 408.7625ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials/cred_fNYVZtDT5757Z2m3VtWupp
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cred_fNYVZtDT5757Z2m3VtWupp","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Credential A","created_at":"2026-08-13T04:50:59.112Z","updated_at":"2026-08-13T04:50:59.112Z","expires_at":"2096-05-13T09:33:13.000Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 382.414875ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_fNYVZtDT5757Z2m3VtWupp"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 314.589458ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_fNYVZtDT5757Z2m3VtWupp"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 343.034ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials/cred_fNYVZtDT5757Z2m3VtWupp
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cred_fNYVZtDT5757Z2m3VtWupp","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Credential A","created_at":"2026-08-13T04:50:59.112Z","updated_at":"2026-08-13T04:50:59.112Z","expires_at":"2096-05-13T09:33:13.000Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 522.586ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_fNYVZtDT5757Z2m3VtWupp"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 304.356792ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_fNYVZtDT5757Z2m3VtWupp"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 295.724709ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials/cred_fNYVZtDT5757Z2m3VtWupp
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cred_fNYVZtDT5757Z2m3VtWupp","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Credential A","created_at":"2026-08-13T04:50:59.112Z","updated_at":"2026-08-13T04:50:59.112Z","expires_at":"2096-05-13T09:33:13.000Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 319.469917ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417?fields=client_id&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 311.834584ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"cred_fNYVZtDT5757Z2m3VtWupp","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Credential A","created_at":"2026-08-13T04:50:59.112Z","updated_at":"2026-08-13T04:50:59.112Z","expires_at":"2096-05-13T09:33:13.000Z"}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 308.476667ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417?fields=client_id%2Capp_type&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 310.925041ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 107
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"client_authentication_methods":{"private_key_jwt":{"credentials":[]}},"token_endpoint_auth_method":null}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 368.939792ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials/cred_fNYVZtDT5757Z2m3VtWupp
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 312.325083ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 2109
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Credential B","credential_type":"public_key","pem":"-----BEGIN CERTIFICATE-----\nMIIFZDCCA0wCCQDNZ2SmDG1sdTANBgkqhkiG9w0BAQsFADB0MQswCQYDVQQGEwJl\nczESMBAGA1UECAwJQmFyY2Vsb25hMRIwEAYDVQQHDAlCYXJjZWxvbmExDTALBgNV\nBAoMBE9rdGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxvcGVyIEV4\ncGVyaWVuY2UwHhcNMjMwNTE2MTEyOTA4WhcNMzMwNTEzMTEyOTA4WjB0MQswCQYD\nVQQGEwJlczESMBAGA1UECAwJQmFyY2Vsb25hMRIwEAYDVQQHDAlCYXJjZWxvbmEx\nDTALBgNVBAoMBE9rdGExDzANBgNVBAsMBkRYLUNEVDEdMBsGA1UEAwwURGV2ZWxv\ncGVyIEV4cGVyaWVuY2UwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDs\nY0FIvVc7gPj3aCMG5kGzYW0lD6tBnaRBdXxTsagaowKjOHc3BkbjXzavdWe1bxVN\nKtI3Itak2G/FqdL7Oh+EU+dgwnE82vlxH4J0V25Y0Bc5rQmfWlRUPOkPvnnOTx2w\n+aSZgo+3QqK9aVoKvAmuG+xXbYgXRWNDlU3sljtsa+aACSyqLNFwEoFfTIZMryb5\nZv69Jc/vMEDweQbgrCEFzFmCqNGp5gVY3Bo/1BnayusP1j7xRd7NjAGl4X36X4F9\n5ARKlh/YM+MnCfQqnSYROJKndiV/MoFnaRPSSJ8wEX3cGFZzT9O9JfdgU4CMhd4b\nb4la0gpWAjADvIIQURk2P0SEokfHv5BRRk82+6BpsvSHb79RagFT2/CYfEMIrmB7\nBUNrQOO3aJF6ZViPVoP47DvOj50Lg6WSNX/1mCzxg2s4qZpqpKHhjng/xuqpG4HP\nqaNPROFxHnxtrx0vd9FtlY9+itmUxMy3usW2g+psGgNkEYF0xIR0hQKD15iOyeQh\nrnCLXTJd0PW5v6vPhDo3vWQm7jtIENjbbvdkTdyVbLMpn4+LnOGyE3Hzw66GW6ty\njdw9So6jlDGTQACapXd3eFczN3zPinapdnMz5m/21YoYoMjmNvYuCYS2MHrnBZZJ\n9RaJOfFj6E/8VyqWyC31SLTjyDEvwmJPJu3V+ZSy+QIDAQABMA0GCSqGSIb3DQEB\nCwUAA4ICAQAmhys6SSJLclpnq0GwiU2zQCYE/zFtalDTMclXXa8KJK7lsRZXccMu\nzawDjKtZ8H2C+RqF7e9bCGXtTTEpP65Oz9vXiLjCCS/GoC67AOlWNGIhBnQkoY1s\nTlJ+4kuBKXEXbYObyvh/ZgpYXXdNtDJ4VTP5NfdzlVI+aeI7HYvpSN2w4SvKvtWq\nLIQvlDUjwnELZ7gp9AJHUE+xfR9VIZ6ycd2n+k9lWSrzP8zhTrNe7N5++vzVitw3\nvNnJDPD9oa5PKQDJC64YLOHSSTCFLkNSwU3LjV+k8kfhlDW6zDJNx9pLDRf4vRN9\nmmxlWpfg71DHcB6ZUf10hmalLAq8F9acv3k7w0tQYh2M/f2Rfji76Wb2T+tLS0ve\n6wkxgrP1pNRWX1OeWpIJoEZGyFZd5ZrV99djN3N09gfORXWhAyQXzJz6A5Xg3m1f\nru1Dbr41GYY/77B1m6S5HtSTf/KpvW2EnISnL7pz0c4K5A1ZH0DBZhbFL/Fbvghz\nYqOj0xiWNk/RfmEVaYF7mquEMYzAzr8Ma9Ivj73bHV0SgtunOKehUlvjOKf7n+lX\ngpPrAm1Sgm0ao259gYOM7wsNkPDlsTxsnFOFnuJgAyPxWAZF0k8Z/jXWlbudD6b8\nzTeW4JXOP2p9PaUJB3asHy2CoUMkAh7mGOPPJD0y0deabEfo5+dE5A==\n-----END CERTIFICATE-----\n\n","alg":"RS256","parse_expiry_from_cert":false,"expires_at":"2096-05-13T09:33:13Z"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 275
+        uncompressed: false
+        body: '{"id":"cred_3CYNcu349ZoGze47FwLdpP","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Credential B","created_at":"2026-08-13T04:51:07.364Z","updated_at":"2026-08-13T04:51:07.364Z","expires_at":"2096-05-13T09:33:13.000Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 330.356459ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417?fields=client_id%2Capp_type&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 303.159833ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 143
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_3CYNcu349ZoGze47FwLdpP"}]}},"token_endpoint_auth_method":null}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_3CYNcu349ZoGze47FwLdpP"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 332.846458ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_3CYNcu349ZoGze47FwLdpP"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 302.568917ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials/cred_3CYNcu349ZoGze47FwLdpP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cred_3CYNcu349ZoGze47FwLdpP","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Credential B","created_at":"2026-08-13T04:51:07.364Z","updated_at":"2026-08-13T04:51:07.364Z","expires_at":"2096-05-13T09:33:13.000Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 301.13425ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_3CYNcu349ZoGze47FwLdpP"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 310.047333ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_3CYNcu349ZoGze47FwLdpP"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 310.150625ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials/cred_3CYNcu349ZoGze47FwLdpP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cred_3CYNcu349ZoGze47FwLdpP","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Credential B","created_at":"2026-08-13T04:51:07.364Z","updated_at":"2026-08-13T04:51:07.364Z","expires_at":"2096-05-13T09:33:13.000Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 292.063042ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_3CYNcu349ZoGze47FwLdpP"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 302.242791ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000},"client_authentication_methods":{"private_key_jwt":{"credentials":[{"id":"cred_3CYNcu349ZoGze47FwLdpP"}]}}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 301.029625ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials/cred_3CYNcu349ZoGze47FwLdpP
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"cred_3CYNcu349ZoGze47FwLdpP","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Credential B","created_at":"2026-08-13T04:51:07.364Z","updated_at":"2026-08-13T04:51:07.364Z","expires_at":"2096-05-13T09:33:13.000Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 309.547833ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417?fields=client_id%2Capp_type&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 314.137333ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials?include_totals=true&per_page=50
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '[{"id":"cred_3CYNcu349ZoGze47FwLdpP","credential_type":"public_key","kid":"FnNtsjkgcpkHjrTJqenDiJx31_g8n_-wWtYUUPn4FyM","alg":"RS256","name":"Credential B","created_at":"2026-08-13T04:51:07.364Z","updated_at":"2026-08-13T04:51:07.364Z","expires_at":"2096-05-13T09:33:13.000Z"}]'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 299.89175ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417?fields=client_id%2Capp_type&include_fields=true
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","app_type":"non_interactive","signing_keys":[{"cert":"[REDACTED]"}]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 307.102041ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 89
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"client_authentication_methods":null,"token_endpoint_auth_method":"client_secret_post"}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"name":"Acceptance Test - Client Credentials - TestAccClientCredentialsPrivateKeyJWTRenameWithSameKeyRotates","client_id":"gCBVFmzzKRpetD7obgI37Yn1CIbKp417","client_secret":"[REDACTED]","app_type":"non_interactive","is_first_party":true,"is_token_endpoint_ip_header_trusted":false,"oidc_conformant":false,"jwt_configuration":{"secret_encoded":false,"alg":"RS256"},"signing_keys":[{"cert":"[REDACTED]"}],"sso_disabled":false,"cross_origin_authentication":false,"grant_types":["authorization_code","implicit","refresh_token","client_credentials"],"custom_login_page_on":true,"token_endpoint_auth_method":"client_secret_post","refresh_token":{"rotation_type":"non-rotating","expiration_type":"non-expiring","leeway":0,"token_lifetime":31557600,"infinite_token_lifetime":true,"infinite_idle_token_lifetime":true,"idle_token_lifetime":2592000}}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 326.834167ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417/credentials/cred_3CYNcu349ZoGze47FwLdpP
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 303.054416ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/clients/gCBVFmzzKRpetD7obgI37Yn1CIbKp417
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 204 No Content
+        code: 204
+        duration: 462.032541ms


### PR DESCRIPTION

# Fix client credentials diff matching to compare cred name

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

- `classifyCredentialChanges` in `internal/auth0/client/resource_credentials.go` now requires `name` to match (in addition to PEM/key-id and algorithm) before treating an added credential and a removed credential as the same underlying credential.
- Previously, two `private_key_jwt` credentials with identical PEM/algorithm but different `name` values were matched to each other, so a `name`-only change went undetected and was not applied against the Auth0 API.

### 🔬 Testing

- No new automated tests were added in this change; existing coverage for `classifyCredentialChanges` should be extended to cover the name-mismatch case.
- Manual verification: change only the `name` of an existing `private_key_jwt` credential in configuration and confirm `terraform plan`/`apply` now applies the name update instead of treating it as unchanged.

### 📝 Checklist

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
