### PR TITLE
Add Changelog for v1.54.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## v1.54.1
 
 BUG FIXES:
 - `resource/auth0_connection` – Fix updates failing with `cannot patch unique property on email attribute` on `auth0` connections whose `options.attributes.email.unique` is `false`. The Management API reads a missing `unique` as `true`, so any change to an unrelated option was rejected ([#1669](https://github.com/auth0/terraform-provider-auth0/pull/1669))


### PR DESCRIPTION
BUG FIXES:
- `resource/auth0_connection` – Fix updates failing with `cannot patch unique property on email attribute` on `auth0` connections whose `options.attributes.email.unique` is `false`. The Management API reads a missing `unique` as `true`, so any change to an unrelated option was rejected ([#1669](https://github.com/auth0/terraform-provider-auth0/pull/1669))
