### PR TITLE
fix: Set OrgId and ConnID as ForceNew

### DIFF
--- a/internal/auth0/organization/resource_connection.go
+++ b/internal/auth0/organization/resource_connection.go
@@ -27,11 +27,13 @@ func NewConnectionResource() *schema.Resource {
 			"organization_id": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The ID of the organization to enable the connection for.",
 			},
 			"connection_id": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The ID of the connection to enable for the organization.",
 			},
 			"assign_membership_on_login": {


### PR DESCRIPTION

### 🔧 Changes

`auth0_organization_connection` did not mark its identity fields as `ForceNew`. Both `organization_id` and `connection_id` form the resource's composite ID (`<org_id>::<connection_id>`), and the Management API has no operation to move an enablement from one connection to another; it can only be created or deleted.

As a result, changing `connection_id` planned as an in-place update and called `PATCH /organizations/{org}/connections/{new_id}` for a connection that was never enabled on the organization, which fails with 404

Add `ForceNew: true` to `organization_id` and `connection_id` so a change to either plans as destroy-and-create

### 📚 References
#1680 

### 🔬 Testing

Manually tested that the link is destroyed and recreated between new ConnId and OrgId


### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
