### PR TITLE
fix: Explicitly handle patch for `unique` property under ConnectionOptions.Attributes.Email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+BUG FIXES:
+- `resource/auth0_connection` – Fix updates failing with `cannot patch unique property on email attribute` on `auth0` connections whose `options.attributes.email.unique` is `false`. The Management API reads a missing `unique` as `true`, so any change to an unrelated option was rejected ([#1669](https://github.com/auth0/terraform-provider-auth0/pull/1669))
+
+
 ## v1.54.0
 
 FEATURES:

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -884,7 +884,7 @@ Optional:
 - `identifier` (Block List) Connection Options Email Attribute Identifier (see [below for nested schema](#nestedblock--options--attributes--email--identifier))
 - `profile_required` (Boolean) Defines whether Profile is required
 - `signup` (Block List) Defines signup settings for Email attribute (see [below for nested schema](#nestedblock--options--attributes--email--signup))
-- `unique` (Boolean) If set to false, it allow multiple accounts with the same email address. Defaults to `true`. This can only be set when the connection is created: the Auth0 Management API does not allow updating it, so changing it on an existing connection fails at plan time and requires recreating the connection.
+- `unique` (Boolean) If set to false, it allow multiple accounts with the same email address. Defaults to `true`. This can only be set when the connection is created: the Auth0 Management API does not allow updating it, so changing it on an existing connection fails at plan time and requires recreating the connection. The API also refuses to add a non-unique email attribute to a connection that does not already have one.
 - `verification_method` (String) Defines whether whether user will receive a link or an OTP during user signup for email verification and password reset for email verification
 
 <a id="nestedblock--options--attributes--email--identifier"></a>

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -884,7 +884,7 @@ Optional:
 - `identifier` (Block List) Connection Options Email Attribute Identifier (see [below for nested schema](#nestedblock--options--attributes--email--identifier))
 - `profile_required` (Boolean) Defines whether Profile is required
 - `signup` (Block List) Defines signup settings for Email attribute (see [below for nested schema](#nestedblock--options--attributes--email--signup))
-- `unique` (Boolean) If set to false, it allow multiple accounts with the same email address
+- `unique` (Boolean) If set to false, it allow multiple accounts with the same email address. Defaults to `true`. This can only be set when the connection is created: the Auth0 Management API does not allow updating it, so changing it on an existing connection fails at plan time and requires recreating the connection.
 - `verification_method` (String) Defines whether whether user will receive a link or an OTP during user signup for email verification and password reset for email verification
 
 <a id="nestedblock--options--attributes--email--identifier"></a>

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -107,7 +107,10 @@ func expandConnection(
 		}
 	}
 
-	// Prevent erasing database configuration secrets.
+	// Updating a database connection needs the stored options: the PATCH payload
+	// replaces options wholesale, so values the configuration cannot supply have to
+	// be read back and carried over. The strategy check also guards the type
+	// assertions below — only the auth0 strategy uses *management.ConnectionOptions.
 	if !data.IsNewResource() && strategy == management.ConnectionStrategyAuth0 && connection.Options != nil {
 		apiConn, err := api.Connection.Read(ctx, data.Id())
 		if err != nil {
@@ -117,6 +120,7 @@ func expandConnection(
 		options := connection.Options.(*management.ConnectionOptions)
 		apiOptions := apiConn.Options.(*management.ConnectionOptions)
 
+		// Prevent erasing database configuration secrets.
 		diagnostics = append(
 			diagnostics,
 			checkForUnmanagedConfigurationSecrets(
@@ -125,6 +129,8 @@ func expandConnection(
 			)...,
 		)
 
+		// The API reads a missing unique as true and rejects the PATCH when the
+		// stored value is false, so the stored value has to be sent back.
 		echoEmailAttributeUnique(options, apiOptions)
 	}
 

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -388,12 +388,12 @@ func expandConnectionOptionsCustomPasswordHash(config cty.Value) *management.Cus
 	return customPasswordHash
 }
 
-func expandConnectionOptionsAttributes(config cty.Value, isNew bool) *management.ConnectionOptionsAttributes {
+func expandConnectionOptionsAttributes(config cty.Value) *management.ConnectionOptionsAttributes {
 	var coa *management.ConnectionOptionsAttributes
 	config.ForEachElement(
 		func(_ cty.Value, attributes cty.Value) (stop bool) {
 			coa = &management.ConnectionOptionsAttributes{
-				Email:       expandConnectionOptionsEmailAttribute(attributes, isNew),
+				Email:       expandConnectionOptionsEmailAttribute(attributes),
 				Username:    expandConnectionOptionsUsernameAttribute(attributes),
 				PhoneNumber: expandConnectionOptionsPhoneNumberAttribute(attributes),
 			}
@@ -402,7 +402,7 @@ func expandConnectionOptionsAttributes(config cty.Value, isNew bool) *management
 	return coa
 }
 
-func expandConnectionOptionsEmailAttribute(config cty.Value, isNew bool) *management.ConnectionOptionsEmailAttribute {
+func expandConnectionOptionsEmailAttribute(config cty.Value) *management.ConnectionOptionsEmailAttribute {
 	var coea *management.ConnectionOptionsEmailAttribute
 	config.GetAttr("email").ForEachElement(
 		func(_ cty.Value, email cty.Value) (stop bool) {
@@ -411,30 +411,34 @@ func expandConnectionOptionsEmailAttribute(config cty.Value, isNew bool) *manage
 				ProfileRequired:    value.Bool(email.GetAttr("profile_required")),
 				VerificationMethod: (*management.ConnectionOptionsEmailAttributeVerificationMethod)(value.String(email.GetAttr("verification_method"))),
 				Signup:             expandConnectionOptionsAttributeSignup(email),
-			}
-			// Unique is a create-only property; including it only in a POST request.
-			// On updates echoEmailAttributeUnique fills it in from the API, as the
-			// API rejects a PATCH that omits it whenever the stored value is false.
-			if isNew {
-				coea.Unique = value.Bool(email.GetAttr("unique"))
+				// The API rejects a PATCH that omits unique when the stored value is
+				// false, so it is always sent. On updates echoEmailAttributeUnique
+				// overwrites this with the stored value, since the property is
+				// immutable; the configured value only takes effect on a create or
+				// when the email attribute is being added.
+				Unique: value.Bool(email.GetAttr("unique")),
 			}
 			return stop
 		})
 	return coea
 }
 
-// echoEmailAttributeUnique copies the stored unique value into an update payload.
+// echoEmailAttributeUnique overwrites the unique value in an update payload with
+// the value the API has stored.
 //
 // The Management API treats a missing options.attributes.email.unique as an
 // implicit true, so omitting it on a connection where it is false reads as an
 // attempt to flip the value and fails with "cannot patch unique property on email
-// attribute"; even when the update leaves the email attribute untouched.
+// attribute"; even when the update leaves the email attribute untouched. The
+// property is immutable, so echoing the stored value is always what the API
+// expects: a configuration that agrees is unchanged by this, and one that
+// disagrees is already rejected at plan time by validateConnection.
 func echoEmailAttributeUnique(options, apiOptions *management.ConnectionOptions) {
 	emailAttribute := options.GetAttributes().GetEmail()
 	apiEmailAttribute := apiOptions.GetAttributes().GetEmail()
 
-	// When the email attribute is being added there is no stored value to echo.
-	// The API only accepts additions that are unique and reports its own error.
+	// When the email attribute is being added there is no stored value to echo, so
+	// the configured value is left in place for the API to accept or reject.
 	if emailAttribute == nil || apiEmailAttribute == nil {
 		return
 	}
@@ -548,7 +552,7 @@ func expandConnectionOptionsAttributeAllowedTypes(config cty.Value) *management.
 	return coaat
 }
 
-func expandConnectionOptionsAuth0(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
+func expandConnectionOptionsAuth0(_ *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptions{
 		PasswordPolicy:                   value.String(config.GetAttr("password_policy")),
 		NonPersistentAttrs:               value.Strings(config.GetAttr("non_persistent_attrs")),
@@ -562,7 +566,7 @@ func expandConnectionOptionsAuth0(data *schema.ResourceData, config cty.Value) (
 		RequiresUsername:                 value.Bool(config.GetAttr("requires_username")),
 		CustomScripts:                    value.MapOfStrings(config.GetAttr("custom_scripts")),
 		Configuration:                    value.MapOfStrings(config.GetAttr("configuration")),
-		Attributes:                       expandConnectionOptionsAttributes(config.GetAttr("attributes"), data.IsNewResource()),
+		Attributes:                       expandConnectionOptionsAttributes(config.GetAttr("attributes")),
 		StrategyVersion:                  value.Int(config.GetAttr("strategy_version")),
 		RealmFallback:                    value.Bool(config.GetAttr("realm_fallback")),
 	}

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -114,13 +114,18 @@ func expandConnection(
 			return nil, diag.FromErr(err)
 		}
 
+		options := connection.Options.(*management.ConnectionOptions)
+		apiOptions := apiConn.Options.(*management.ConnectionOptions)
+
 		diagnostics = append(
 			diagnostics,
 			checkForUnmanagedConfigurationSecrets(
-				connection.Options.(*management.ConnectionOptions).GetConfiguration(),
-				apiConn.Options.(*management.ConnectionOptions).GetConfiguration(),
+				options.GetConfiguration(),
+				apiOptions.GetConfiguration(),
 			)...,
 		)
+
+		echoEmailAttributeUnique(options, apiOptions)
 	}
 
 	return connection, diagnostics
@@ -402,12 +407,33 @@ func expandConnectionOptionsEmailAttribute(config cty.Value, isNew bool) *manage
 				Signup:             expandConnectionOptionsAttributeSignup(email),
 			}
 			// Unique is a create-only property; including it only in a POST request.
+			// On updates echoEmailAttributeUnique fills it in from the API, as the
+			// API rejects a PATCH that omits it whenever the stored value is false.
 			if isNew {
 				coea.Unique = value.Bool(email.GetAttr("unique"))
 			}
 			return stop
 		})
 	return coea
+}
+
+// echoEmailAttributeUnique copies the stored unique value into an update payload.
+//
+// The Management API treats a missing options.attributes.email.unique as an
+// implicit true, so omitting it on a connection where it is false reads as an
+// attempt to flip the value and fails with "cannot patch unique property on email
+// attribute"; even when the update leaves the email attribute untouched.
+func echoEmailAttributeUnique(options, apiOptions *management.ConnectionOptions) {
+	emailAttribute := options.GetAttributes().GetEmail()
+	apiEmailAttribute := apiOptions.GetAttributes().GetEmail()
+
+	// When the email attribute is being added there is no stored value to echo.
+	// The API only accepts additions that are unique and reports its own error.
+	if emailAttribute == nil || apiEmailAttribute == nil {
+		return
+	}
+
+	emailAttribute.Unique = auth0.Bool(emailAttributeUnique(apiEmailAttribute))
 }
 
 func expandConnectionOptionsUsernameAttribute(config cty.Value) *management.ConnectionOptionsUsernameAttribute {

--- a/internal/auth0/connection/expand_test.go
+++ b/internal/auth0/connection/expand_test.go
@@ -94,12 +94,64 @@ func TestEchoEmailAttributeUnique(t *testing.T) {
 		assert.Equal(t, auth0.Bool(true), options.GetAttributes().GetEmail().Unique)
 	})
 
-	t.Run("leaves unique untouched when the email attribute is being added", func(t *testing.T) {
-		options := optionsWithEmailUnique(nil)
+	t.Run("keeps a configured false when the email attribute is being added", func(t *testing.T) {
+		options := optionsWithEmailUnique(auth0.Bool(false))
 
 		echoEmailAttributeUnique(options, &management.ConnectionOptions{})
 
-		assert.Nil(t, options.GetAttributes().GetEmail().Unique)
+		assert.Equal(t, auth0.Bool(false), options.GetAttributes().GetEmail().Unique)
+	})
+
+	t.Run("overwrites a configured value that disagrees with the stored one", func(t *testing.T) {
+		options := optionsWithEmailUnique(auth0.Bool(false))
+
+		echoEmailAttributeUnique(options, optionsWithEmailUnique(auth0.Bool(true)))
+
+		assert.Equal(t, auth0.Bool(true), options.GetAttributes().GetEmail().Unique)
+	})
+}
+
+// TestExpandConnectionOptionsEmailAttributeUnique asserts that unique is expanded
+// from the configuration on every request, not only on create. The API rejects a
+// PATCH that omits it when the stored value is false, and an email attribute added
+// on update has no stored value for echoEmailAttributeUnique to supply.
+func TestExpandConnectionOptionsEmailAttributeUnique(t *testing.T) {
+	attributesConfig := func(unique cty.Value) cty.Value {
+		return cty.ObjectVal(map[string]cty.Value{
+			"email": cty.ListVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"identifier": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+						"active":         cty.Bool,
+						"default_method": cty.String,
+					})),
+					"profile_required":    cty.True,
+					"verification_method": cty.StringVal("link"),
+					"signup": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+						"status":       cty.String,
+						"verification": cty.List(cty.Object(map[string]cty.Type{"active": cty.Bool})),
+					})),
+					"unique": unique,
+				}),
+			}),
+		})
+	}
+
+	t.Run("expands a configured false", func(t *testing.T) {
+		emailAttribute := expandConnectionOptionsEmailAttribute(attributesConfig(cty.False))
+
+		assert.Equal(t, auth0.Bool(false), emailAttribute.Unique)
+	})
+
+	t.Run("expands a configured true", func(t *testing.T) {
+		emailAttribute := expandConnectionOptionsEmailAttribute(attributesConfig(cty.True))
+
+		assert.Equal(t, auth0.Bool(true), emailAttribute.Unique)
+	})
+
+	t.Run("omits unique when the configuration leaves it unset", func(t *testing.T) {
+		emailAttribute := expandConnectionOptionsEmailAttribute(attributesConfig(cty.NullVal(cty.Bool)))
+
+		assert.Nil(t, emailAttribute.Unique)
 	})
 }
 

--- a/internal/auth0/connection/expand_test.go
+++ b/internal/auth0/connection/expand_test.go
@@ -66,6 +66,49 @@ func TestCheckForUnmanagedConfigurationSecrets(t *testing.T) {
 	}
 }
 
+// TestEchoEmailAttributeUnique guards the workaround for the Management API
+// rejecting a PATCH that omits options.attributes.email.unique when the stored
+// value is false.
+func TestEchoEmailAttributeUnique(t *testing.T) {
+	optionsWithEmailUnique := func(unique *bool) *management.ConnectionOptions {
+		return &management.ConnectionOptions{
+			Attributes: &management.ConnectionOptionsAttributes{
+				Email: &management.ConnectionOptionsEmailAttribute{Unique: unique},
+			},
+		}
+	}
+
+	t.Run("echoes back a stored unique of false so the API accepts the patch", func(t *testing.T) {
+		options := optionsWithEmailUnique(nil)
+
+		echoEmailAttributeUnique(options, optionsWithEmailUnique(auth0.Bool(false)))
+
+		assert.Equal(t, auth0.Bool(false), options.GetAttributes().GetEmail().Unique)
+	})
+
+	t.Run("treats a unique absent from the API response as true", func(t *testing.T) {
+		options := optionsWithEmailUnique(nil)
+
+		echoEmailAttributeUnique(options, optionsWithEmailUnique(nil))
+
+		assert.Equal(t, auth0.Bool(true), options.GetAttributes().GetEmail().Unique)
+	})
+
+	t.Run("leaves unique untouched when the email attribute is being added", func(t *testing.T) {
+		options := optionsWithEmailUnique(nil)
+
+		echoEmailAttributeUnique(options, &management.ConnectionOptions{})
+
+		assert.Nil(t, options.GetAttributes().GetEmail().Unique)
+	})
+}
+
+func TestEmailAttributeUnique(t *testing.T) {
+	assert.True(t, emailAttributeUnique(nil))
+	assert.True(t, emailAttributeUnique(&management.ConnectionOptionsEmailAttribute{}))
+	assert.False(t, emailAttributeUnique(&management.ConnectionOptionsEmailAttribute{Unique: auth0.Bool(false)}))
+}
+
 // TestConnectionOptionsTypeOmitsWhenNil guards against a regression where an unset
 // connection `type` was serialized as `"type":null`, which the Auth0 API rejects
 // with `"options.type" must be ...`. The field must be omitted entirely when nil,

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -250,9 +250,10 @@ func flattenAttributes(connAttributes *management.ConnectionOptionsAttributes) i
 }
 
 // emailAttributeUnique reports the effective value of the email attribute's
-// unique property. The Management API leaves it out of the response only for
-// attributes that predate the property, where it behaves as true, so an absent
-// value must not be read as false.
+// unique property. The Management API treats an absent unique as true, both in
+// the responses it returns and in the payloads it accepts, so an absent value
+// must not be read as false. This is confirmed API behaviour rather than an
+// inference, but it is not part of the published specification.
 func emailAttributeUnique(emailAttribute *management.ConnectionOptionsEmailAttribute) bool {
 	if emailAttribute == nil || emailAttribute.Unique == nil {
 		return true

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -252,8 +252,7 @@ func flattenAttributes(connAttributes *management.ConnectionOptionsAttributes) i
 // emailAttributeUnique reports the effective value of the email attribute's
 // unique property. The Management API treats an absent unique as true, both in
 // the responses it returns and in the payloads it accepts, so an absent value
-// must not be read as false. This is confirmed API behaviour rather than an
-// inference, but it is not part of the published specification.
+// must not be read as false.
 func emailAttributeUnique(emailAttribute *management.ConnectionOptionsEmailAttribute) bool {
 	if emailAttribute == nil || emailAttribute.Unique == nil {
 		return true

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -249,6 +249,18 @@ func flattenAttributes(connAttributes *management.ConnectionOptionsAttributes) i
 	}
 }
 
+// emailAttributeUnique reports the effective value of the email attribute's
+// unique property. The Management API leaves it out of the response only for
+// attributes that predate the property, where it behaves as true, so an absent
+// value must not be read as false.
+func emailAttributeUnique(emailAttribute *management.ConnectionOptionsEmailAttribute) bool {
+	if emailAttribute == nil || emailAttribute.Unique == nil {
+		return true
+	}
+
+	return emailAttribute.GetUnique()
+}
+
 func flattenEmailAttribute(emailAttribute *management.ConnectionOptionsEmailAttribute) []map[string]interface{} {
 	if emailAttribute == nil {
 		return nil
@@ -260,7 +272,7 @@ func flattenEmailAttribute(emailAttribute *management.ConnectionOptionsEmailAttr
 			"profile_required":    emailAttribute.GetProfileRequired(),
 			"signup":              flattenSignUp(emailAttribute.GetSignup()),
 			"verification_method": emailAttribute.GetVerificationMethod(),
-			"unique":              emailAttribute.GetUnique(),
+			"unique":              emailAttributeUnique(emailAttribute),
 		},
 	}
 }

--- a/internal/auth0/connection/resource.go
+++ b/internal/auth0/connection/resource.go
@@ -42,6 +42,16 @@ func validateConnection(_ context.Context, diff *schema.ResourceDiff, _ interfac
 		return nil
 	}
 
+	// Without a stored email attribute there is no stored unique to conflict with,
+	// so the connection is free to adopt whatever the configuration asks for. This
+	// has to be checked before reading the value itself: GetChange cannot express
+	// an absent value and reports the zero value, making "no email attribute" look
+	// identical to "stored as false".
+	storedEmailCount, _ := diff.GetChange("options.0.attributes.0.email.#")
+	if count, ok := storedEmailCount.(int); !ok || count == 0 {
+		return nil
+	}
+
 	// A value the configuration leaves unset is filled in from state by the
 	// Computed flag, so only an explicit change shows up here.
 	oldValue, newValue := diff.GetChange("options.0.attributes.0.email.0.unique")

--- a/internal/auth0/connection/resource.go
+++ b/internal/auth0/connection/resource.go
@@ -2,6 +2,7 @@ package connection
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -21,6 +22,7 @@ func NewResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		CustomizeDiff: validateConnection,
 		Description: "With Auth0, you can define sources of users, otherwise known as connections, " +
 			"which may include identity providers (such as Google or LinkedIn), databases, or " +
 			"passwordless authentication methods. This resource allows you to configure " +
@@ -28,6 +30,32 @@ func NewResource() *schema.Resource {
 		Schema:        resourceSchema,
 		SchemaVersion: 3,
 	}
+}
+
+// validateConnection rejects a planned change to options.attributes.email.unique.
+// The Management API only accepts that property when the connection is created and
+// rejects any PATCH that changes it, so such a diff can never be applied and would
+// otherwise persist forever. Failing here surfaces it at plan time instead.
+func validateConnection(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	// On create there is nothing to conflict with; the API accepts any value.
+	if diff.Id() == "" {
+		return nil
+	}
+
+	// A value the configuration leaves unset is filled in from state by the
+	// Computed flag, so only an explicit change shows up here.
+	oldValue, newValue := diff.GetChange("options.0.attributes.0.email.0.unique")
+	if oldValue == newValue {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"options.attributes.email.unique cannot be changed after the connection is created: "+
+			"it is %v and the configuration requests %v. The Auth0 Management API only accepts "+
+			"this property when the connection is created. Restore it to %v, or destroy and "+
+			"recreate the connection to change it",
+		oldValue, newValue, oldValue,
+	)
 }
 
 func createConnection(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -341,6 +341,110 @@ func TestAccConnectionOptionsAttrEmail(t *testing.T) {
 	})
 }
 
+const testAccConnectionOptionAttrEmailNonUniqueTemplate = `
+resource "auth0_connection" "my_connection" {
+	name = "Acceptance-Test-Connection-{{.testName}}"
+	strategy = "auth0"
+	options {
+		enabled_database_customization = true
+		custom_scripts = {
+			login = "{{.loginScript}}"
+		}
+		attributes {
+			email {
+				identifier {
+					active = false
+				}
+				profile_required = true
+				verification_method = "link"
+				signup {
+					status = "required"
+					verification {
+						active = false
+					}
+				}
+				{{.unique}}
+			}
+			username {
+				identifier {
+					active = true
+				}
+				profile_required = true
+				signup {
+					status = "required"
+				}
+				validation {
+					min_length = 3
+					max_length = 20
+					allowed_types {
+						email = false
+						phone_number = false
+					}
+				}
+			}
+		}
+	}
+}
+`
+
+// TestAccConnectionOptionsAttrEmailNonUnique asserts that a connection whose email
+// attribute is not unique can still be updated. The Management API reads a missing
+// options.attributes.email.unique as true, so a PATCH that omits it on such a
+// connection used to fail with "cannot patch unique property on email attribute",
+// blocking unrelated changes like a login script update.
+// See https://github.com/auth0/terraform-provider-auth0/issues/1646.
+func TestAccConnectionOptionsAttrEmailNonUnique(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseParametersInTemplate(testAccConnectionOptionAttrEmailNonUniqueTemplate, map[string]interface{}{
+					"testName":    t.Name(),
+					"unique":      "unique = false",
+					"loginScript": "function login(email, password, callback) { callback(null, {}); }",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.email.0.unique", "false"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.custom_scripts.login", "function login(email, password, callback) { callback(null, {}); }"),
+				),
+			},
+			{
+				// Updating an unrelated option must not trip the unique validation.
+				Config: acctest.ParseParametersInTemplate(testAccConnectionOptionAttrEmailNonUniqueTemplate, map[string]interface{}{
+					"testName":    t.Name(),
+					"unique":      "unique = false",
+					"loginScript": "function login(email, password, callback) { /* updated */ callback(null, {}); }",
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.email.0.unique", "false"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.custom_scripts.login", "function login(email, password, callback) { /* updated */ callback(null, {}); }"),
+				),
+			},
+			{
+				// The API forbids changing unique, so this must fail at plan time
+				// rather than produce a diff that can never be applied.
+				Config: acctest.ParseParametersInTemplate(testAccConnectionOptionAttrEmailNonUniqueTemplate, map[string]interface{}{
+					"testName":    t.Name(),
+					"unique":      "unique = true",
+					"loginScript": "function login(email, password, callback) { /* updated */ callback(null, {}); }",
+				}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile("options.attributes.email.unique cannot be changed"),
+			},
+			{
+				// Leaving unique out of the configuration adopts the stored value, so
+				// it must neither error nor produce a diff.
+				Config: acctest.ParseParametersInTemplate(testAccConnectionOptionAttrEmailNonUniqueTemplate, map[string]interface{}{
+					"testName":    t.Name(),
+					"unique":      "",
+					"loginScript": "function login(email, password, callback) { /* updated */ callback(null, {}); }",
+				}),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccConnectionOptionsAttrUserName(t *testing.T) {
 	params := map[string]interface{}{
 		"testName":          t.Name(),

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -444,6 +444,114 @@ func TestAccConnectionOptionsAttrEmailNonUnique(t *testing.T) {
 	})
 }
 
+const testAccConnectionAddEmailAttributeTemplate = `
+resource "auth0_connection" "my_connection" {
+	name = "Acceptance-Test-Connection-{{.testName}}"
+	strategy = "auth0"
+	options {
+		brute_force_protection = true
+		{{.attributes}}
+	}
+}
+`
+
+const testAccConnectionAddEmailAttributeBlock = `
+		attributes {
+			email {
+				identifier {
+					active = false
+				}
+				profile_required = true
+				verification_method = "link"
+				signup {
+					status = "required"
+					verification {
+						active = false
+					}
+				}
+				{{.unique}}
+			}
+			username {
+				identifier {
+					active = true
+				}
+				profile_required = true
+				signup {
+					status = "required"
+				}
+				validation {
+					min_length = 3
+					max_length = 20
+					allowed_types {
+						email = false
+						phone_number = false
+					}
+				}
+			}
+		}
+`
+
+func testAccConnectionAddEmailAttributeConfig(testName, unique string, withAttributes bool) string {
+	attributes := ""
+	if withAttributes {
+		attributes = acctest.ParseParametersInTemplate(
+			testAccConnectionAddEmailAttributeBlock,
+			map[string]interface{}{"unique": unique},
+		)
+	}
+
+	return acctest.ParseParametersInTemplate(testAccConnectionAddEmailAttributeTemplate, map[string]interface{}{
+		"testName":   testName,
+		"attributes": attributes,
+	})
+}
+
+// TestAccConnectionAddEmailAttributeNonUnique asserts that adding a non-unique email
+// attribute to an existing connection surfaces the API's rejection. The provider now
+// sends unique on every request, so the API answers with its own error instead of
+// silently creating a unique attribute the configuration did not ask for.
+func TestAccConnectionAddEmailAttributeNonUnique(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectionAddEmailAttributeConfig(t.Name(), "", false),
+			},
+			{
+				Config:      testAccConnectionAddEmailAttributeConfig(t.Name(), "unique = false", true),
+				ExpectError: regexp.MustCompile("cannot add non-unique email attribute"),
+			},
+		},
+	})
+}
+
+// TestAccConnectionAddEmailAttributeUnique asserts that adding a unique email
+// attribute to an existing connection still works, both when unique is stated
+// explicitly and when it is left to the API default.
+func TestAccConnectionAddEmailAttributeUnique(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectionAddEmailAttributeConfig(t.Name(), "", false),
+			},
+			{
+				Config: testAccConnectionAddEmailAttributeConfig(t.Name(), "unique = true", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.attributes.0.email.0.unique", "true"),
+				),
+			},
+			{
+				Config:   testAccConnectionAddEmailAttributeConfig(t.Name(), "unique = true", true),
+				PlanOnly: true,
+			},
+			{
+				// Omitting unique adopts the stored true and must not produce a diff.
+				Config:   testAccConnectionAddEmailAttributeConfig(t.Name(), "", true),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccConnectionOptionsAttrUserName(t *testing.T) {
 	params := map[string]interface{}{
 		"testName":          t.Name(),

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -427,9 +427,8 @@ func TestAccConnectionOptionsAttrEmailNonUnique(t *testing.T) {
 					"unique":      "unique = true",
 					"loginScript": "function login(email, password, callback) { /* updated */ callback(null, {}); }",
 				}),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile("options.attributes.email.unique cannot be changed"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("options.attributes.email.unique cannot be changed"),
 			},
 			{
 				// Leaving unique out of the configuration adopts the stored value, so

--- a/internal/auth0/connection/resource_validate_test.go
+++ b/internal/auth0/connection/resource_validate_test.go
@@ -1,0 +1,135 @@
+package connection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateConnection covers the plan time guard on
+// options.attributes.email.unique. The guard can hard fail a plan, so both the
+// changes it must reject and the ones it must let through are asserted here.
+func TestValidateConnection(t *testing.T) {
+	const connectionID = "con_testConnection123"
+
+	stateWithStoredUnique := func(unique string) map[string]string {
+		return map[string]string{
+			"id":                                    connectionID,
+			"name":                                  "my-connection",
+			"strategy":                              "auth0",
+			"options.#":                             "1",
+			"options.0.attributes.#":                "1",
+			"options.0.attributes.0.email.#":        "1",
+			"options.0.attributes.0.email.0.unique": unique,
+		}
+	}
+
+	configWithUnique := func(name string, unique interface{}) map[string]interface{} {
+		emailConfig := map[string]interface{}{"profile_required": true}
+		if unique != nil {
+			emailConfig["unique"] = unique
+		}
+
+		return map[string]interface{}{
+			"name":     name,
+			"strategy": "auth0",
+			"options": []interface{}{
+				map[string]interface{}{
+					"attributes": []interface{}{
+						map[string]interface{}{
+							"email": []interface{}{emailConfig},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name          string
+		state         map[string]string
+		config        map[string]interface{}
+		expectedError string
+	}{
+		{
+			name:   "allows any value on create",
+			state:  nil,
+			config: configWithUnique("my-connection", true),
+		},
+		{
+			name:   "allows a stored false to stay false",
+			state:  stateWithStoredUnique("false"),
+			config: configWithUnique("my-connection", false),
+		},
+		{
+			name:   "allows a configuration that omits unique to adopt the stored false",
+			state:  stateWithStoredUnique("false"),
+			config: configWithUnique("my-connection", nil),
+		},
+		{
+			name:   "allows a stored true to stay true",
+			state:  stateWithStoredUnique("true"),
+			config: configWithUnique("my-connection", true),
+		},
+		{
+			name: "allows adding an email attribute absent from state",
+			state: map[string]string{
+				"id":       connectionID,
+				"name":     "my-connection",
+				"strategy": "auth0",
+			},
+			config: configWithUnique("my-connection", true),
+		},
+		{
+			name: "allows adding an email attribute to an empty attributes block",
+			state: map[string]string{
+				"id":                             connectionID,
+				"name":                           "my-connection",
+				"strategy":                       "auth0",
+				"options.#":                      "1",
+				"options.0.attributes.#":         "1",
+				"options.0.attributes.0.email.#": "0",
+			},
+			config: configWithUnique("my-connection", true),
+		},
+		{
+			name:          "rejects flipping a stored false to true",
+			state:         stateWithStoredUnique("false"),
+			config:        configWithUnique("my-connection", true),
+			expectedError: "options.attributes.email.unique cannot be changed after the connection is created",
+		},
+		{
+			name:          "rejects flipping a stored true to false",
+			state:         stateWithStoredUnique("true"),
+			config:        configWithUnique("my-connection", false),
+			expectedError: "options.attributes.email.unique cannot be changed after the connection is created",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var instanceState *terraform.InstanceState
+			if testCase.state != nil {
+				instanceState = &terraform.InstanceState{ID: connectionID, Attributes: testCase.state}
+			}
+
+			_, err := NewResource().Diff(
+				context.Background(),
+				instanceState,
+				terraform.NewResourceConfigRaw(testCase.config),
+				nil,
+			)
+
+			if testCase.expectedError == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), testCase.expectedError)
+		})
+	}
+}

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -1200,10 +1200,13 @@ var optionsSchema = &schema.Schema{
 										},
 									},
 									"unique": {
-										Type:        schema.TypeBool,
-										Optional:    true,
-										Computed:    true,
-										Description: "If set to false, it allow multiple accounts with the same email address",
+										Type:     schema.TypeBool,
+										Optional: true,
+										Computed: true,
+										Description: "If set to false, it allow multiple accounts with the same email address. " +
+											"Defaults to `true`. This can only be set when the connection is created: the " +
+											"Auth0 Management API does not allow updating it, so changing it on an existing " +
+											"connection fails at plan time and requires recreating the connection.",
 									},
 								},
 							},

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -1206,7 +1206,9 @@ var optionsSchema = &schema.Schema{
 										Description: "If set to false, it allow multiple accounts with the same email address. " +
 											"Defaults to `true`. This can only be set when the connection is created: the " +
 											"Auth0 Management API does not allow updating it, so changing it on an existing " +
-											"connection fails at plan time and requires recreating the connection.",
+											"connection fails at plan time and requires recreating the connection. The API " +
+											"also refuses to add a non-unique email attribute to a connection that does not " +
+											"already have one.",
 									},
 								},
 							},

