### PR TITLE
feat: add hide_client_secret option to connection data source

### DIFF
--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -28,6 +28,7 @@ data "auth0_connection" "some-connection-by-id" {
 ### Optional
 
 - `connection_id` (String) The ID of the connection. If not provided, `name` must be set.
+- `hide_client_secret` (Boolean) Set this to avoid persisting the sensitive `options.client_secret` value in state; it will be stored as an empty string.
 - `name` (String) The name of the connection. If not provided, `connection_id` must be set.
 - `skip_enabled_clients` (Boolean) Whether to skip enabled clients for this connection. Setting this to `true` will skip additional paginated API calls to /api/v2/connections/{id}/clients. Default: `false`.
 

--- a/internal/auth0/connection/data_source.go
+++ b/internal/auth0/connection/data_source.go
@@ -51,6 +51,13 @@ func dataSourceSchema() map[string]*schema.Schema {
 			"Skips populating if `skip_enabled_clients` is `true`.",
 	}
 
+	dataSourceSchema["hide_client_secret"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Description: "Set this to avoid persisting the sensitive `options.client_secret` value in state; " +
+			"it will be stored as an empty string.",
+	}
+
 	return dataSourceSchema
 }
 

--- a/internal/auth0/connection/data_source_test.go
+++ b/internal/auth0/connection/data_source_test.go
@@ -105,3 +105,63 @@ func TestAccDataSourceConnection(t *testing.T) {
 		},
 	})
 }