--- a/test/data/recordings/TestAccConnectionAddEmailAttributeNonUnique.yaml
+++ b/test/data/recordings/TestAccConnectionAddEmailAttributeNonUnique.yaml
@@ -1,0 +1,240 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 143
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeNonUnique","strategy":"auth0","options":{"brute_force_protection":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_uIrULNiUbnVc6YQK","options":{"mfa":{"active":true,"return_enroll_settings":true},"brute_force_protection":true,"password_options":{"complexity":{"character_type_rule":"all","identical_characters":"allow","sequential_characters":"allow","max_length_exceeded":"error","min_length":15,"character_types":[]},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]},"history":{"active":false,"size":3},"dictionary":{"active":false,"custom":[],"default":"en_100k"}},"strategy_version":2,"authentication_methods":{"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true}},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 452.197584ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_uIrULNiUbnVc6YQK
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_uIrULNiUbnVc6YQK","options":{"mfa":{"active":true,"return_enroll_settings":true},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 370.338167ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_uIrULNiUbnVc6YQK
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_uIrULNiUbnVc6YQK","options":{"mfa":{"active":true,"return_enroll_settings":true},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 337.402666ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_uIrULNiUbnVc6YQK
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_uIrULNiUbnVc6YQK","options":{"mfa":{"active":true,"return_enroll_settings":true},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 343.803ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_uIrULNiUbnVc6YQK
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_uIrULNiUbnVc6YQK","options":{"mfa":{"active":true,"return_enroll_settings":true},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 360.368375ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 426
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"options":{"brute_force_protection":true,"attributes":{"email":{"identifier":{"active":false},"profile_required":true,"signup":{"status":"required","verification":{"active":false}},"verification_method":"link","unique":false},"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":3,"max_length":20,"allowed_types":{"email":false,"phone_number":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_uIrULNiUbnVc6YQK
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 117
+        uncompressed: false
+        body: '{"statusCode":400,"error":"Bad Request","message":"cannot add non-unique email attribute","errorCode":"invalid_body"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 400 Bad Request
+        code: 400
+        duration: 351.180916ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_uIrULNiUbnVc6YQK
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-08-07T10:52:09.002Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 360.376ms

--- a/test/data/recordings/TestAccConnectionAddEmailAttributeUnique.yaml
+++ b/test/data/recordings/TestAccConnectionAddEmailAttributeUnique.yaml
@@ -1,0 +1,372 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 140
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique","strategy":"auth0","options":{"brute_force_protection":true}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_4C81DhA8yZfv0VA8","options":{"mfa":{"active":true,"return_enroll_settings":true},"brute_force_protection":true,"password_options":{"complexity":{"character_type_rule":"all","identical_characters":"allow","sequential_characters":"allow","max_length_exceeded":"error","min_length":15,"character_types":[]},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]},"history":{"active":false,"size":3},"dictionary":{"active":false,"custom":[],"default":"en_100k"}},"strategy_version":2,"authentication_methods":{"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true}},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 399.892584ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_4C81DhA8yZfv0VA8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_4C81DhA8yZfv0VA8","options":{"mfa":{"active":true,"return_enroll_settings":true},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 402.291458ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_4C81DhA8yZfv0VA8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_4C81DhA8yZfv0VA8","options":{"mfa":{"active":true,"return_enroll_settings":true},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 368.253667ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_4C81DhA8yZfv0VA8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_4C81DhA8yZfv0VA8","options":{"mfa":{"active":true,"return_enroll_settings":true},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 377.680917ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_4C81DhA8yZfv0VA8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_4C81DhA8yZfv0VA8","options":{"mfa":{"active":true,"return_enroll_settings":true},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 393.522583ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 425
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"options":{"brute_force_protection":true,"attributes":{"email":{"identifier":{"active":false},"profile_required":true,"signup":{"status":"required","verification":{"active":false}},"verification_method":"link","unique":true},"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":3,"max_length":20,"allowed_types":{"email":false,"phone_number":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_4C81DhA8yZfv0VA8
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_4C81DhA8yZfv0VA8","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":true,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 387.839833ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_4C81DhA8yZfv0VA8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_4C81DhA8yZfv0VA8","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":true,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 337.967ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_4C81DhA8yZfv0VA8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_4C81DhA8yZfv0VA8","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":true,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 386.237083ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_4C81DhA8yZfv0VA8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_4C81DhA8yZfv0VA8","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":true,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 364.046291ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_4C81DhA8yZfv0VA8
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_4C81DhA8yZfv0VA8","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":true,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionAddEmailAttributeUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 368.339375ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_4C81DhA8yZfv0VA8
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-08-07T10:52:13.031Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 352.535458ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrEmailNonUnique.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrEmailNonUnique.yaml
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"mfa":{"active":true,"return_enroll_settings":true},"enabledDatabaseCustomization":true,"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"attributes":{"email":{"identifier":{"active":false},"profile_required":true,"signup":{"status":"required","verification":{"active":false}},"verification_method":"link","unique":false},"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":3,"max_length":20,"allowed_types":{"email":false,"phone_number":false}}}},"password_options":{"complexity":{"character_type_rule":"all","identical_characters":"allow","sequential_characters":"allow","max_length_exceeded":"error","min_length":15,"character_types":[]},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]},"history":{"active":false,"size":3},"dictionary":{"active":false,"custom":[],"default":"en_100k"}},"strategy_version":2,"authentication_methods":{"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        body: '{"id":"con_RcViD9PNpmKOOnr0","options":{"mfa":{"active":true,"return_enroll_settings":true},"enabledDatabaseCustomization":true,"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"attributes":{"email":{"identifier":{"active":false},"profile_required":true,"signup":{"status":"required","verification":{"active":false}},"verification_method":"link","unique":false},"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":3,"max_length":20,"allowed_types":{"email":false,"phone_number":false}}}},"password_options":{"complexity":{"character_type_rule":"all","identical_characters":"allow","sequential_characters":"allow","max_length_exceeded":"error","min_length":15,"character_types":[]},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]},"history":{"active":false,"size":3},"dictionary":{"active":false,"custom":[],"default":"en_100k"}},"strategy_version":2,"authentication_methods":{"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 459.647166ms
+        duration: 545.365542ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -53,7 +53,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RcViD9PNpmKOOnr0
         method: GET
       response:
         proto: HTTP/2.0
@@ -63,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        body: '{"id":"con_RcViD9PNpmKOOnr0","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 289.62525ms
+        duration: 360.549625ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,7 +86,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RcViD9PNpmKOOnr0
         method: GET
       response:
         proto: HTTP/2.0
@@ -96,13 +96,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        body: '{"id":"con_RcViD9PNpmKOOnr0","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 287.602542ms
+        duration: 402.266667ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -119,7 +119,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RcViD9PNpmKOOnr0
         method: GET
       response:
         proto: HTTP/2.0
@@ -129,13 +129,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        body: '{"id":"con_RcViD9PNpmKOOnr0","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 390.948084ms
+        duration: 357.348333ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -152,7 +152,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RcViD9PNpmKOOnr0
         method: GET
       response:
         proto: HTTP/2.0
@@ -162,13 +162,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        body: '{"id":"con_RcViD9PNpmKOOnr0","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 366.080292ms
+        duration: 366.512208ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -188,7 +188,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RcViD9PNpmKOOnr0
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -198,13 +198,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        body: '{"id":"con_RcViD9PNpmKOOnr0","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.159667ms
+        duration: 375.792583ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -221,7 +221,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RcViD9PNpmKOOnr0
         method: GET
       response:
         proto: HTTP/2.0
@@ -231,13 +231,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        body: '{"id":"con_RcViD9PNpmKOOnr0","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 288.219667ms
+        duration: 423.03325ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -254,7 +254,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RcViD9PNpmKOOnr0
         method: GET
       response:
         proto: HTTP/2.0
@@ -264,13 +264,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        body: '{"id":"con_RcViD9PNpmKOOnr0","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 341.844667ms
+        duration: 373.588375ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -287,7 +287,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RcViD9PNpmKOOnr0
         method: GET
       response:
         proto: HTTP/2.0
@@ -297,13 +297,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        body: '{"id":"con_RcViD9PNpmKOOnr0","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 287.598084ms
+        duration: 356.88775ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -320,7 +320,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.46.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_RcViD9PNpmKOOnr0
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -330,10 +330,10 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2026-08-06T10:28:44.813Z"}'
+        body: '{"deleted_at":"2026-08-07T10:50:59.229Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 399.151292ms
+        duration: 358.72825ms

--- a/test/data/recordings/TestAccConnectionOptionsAttrEmailNonUnique.yaml
+++ b/test/data/recordings/TestAccConnectionOptionsAttrEmailNonUnique.yaml
@@ -1,0 +1,339 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 624
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","strategy":"auth0","options":{"enabledDatabaseCustomization":true,"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"attributes":{"email":{"identifier":{"active":false},"profile_required":true,"signup":{"status":"required","verification":{"active":false}},"verification_method":"link","unique":false},"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":3,"max_length":20,"allowed_types":{"email":false,"phone_number":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"mfa":{"active":true,"return_enroll_settings":true},"enabledDatabaseCustomization":true,"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"attributes":{"email":{"identifier":{"active":false},"profile_required":true,"signup":{"status":"required","verification":{"active":false}},"verification_method":"link","unique":false},"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":3,"max_length":20,"allowed_types":{"email":false,"phone_number":false}}}},"password_options":{"complexity":{"character_type_rule":"all","identical_characters":"allow","sequential_characters":"allow","max_length_exceeded":"error","min_length":15,"character_types":[]},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]},"history":{"active":false,"size":3},"dictionary":{"active":false,"custom":[],"default":"en_100k"}},"strategy_version":2,"authentication_methods":{"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 459.647166ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 289.62525ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 287.602542ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 390.948084ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"mfa":{"active":true,"return_enroll_settings":true},"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 366.080292ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 540
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"options":{"enabledDatabaseCustomization":true,"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"attributes":{"email":{"identifier":{"active":false},"profile_required":true,"signup":{"status":"required","verification":{"active":false}},"verification_method":"link","unique":false},"username":{"identifier":{"active":true},"profile_required":true,"signup":{"status":"required"},"validation":{"min_length":3,"max_length":20,"allowed_types":{"email":false,"phone_number":false}}}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 324.159667ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 288.219667ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 341.844667ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_u7GdOVuRalIMQ2Na","options":{"attributes":{"email":{"signup":{"status":"required","verification":{"active":false}},"unique":false,"identifier":{"active":false},"profile_required":true,"verification_method":"link"},"username":{"signup":{"status":"required"},"identifier":{"active":true},"validation":{"max_length":20,"min_length":3,"allowed_types":{"email":false,"phone_number":false}},"profile_required":true}},"customScripts":{"login":"function login(email, password, callback) { /* updated */ callback(null, {}); }"},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true,"enabledDatabaseCustomization":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOptionsAttrEmailNonUnique"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 287.598084ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.46.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_u7GdOVuRalIMQ2Na
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-08-06T10:28:44.813Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 399.151292ms


### PR DESCRIPTION
### 🔧 Changes

Fixes updates on connections with `options.attributes.email.unique = false`, which have been failing with a 400.

The Management API treats a missing `unique` in a PATCH as an assertion of `true`. Making it create-only (#1639) meant every subsequent update to such a connection, even one touching only a login script, read as an attempt to flip the value and was rejected with `cannot patch unique property on email attribute`.


- **`echoEmailAttributeUnique`**: sends the stored value back on update, so unrelated changes apply cleanly. No additional API calls are made and it reuses the `Connection.Read`
- **`validateConnection`**:  rejects an actual change to `unique` at plan time via `CustomizeDiff`.  This shall prevent users from modifying this property once connection is created.

The `unique` schema description now documents that it cannot be changed after create.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📚 References
#1639 
#1646


### 🔬 Testing
Manually tests both POST/PATCH flows and also added relevant test-cases covered under `TestAccConnectionOptionsAttrEmailNonUnique`

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