+
+// The github strategy echoes options.client_secret back on read, unlike the google-oauth2
+// fixtures elsewhere, which pass empty credentials to use the Auth0 dev keys.
+const testAccGivenAConnectionWithASecret = `
+resource "auth0_connection" "my_connection" {
+	name     = "Acceptance-Test-Connection-{{.testName}}"
+	strategy = "github"
+
+	options {
+		client_id     = "my-client-id"
+		client_secret = "my-client-secret"
+	}
+}
+`
+
+const testAccDataConnectionConfigShowClientSecret = testAccGivenAConnectionWithASecret + `
+data "auth0_connection" "test" {
+	depends_on = [ auth0_connection.my_connection ]
+
+	connection_id = auth0_connection.my_connection.id
+}
+`
+
+const testAccDataConnectionConfigHideClientSecret = testAccGivenAConnectionWithASecret + `
+data "auth0_connection" "test" {
+	depends_on = [ auth0_connection.my_connection ]
+
+	connection_id      = auth0_connection.my_connection.id
+	hide_client_secret = true
+}
+`
+
+func TestAccDataSourceConnectionHideClientSecret(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				// Unset, the data source still returns the secret: the flag is opt-in.
+				Config: acctest.ParseTestName(testAccDataConnectionConfigShowClientSecret, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.auth0_connection.test", "id"),
+					resource.TestCheckResourceAttr("data.auth0_connection.test", "strategy", "github"),
+					resource.TestCheckResourceAttr("data.auth0_connection.test", "options.0.client_id", "my-client-id"),
+					resource.TestCheckResourceAttr("data.auth0_connection.test", "options.0.client_secret", "my-client-secret"),
+				),
+			},
+			{
+				Config: acctest.ParseTestName(testAccDataConnectionConfigHideClientSecret, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.auth0_connection.test", "id"),
+					resource.TestCheckResourceAttr("data.auth0_connection.test", "hide_client_secret", "true"),
+					resource.TestCheckResourceAttr("data.auth0_connection.test", "options.0.client_secret", ""),
+					resource.TestCheckResourceAttr("data.auth0_connection.test", "strategy", "github"),
+					resource.TestCheckResourceAttr("data.auth0_connection.test", "options.0.client_id", "my-client-id"),
+					// Only the data source hides it; the resource still manages it.
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.client_secret", "my-client-secret"),
+				),
+			},
+		},
+	})
+}

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -91,6 +91,10 @@ func flattenConnection(data *schema.ResourceData, connection *management.Connect
 func flattenConnectionForDataSource(data *schema.ResourceData, connection *management.Connection, enabledClients *management.ConnectionEnabledClientList) diag.Diagnostics {
 	diags := flattenConnection(data, connection)
 
+	if data.Get("hide_client_secret").(bool) {
+		diags = append(diags, diag.FromErr(hideConnectionOptionsClientSecret(data))...)
+	}
+
 	var clientIDs []string
 	for _, ec := range enabledClients.GetClients() {
 		clientIDs = append(clientIDs, ec.GetClientID())
@@ -100,6 +104,26 @@ func flattenConnectionForDataSource(data *schema.ResourceData, connection *manag
 	diags = append(diags, diag.FromErr(err)...)
 
 	return diags
+}
+
+func hideConnectionOptionsClientSecret(data *schema.ResourceData) error {
+	rawOptions, ok := data.Get("options").([]interface{})
+	if !ok || len(rawOptions) == 0 {
+		return nil
+	}
+
+	options, ok := rawOptions[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	if _, ok := options["client_secret"]; !ok {
+		return nil
+	}
+
+	options["client_secret"] = ""
+
+	return data.Set("options", rawOptions)
 }
 
 func flattenConnectionAuthentication(authentication *management.Authentication) []interface{} {

--- a/internal/auth0/connection/flatten_test.go
+++ b/internal/auth0/connection/flatten_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/auth0/go-auth0"
 	"github.com/auth0/go-auth0/management"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -128,5 +129,130 @@ func TestFlattenConnectionCrossAppAccessResourceApp(t *testing.T) {
 		flat, ok := result[0].(map[string]interface{})
 		assert.True(t, ok, "expected result[0] to be a map[string]interface{}")
 		assert.Equal(t, "disabled", flat["status"])
+	})
+}
+
+// flattenedOptions reads back the single options block written to state.
+func flattenedOptions(t *testing.T, data *schema.ResourceData) map[string]interface{} {
+	t.Helper()
+
+	rawOptions, ok := data.Get("options").([]interface{})
+	assert.True(t, ok, "expected options to be a []interface{}")
+	assert.Len(t, rawOptions, 1)
+
+	options, ok := rawOptions[0].(map[string]interface{})
+	assert.True(t, ok, "expected options[0] to be a map[string]interface{}")
+
+	return options
+}
+
+func TestHideConnectionOptionsClientSecret(t *testing.T) {
+	t.Run("blanks client_secret but keeps the rest of options", func(t *testing.T) {
+		data := NewDataSource().TestResourceData()
+		assert.NoError(t, data.Set("hide_client_secret", true))
+
+		diags := flattenConnectionForDataSource(data, &management.Connection{
+			Name:     auth0.String("my-google"),
+			Strategy: auth0.String("google-oauth2"),
+			Options: &management.ConnectionOptionsGoogleOAuth2{
+				ClientID:     auth0.String("my-client-id"),
+				ClientSecret: auth0.String("my-client-secret"),
+			},
+		}, nil)
+		assert.False(t, diags.HasError())
+
+		options := flattenedOptions(t, data)
+		assert.Empty(t, options["client_secret"])
+		assert.Equal(t, "my-client-id", options["client_id"])
+		assert.Equal(t, "my-google", data.Get("name"))
+	})
+
+	t.Run("leaves client_secret untouched when hide_client_secret is unset", func(t *testing.T) {
+		data := NewDataSource().TestResourceData()
+
+		diags := flattenConnectionForDataSource(data, &management.Connection{
+			Name:     auth0.String("my-google"),
+			Strategy: auth0.String("google-oauth2"),
+			Options: &management.ConnectionOptionsGoogleOAuth2{
+				ClientSecret: auth0.String("my-client-secret"),
+			},
+		}, nil)
+		assert.False(t, diags.HasError())
+
+		assert.Equal(t, "my-client-secret", flattenedOptions(t, data)["client_secret"])
+	})
+
+	t.Run("leaves the other option secrets alone, they are out of scope for now", func(t *testing.T) {
+		data := NewDataSource().TestResourceData()
+		assert.NoError(t, data.Set("hide_client_secret", true))
+
+		diags := flattenConnectionForDataSource(data, &management.Connection{
+			Name:     auth0.String("my-sms"),
+			Strategy: auth0.String("sms"),
+			Options: &management.ConnectionOptionsSMS{
+				TwilioToken: auth0.String("my-twilio-token"),
+				GatewayAuthentication: &management.ConnectionGatewayAuthentication{
+					Secret: auth0.String("my-gateway-secret"),
+				},
+			},
+		}, nil)
+		assert.False(t, diags.HasError())
+
+		options := flattenedOptions(t, data)
+		assert.Equal(t, "my-twilio-token", options["twilio_token"])
+
+		gateway, ok := options["gateway_authentication"].([]interface{})
+		assert.True(t, ok, "expected gateway_authentication to be a []interface{}")
+		assert.Len(t, gateway, 1)
+
+		gatewayMap, ok := gateway[0].(map[string]interface{})
+		assert.True(t, ok, "expected gateway_authentication[0] to be a map[string]interface{}")
+		assert.Equal(t, "my-gateway-secret", gatewayMap["secret"])
+	})
+
+	t.Run("is a no-op for a strategy whose options carry no client_secret", func(t *testing.T) {
+		data := NewDataSource().TestResourceData()
+		assert.NoError(t, data.Set("hide_client_secret", true))
+
+		diags := flattenConnectionForDataSource(data, &management.Connection{
+			Name:     auth0.String("my-sms"),
+			Strategy: auth0.String("sms"),
+			Options: &management.ConnectionOptionsSMS{
+				TwilioSID: auth0.String("my-twilio-sid"),
+			},
+		}, nil)
+		assert.False(t, diags.HasError())
+
+		assert.Equal(t, "my-twilio-sid", flattenedOptions(t, data)["twilio_sid"])
+	})
+
+	t.Run("tolerates a connection with no options at all", func(t *testing.T) {
+		data := NewDataSource().TestResourceData()
+		assert.NoError(t, data.Set("hide_client_secret", true))
+
+		diags := flattenConnectionForDataSource(data, &management.Connection{
+			Name:     auth0.String("my-connection"),
+			Strategy: auth0.String("auth0"),
+		}, nil)
+
+		assert.False(t, diags.HasError())
+	})
+
+	// The resource needs the secret in state to manage it.
+	t.Run("leaves the resource path untouched", func(t *testing.T) {
+		data := NewResource().TestResourceData()
+		assert.Nil(t, data.Get("hide_client_secret"))
+
+		diags := flattenConnection(data, &management.Connection{
+			Name:     auth0.String("my-github"),
+			Strategy: auth0.String("github"),
+			Options: &management.ConnectionOptionsGitHub{
+				ClientID:     auth0.String("my-client-id"),
+				ClientSecret: auth0.String("my-client-secret"),
+			},
+		})
+		assert.False(t, diags.HasError())
+
+		assert.Equal(t, "my-client-secret", flattenedOptions(t, data)["client_secret"])
 	})
 }

--- a/test/data/recordings/TestAccDataSourceConnectionHideClientSecret.yaml
+++ b/test/data/recordings/TestAccDataSourceConnectionHideClientSecret.yaml
@@ -1,0 +1,600 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 176
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","strategy":"github","options":{"client_id":"my-client-id","client_secret":"my-client-secret"}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 419
+        uncompressed: false
+        body: '{"id":"con_LHPcV4aRX6MBogUW","options":{"client_id":"my-client-id","client_secret":"my-client-secret","scope":[]},"strategy":"github","name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 460.657292ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_LHPcV4aRX6MBogUW","options":{"scope":[],"client_id":"my-client-id","client_secret":"my-client-secret"},"strategy":"github","name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 379.970625ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_LHPcV4aRX6MBogUW","options":{"scope":[],"client_id":"my-client-id","client_secret":"my-client-secret"},"strategy":"github","name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 381.875375ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW/clients
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"clients":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 387.776625ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_LHPcV4aRX6MBogUW","options":{"scope":[],"client_id":"my-client-id","client_secret":"my-client-secret"},"strategy":"github","name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 355.735458ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW/clients
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"clients":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 359.631084ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_LHPcV4aRX6MBogUW","options":{"scope":[],"client_id":"my-client-id","client_secret":"my-client-secret"},"strategy":"github","name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 337.52125ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_LHPcV4aRX6MBogUW","options":{"scope":[],"client_id":"my-client-id","client_secret":"my-client-secret"},"strategy":"github","name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 343.520667ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW/clients
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"clients":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 366.142875ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_LHPcV4aRX6MBogUW","options":{"scope":[],"client_id":"my-client-id","client_secret":"my-client-secret"},"strategy":"github","name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 730.204125ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_LHPcV4aRX6MBogUW","options":{"scope":[],"client_id":"my-client-id","client_secret":"my-client-secret"},"strategy":"github","name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 349.72775ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW/clients
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"clients":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 342.805958ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_LHPcV4aRX6MBogUW","options":{"scope":[],"client_id":"my-client-id","client_secret":"my-client-secret"},"strategy":"github","name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 363.466875ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW/clients
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"clients":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 339.613375ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_LHPcV4aRX6MBogUW","options":{"scope":[],"client_id":"my-client-id","client_secret":"my-client-secret"},"strategy":"github","name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 349.503375ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_LHPcV4aRX6MBogUW","options":{"scope":[],"client_id":"my-client-id","client_secret":"my-client-secret"},"strategy":"github","name":"Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccDataSourceConnectionHideClientSecret"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 399.406417ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW/clients
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 14
+        uncompressed: false
+        body: '{"clients":[]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 348.809417ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.47.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_LHPcV4aRX6MBogUW
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-08-24T14:44:19.004Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 357.744125ms


### PR DESCRIPTION
### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds an optional `hide_client_secret` boolean to the `auth0_connection` data source.

When set to `true`, the data source blanks `options.client_secret` (stores it as an empty string) instead of persisting the sensitive value in Terraform state. The flag is opt-in: left unset, the data source returns the secret as before, so existing configurations are unaffected.

```hcl
data "auth0_connection" "my_connection" {
  connection_id      = auth0_connection.my_connection.id
  hide_client_secret = true
}
```

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- Closes #1682

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Adds an acceptance test asserting the data source returns `options.client_secret` by default and blanks it when `hide_client_secret` is `true`, while the managing resource keeps the secret.
- Adds unit tests covering the happy path, the opt-out default, strategies with no `client_secret`, connections with no options at all, and that other option secrets and the resource path stay untouched.

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
