### PR TITLE
feat: add write-only options_client_secret_wo to connection

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -13,6 +13,12 @@ creation of multiple connections per strategy, the additional connections may no
 
 ~> When updating the `options` parameter, ensure that all nested fields within the `options` schema are explicitly defined. Failing to do so may result in the loss of existing configurations.
 
+~> When `options_client_secret_wo` (write-only) is set, `terraform plan -refresh=false` may report a
+non-empty plan for unrelated optional `options` fields (e.g. `+ scripts = {}`). This is an upstream
+limitation of the Terraform Plugin SDK ([hashicorp/terraform-plugin-sdk#1612](https://github.com/hashicorp/terraform-plugin-sdk/issues/1612))
+that only surfaces without a refresh; a normal `terraform plan`/`apply` (which refreshes) is
+unaffected and idempotent.
+
 ## Example Usage
 
 ### Auth0 Connection
@@ -97,6 +103,32 @@ resource "auth0_connection" "my_connection" {
       local_enrollment_enabled       = true
       progressive_enrollment_enabled = true
     }
+  }
+}
+
+# The strategy's client secret can be set as a write-only argument so it is never persisted to
+# Terraform state. It can be sourced from an ephemeral value (e.g. a secrets manager) and is
+# mutually exclusive with `options.client_secret`. Bump `options_client_secret_wo_version` to
+# rotate the secret.
+#
+# NOTE: Write-only arguments require Terraform 1.11 or later.
+resource "auth0_connection" "my_connection_write_only_secret" {
+  name     = "Example-Connection-Write-Only-Secret"
+  strategy = "oidc"
+
+  options_client_secret_wo         = var.connection_client_secret # can be an ephemeral value
+  options_client_secret_wo_version = 1
+
+  options {
+    client_id              = "1234567"
+    type                   = "back_channel"
+    issuer                 = "https://www.paypalobjects.com"
+    jwks_uri               = "https://api.paypal.com/v1/oauth2/certs"
+    discovery_url          = "https://www.paypalobjects.com/.well-known/openid-configuration"
+    token_endpoint         = "https://api.paypal.com/v1/oauth2/token"
+    userinfo_endpoint      = "https://api.paypal.com/v1/oauth2/token/userinfo"
+    authorization_endpoint = "https://www.paypal.com/signin/authorize"
+    scopes                 = ["openid", "email"]
   }
 }
 ```
@@ -680,6 +712,8 @@ resource "auth0_connection" "okta" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `authentication` (Block List, Max: 1) Configure the purpose of a connection to be used for authentication during login.**Note:** Once configured, removing this block from your configuration is a no-op and will not disable the purpose on the connection; set `active` to `false` explicitly to deactivate it. (see [below for nested schema](#nestedblock--authentication))
 - `connected_accounts` (Block List, Max: 1) Configure the purpose of a connection to be used for connected accounts and Token Vault.**Note:** Once configured, removing this block from your configuration is a no-op and will not disable the purpose on the connection; set `active` to `false` explicitly to deactivate it. (see [below for nested schema](#nestedblock--connected_accounts))
 - `cross_app_access_requesting_app` (Block List, Max: 1) Configure the purpose of a connection to be used as a requesting application authorization server for Cross-App Access (XAA). This is an Early Access feature and requires the `token_vault_xaa` flag to be enabled on your tenant. Only supported on `oidc` and `okta` strategy connections. **Note:** Once configured, removing this block from your configuration is a no-op and will not disable the purpose on the connection; set `active` to `false` explicitly to deactivate it. (EA Only) (see [below for nested schema](#nestedblock--cross_app_access_requesting_app))
@@ -688,6 +722,8 @@ resource "auth0_connection" "okta" {
 - `is_domain_connection` (Boolean) Indicates whether the connection is domain level.
 - `metadata` (Map of String) Metadata associated with the connection, in the form of a map of string values (max 255 chars).
 - `options` (Block List, Max: 1) Configuration settings for connection options. (see [below for nested schema](#nestedblock--options))
+- `options_client_secret_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The strategy's client secret (write-only). This value is **not** stored in Terraform state and can be sourced from an ephemeral value. Bump `options_client_secret_wo_version` to rotate it. Conflicts with `options.client_secret`.
+- `options_client_secret_wo_version` (Number) Version counter for `options_client_secret_wo`, required whenever the write-only secret is set. Must be a positive integer starting at `1`. This value signals rotation intent, though the secret is resent even for other config updates.
 - `realms` (List of String) Defines the realms for which the connection will be used (e.g., email domains). If not specified, the connection name is added as the realm.
 - `show_as_button` (Boolean) Display connection as a button. Only available on enterprise connections.
 
@@ -745,7 +781,7 @@ Optional:
 - `authorization_endpoint` (String) Authorization endpoint.
 - `brute_force_protection` (Boolean) Indicates whether to enable brute force protection, which will limit the number of signups and failed logins from a suspicious IP address.
 - `client_id` (String) The strategy's client ID.
-- `client_secret` (String, Sensitive) The strategy's client secret.
+- `client_secret` (String, Sensitive) The strategy's client secret. **Note:** For better security, consider using `options_client_secret_wo` instead to avoid storing the secret in Terraform state.
 - `community_base_url` (String) Salesforce community base URL.
 - `configuration` (Map of String, Sensitive) A case-sensitive map of key value pairs used as configuration variables for the `custom_script`.
 - `connection_settings` (Block List, Max: 1) Proof Key for Code Exchange (PKCE) configuration settings for an OIDC or Okta Workforce connection. (see [below for nested schema](#nestedblock--options--connection_settings))

--- a/examples/resources/auth0_connection/resource.tf
+++ b/examples/resources/auth0_connection/resource.tf
@@ -79,3 +79,29 @@ resource "auth0_connection" "my_connection" {
     }
   }
 }
+
+# The strategy's client secret can be set as a write-only argument so it is never persisted to
+# Terraform state. It can be sourced from an ephemeral value (e.g. a secrets manager) and is
+# mutually exclusive with `options.client_secret`. Bump `options_client_secret_wo_version` to
+# rotate the secret.
+#
+# NOTE: Write-only arguments require Terraform 1.11 or later.
+resource "auth0_connection" "my_connection_write_only_secret" {
+  name     = "Example-Connection-Write-Only-Secret"
+  strategy = "oidc"
+
+  options_client_secret_wo         = var.connection_client_secret # can be an ephemeral value
+  options_client_secret_wo_version = 1
+
+  options {
+    client_id              = "1234567"
+    type                   = "back_channel"
+    issuer                 = "https://www.paypalobjects.com"
+    jwks_uri               = "https://api.paypal.com/v1/oauth2/certs"
+    discovery_url          = "https://www.paypalobjects.com/.well-known/openid-configuration"
+    token_endpoint         = "https://api.paypal.com/v1/oauth2/token"
+    userinfo_endpoint      = "https://api.paypal.com/v1/oauth2/token/userinfo"
+    authorization_endpoint = "https://www.paypal.com/signin/authorize"
+    scopes                 = ["openid", "email"]
+  }
+}

--- a/internal/auth0/connection/data_source.go
+++ b/internal/auth0/connection/data_source.go
@@ -22,6 +22,12 @@ func NewDataSource() *schema.Resource {
 
 func dataSourceSchema() map[string]*schema.Schema {
 	dataSourceSchema := internalSchema.TransformResourceToDataSource(internalSchema.Clone(NewResource().Schema))
+
+	// Write-only arguments are input-only and never read back, so they add no value on a data
+	// source. Drop them from the derived schema.
+	delete(dataSourceSchema, "options_client_secret_wo")
+	delete(dataSourceSchema, "options_client_secret_wo_version")
+
 	dataSourceSchema["connection_id"] = &schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -273,10 +273,23 @@ func expandConnectionOptions(data *schema.ResourceData, strategy string) (interf
 	return connectionOptions, diagnostics
 }
 
+// clientSecretForOptions returns the write-only client secret value when set;
+// otherwise, it falls back to the legacy nested options.client_secret.
+// It is read from the full raw config. The secret is resent on every
+// apply (not only when the version changes), because the connection PATCH
+// replaces options wholesale; omitting it would wipe the stored secret.
+func clientSecretForOptions(data *schema.ResourceData, config cty.Value) *string {
+	if writeOnly := data.GetRawConfig().GetAttr("options_client_secret_wo"); !writeOnly.IsNull() {
+		return value.String(writeOnly)
+	}
+
+	return value.String(config.GetAttr("client_secret"))
+}
+
 func expandConnectionOptionsGitHub(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsGitHub{
 		ClientID:           value.String(config.GetAttr("client_id")),
-		ClientSecret:       value.String(config.GetAttr("client_secret")),
+		ClientSecret:       clientSecretForOptions(data, config),
 		SetUserAttributes:  value.String(config.GetAttr("set_user_root_attributes")),
 		NonPersistentAttrs: value.Strings(config.GetAttr("non_persistent_attrs")),
 	}
@@ -780,7 +793,7 @@ func expandPasswordOptionsDictionary(config cty.Value) *management.PasswordOptio
 func expandConnectionOptionsGoogleOAuth2(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsGoogleOAuth2{
 		ClientID:           value.String(config.GetAttr("client_id")),
-		ClientSecret:       value.String(config.GetAttr("client_secret")),
+		ClientSecret:       clientSecretForOptions(data, config),
 		AllowedAudiences:   value.Strings(config.GetAttr("allowed_audiences")),
 		SetUserAttributes:  value.String(config.GetAttr("set_user_root_attributes")),
 		NonPersistentAttrs: value.Strings(config.GetAttr("non_persistent_attrs")),
@@ -797,7 +810,7 @@ func expandConnectionOptionsGoogleOAuth2(data *schema.ResourceData, config cty.V
 func expandConnectionOptionsGoogleApps(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsGoogleApps{
 		ClientID:           value.String(config.GetAttr("client_id")),
-		ClientSecret:       value.String(config.GetAttr("client_secret")),
+		ClientSecret:       clientSecretForOptions(data, config),
 		Domain:             value.String(config.GetAttr("domain")),
 		TenantDomain:       value.String(config.GetAttr("tenant_domain")),
 		EnableUsersAPI:     value.Bool(config.GetAttr("api_enable_users")),
@@ -827,7 +840,7 @@ func expandConnectionOptionsGoogleApps(data *schema.ResourceData, config cty.Val
 func expandConnectionOptionsOAuth2(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsOAuth2{
 		ClientID:           value.String(config.GetAttr("client_id")),
-		ClientSecret:       value.String(config.GetAttr("client_secret")),
+		ClientSecret:       clientSecretForOptions(data, config),
 		AuthorizationURL:   value.String(config.GetAttr("authorization_endpoint")),
 		TokenURL:           value.String(config.GetAttr("token_endpoint")),
 		SetUserAttributes:  value.String(config.GetAttr("set_user_root_attributes")),
@@ -868,7 +881,7 @@ func expandConnectionOptionsOAuth2(data *schema.ResourceData, config cty.Value) 
 func expandConnectionOptionsFacebook(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsFacebook{
 		ClientID:           value.String(config.GetAttr("client_id")),
-		ClientSecret:       value.String(config.GetAttr("client_secret")),
+		ClientSecret:       clientSecretForOptions(data, config),
 		SetUserAttributes:  value.String(config.GetAttr("set_user_root_attributes")),
 		NonPersistentAttrs: value.Strings(config.GetAttr("non_persistent_attrs")),
 	}
@@ -884,7 +897,7 @@ func expandConnectionOptionsFacebook(data *schema.ResourceData, config cty.Value
 func expandConnectionOptionsApple(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsApple{
 		ClientID:           value.String(config.GetAttr("client_id")),
-		ClientSecret:       value.String(config.GetAttr("client_secret")),
+		ClientSecret:       clientSecretForOptions(data, config),
 		TeamID:             value.String(config.GetAttr("team_id")),
 		KeyID:              value.String(config.GetAttr("key_id")),
 		SetUserAttributes:  value.String(config.GetAttr("set_user_root_attributes")),
@@ -902,7 +915,7 @@ func expandConnectionOptionsApple(data *schema.ResourceData, config cty.Value) (
 func expandConnectionOptionsLinkedin(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsLinkedin{
 		ClientID:           value.String(config.GetAttr("client_id")),
-		ClientSecret:       value.String(config.GetAttr("client_secret")),
+		ClientSecret:       clientSecretForOptions(data, config),
 		StrategyVersion:    value.Int(config.GetAttr("strategy_version")),
 		SetUserAttributes:  value.String(config.GetAttr("set_user_root_attributes")),
 		NonPersistentAttrs: value.Strings(config.GetAttr("non_persistent_attrs")),
@@ -919,7 +932,7 @@ func expandConnectionOptionsLinkedin(data *schema.ResourceData, config cty.Value
 func expandConnectionOptionsSalesforce(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsSalesforce{
 		ClientID:           value.String(config.GetAttr("client_id")),
-		ClientSecret:       value.String(config.GetAttr("client_secret")),
+		ClientSecret:       clientSecretForOptions(data, config),
 		CommunityBaseURL:   value.String(config.GetAttr("community_base_url")),
 		SetUserAttributes:  value.String(config.GetAttr("set_user_root_attributes")),
 		NonPersistentAttrs: value.Strings(config.GetAttr("non_persistent_attrs")),
@@ -936,7 +949,7 @@ func expandConnectionOptionsSalesforce(data *schema.ResourceData, config cty.Val
 func expandConnectionOptionsWindowsLive(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsWindowsLive{
 		ClientID:           value.String(config.GetAttr("client_id")),
-		ClientSecret:       value.String(config.GetAttr("client_secret")),
+		ClientSecret:       clientSecretForOptions(data, config),
 		StrategyVersion:    value.Int(config.GetAttr("strategy_version")),
 		SetUserAttributes:  value.String(config.GetAttr("set_user_root_attributes")),
 		NonPersistentAttrs: value.Strings(config.GetAttr("non_persistent_attrs")),
@@ -1056,7 +1069,7 @@ func expandConnectionOptionsAD(_ *schema.ResourceData, config cty.Value) (interf
 func expandConnectionOptionsAzureAD(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsAzureAD{
 		ClientID:            value.String(config.GetAttr("client_id")),
-		ClientSecret:        value.String(config.GetAttr("client_secret")),
+		ClientSecret:        clientSecretForOptions(data, config),
 		AppID:               value.String(config.GetAttr("app_id")),
 		Domain:              value.String(config.GetAttr("domain")),
 		DomainAliases:       value.Strings(config.GetAttr("domain_aliases")),
@@ -1090,7 +1103,7 @@ func expandConnectionOptionsAzureAD(data *schema.ResourceData, config cty.Value)
 func expandConnectionOptionsOIDC(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsOIDC{
 		ClientID:                      value.String(config.GetAttr("client_id")),
-		ClientSecret:                  value.String(config.GetAttr("client_secret")),
+		ClientSecret:                  clientSecretForOptions(data, config),
 		TenantDomain:                  value.String(config.GetAttr("tenant_domain")),
 		DomainAliases:                 value.Strings(config.GetAttr("domain_aliases")),
 		LogoURL:                       value.String(config.GetAttr("icon_url")),
@@ -1157,7 +1170,7 @@ func expandConnectionOptionsOIDC(data *schema.ResourceData, config cty.Value) (i
 func expandConnectionOptionsOkta(data *schema.ResourceData, config cty.Value) (interface{}, diag.Diagnostics) {
 	options := &management.ConnectionOptionsOkta{
 		ClientID:                      value.String(config.GetAttr("client_id")),
-		ClientSecret:                  value.String(config.GetAttr("client_secret")),
+		ClientSecret:                  clientSecretForOptions(data, config),
 		Domain:                        value.String(config.GetAttr("domain")),
 		DomainAliases:                 value.Strings(config.GetAttr("domain_aliases")),
 		AuthorizationEndpoint:         value.String(config.GetAttr("authorization_endpoint")),

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -91,6 +91,14 @@ func flattenConnection(data *schema.ResourceData, connection *management.Connect
 		return diags
 	}
 
+	// On the write-only path, blank the API-echoed secret before setting state so it never
+	// lands in the legacy options.client_secret mirror, and persist the version.
+	usingWriteOnlySecret := false
+	if _, ok := data.GetOk("options_client_secret_wo_version"); ok {
+		usingWriteOnlySecret = true
+		blankClientSecretInOptions(connectionOptions)
+	}
+
 	result := multierror.Append(
 		data.Set("name", connection.GetName()),
 		data.Set("display_name", connection.GetDisplayName()),
@@ -109,7 +117,27 @@ func flattenConnection(data *schema.ResourceData, connection *management.Connect
 		result = multierror.Append(result, data.Set("show_as_button", connection.GetShowAsButton()))
 	}
 
+	if usingWriteOnlySecret {
+		result = multierror.Append(result, data.Set("options_client_secret_wo_version", data.Get("options_client_secret_wo_version")))
+	}
+
 	return diag.FromErr(result.ErrorOrNil())
+}
+
+// blankClientSecretInOptions empties options[0].client_secret in a flattened options list.
+func blankClientSecretInOptions(connectionOptions []interface{}) {
+	if len(connectionOptions) == 0 {
+		return
+	}
+
+	options, ok := connectionOptions[0].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	if _, ok := options["client_secret"]; ok {
+		options["client_secret"] = ""
+	}
 }
 
 func flattenConnectionForDataSource(data *schema.ResourceData, connection *management.Connection, enabledClients *management.ConnectionEnabledClientList) diag.Diagnostics {

--- a/internal/auth0/connection/flatten_test.go
+++ b/internal/auth0/connection/flatten_test.go
@@ -383,3 +383,63 @@ func TestHideConnectionOptionsClientSecret(t *testing.T) {
 		assert.Equal(t, "my-client-secret", flattenedOptions(t, data)["client_secret"])
 	})
 }
+
+func TestBlankClientSecretInOptions(t *testing.T) {
+	t.Run("blanks client_secret when present", func(t *testing.T) {
+		options := []interface{}{map[string]interface{}{
+			"client_id":     "cid",
+			"client_secret": "the-secret",
+		}}
+		blankClientSecretInOptions(options)
+		assert.Equal(t, "", options[0].(map[string]interface{})["client_secret"])
+		assert.Equal(t, "cid", options[0].(map[string]interface{})["client_id"])
+	})
+
+	t.Run("is a no-op when client_secret is absent", func(t *testing.T) {
+		options := []interface{}{map[string]interface{}{"client_id": "cid"}}
+		blankClientSecretInOptions(options)
+		_, present := options[0].(map[string]interface{})["client_secret"]
+		assert.False(t, present)
+	})
+
+	t.Run("is a no-op on an empty options list", func(t *testing.T) {
+		assert.NotPanics(t, func() { blankClientSecretInOptions(nil) })
+		assert.NotPanics(t, func() { blankClientSecretInOptions([]interface{}{}) })
+	})
+}
+
+func TestFlattenConnectionWriteOnlyClientSecret(t *testing.T) {
+	newConnection := func() *management.Connection {
+		return &management.Connection{
+			Name:     auth0.String("my-oidc"),
+			Strategy: auth0.String("oidc"),
+			Options: &management.ConnectionOptionsOIDC{
+				ClientID:     auth0.String("my-client-id"),
+				ClientSecret: auth0.String("secret-echoed-by-api"),
+			},
+		}
+	}
+
+	t.Run("write-only path: blanks the mirrored client_secret and persists the version", func(t *testing.T) {
+		data := NewResource().TestResourceData()
+		assert.NoError(t, data.Set("options_client_secret_wo_version", 1))
+
+		diags := flattenConnection(data, newConnection())
+		assert.False(t, diags.HasError())
+
+		options := flattenedOptions(t, data)
+		assert.Empty(t, options["client_secret"])
+		assert.Equal(t, "my-client-id", options["client_id"])
+		assert.Equal(t, 1, data.Get("options_client_secret_wo_version"))
+	})
+
+	t.Run("legacy path: client_secret is preserved when no write-only version is set", func(t *testing.T) {
+		data := NewResource().TestResourceData()
+
+		diags := flattenConnection(data, newConnection())
+		assert.False(t, diags.HasError())
+
+		options := flattenedOptions(t, data)
+		assert.Equal(t, "secret-echoed-by-api", options["client_secret"])
+	})
+}

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -4193,3 +4193,58 @@ func TestAccConnectionOIDCMetadataOnOkta(t *testing.T) {
 		},
 	})
 }
+
+// TestAccConnectionClientSecretWriteOnlyValidation covers the plan-time schema constraints.
+// Apply/rotation/flatten behaviour is unit-tested; an apply-based test is avoided because the
+// harness's post-apply non-refresh plan trips on terraform-plugin-sdk#1612, which does not
+// affect real usage.
+func TestAccConnectionClientSecretWriteOnlyValidation(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:      acctest.ParseTestName(testAccConnectionClientSecretWOConflicts, t.Name()),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)conflicts with`),
+			},
+			{
+				Config:      acctest.ParseTestName(testAccConnectionClientSecretWOMissingVersion, t.Name()),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`options_client_secret_wo_version`),
+			},
+		},
+	})
+}
+
+const testAccConnectionClientSecretWOConflicts = `
+resource "auth0_connection" "oidc_wo_val" {
+	name     = "Acceptance-Test-OIDC-WO-Val-{{.testName}}"
+	strategy = "oidc"
+
+	options_client_secret_wo         = "wo-secret"
+	options_client_secret_wo_version = 1
+
+	options {
+		client_id     = "123456"
+		client_secret = "legacy-secret"
+		type          = "back_channel"
+		issuer        = "https://api.login.yahoo.com"
+		jwks_uri      = "https://api.login.yahoo.com/openid/v1/certs"
+	}
+}
+`
+
+const testAccConnectionClientSecretWOMissingVersion = `
+resource "auth0_connection" "oidc_wo_val" {
+	name     = "Acceptance-Test-OIDC-WO-Val-{{.testName}}"
+	strategy = "oidc"
+
+	options_client_secret_wo = "wo-secret"
+
+	options {
+		client_id = "123456"
+		type      = "back_channel"
+		issuer    = "https://api.login.yahoo.com"
+		jwks_uri  = "https://api.login.yahoo.com/openid/v1/certs"
+	}
+}
+`

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -92,9 +92,9 @@ var resourceSchema = map[string]*schema.Schema{
 			"`options_client_secret_wo_version` to rotate it. Conflicts with `options.client_secret`.",
 	},
 	"options_client_secret_wo_version": {
-		Type:     schema.TypeInt,
-		Optional: true,
-		RequiredWith:  []string{"options_client_secret_wo"},
+		Type:         schema.TypeInt,
+		Optional:     true,
+		RequiredWith: []string{"options_client_secret_wo"},
 		Description: "Version counter for `options_client_secret_wo`, required whenever the write-only secret is set. " +
 			"Must be a positive integer starting at `1`. This value signals rotation intent, " +
 			"though the secret is resent even for other config updates.",

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -78,6 +78,27 @@ var resourceSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Description: "Display connection as a button. Only available on enterprise connections.",
 	},
+	// The options_client_secret_wo attribute is a sibling of the Computed options block because
+	// the SDK does not allow WriteOnly attributes inside a Computed block.
+	"options_client_secret_wo": {
+		Type:          schema.TypeString,
+		Optional:      true,
+		WriteOnly:     true,
+		Sensitive:     true,
+		ConflictsWith: []string{"options.0.client_secret"},
+		RequiredWith:  []string{"options_client_secret_wo_version"},
+		Description: "The strategy's client secret (write-only). This value is **not** stored in " +
+			"Terraform state and can be sourced from an ephemeral value. Bump " +
+			"`options_client_secret_wo_version` to rotate it. Conflicts with `options.client_secret`.",
+	},
+	"options_client_secret_wo_version": {
+		Type:     schema.TypeInt,
+		Optional: true,
+		RequiredWith:  []string{"options_client_secret_wo"},
+		Description: "Version counter for `options_client_secret_wo`, required whenever the write-only secret is set. " +
+			"Must be a positive integer starting at `1`. This value signals rotation intent, " +
+			"though the secret is resent even for other config updates.",
+	},
 	"options":                         optionsSchema,
 	"authentication":                  authenticationSchema,
 	"connected_accounts":              connectedAccountsSchema,
@@ -426,10 +447,13 @@ var optionsSchema = &schema.Schema{
 				Description: "The strategy's client ID.",
 			},
 			"client_secret": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "The strategy's client secret.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"options_client_secret_wo"},
+				Description: "The strategy's client secret. " +
+					"**Note:** For better security, consider using `options_client_secret_wo` instead " +
+					"to avoid storing the secret in Terraform state.",
 			},
 			"custom_headers": {
 				Type: schema.TypeSet,

--- a/templates/resources/connection.md.tmpl
+++ b/templates/resources/connection.md.tmpl
@@ -13,6 +13,12 @@ creation of multiple connections per strategy, the additional connections may no
 
 ~> When updating the `options` parameter, ensure that all nested fields within the `options` schema are explicitly defined. Failing to do so may result in the loss of existing configurations.
 
+~> When `options_client_secret_wo` (write-only) is set, `terraform plan -refresh=false` may report a
+non-empty plan for unrelated optional `options` fields (e.g. `+ scripts = {}`). This is an upstream
+limitation of the Terraform Plugin SDK ([hashicorp/terraform-plugin-sdk#1612](https://github.com/hashicorp/terraform-plugin-sdk/issues/1612))
+that only surfaces without a refresh; a normal `terraform plan`/`apply` (which refreshes) is
+unaffected and idempotent.
+
 {{ if .HasExample -}}
 
 ## Example Usage

--- a/test/data/recordings/TestAccConnectionClientSecretWriteOnlyValidation.yaml
+++ b/test/data/recordings/TestAccConnectionClientSecretWriteOnlyValidation.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []


### PR DESCRIPTION
### 🔧 Changes

Adds a write-only client secret for connection strategies, keeping secrets out of Terraform state/plan and supporting ephemeral sources (secrets manager, Vault, another resource's write-only output).

- `options_client_secret_wo` and `options_client_secret_wo_version` are top-level siblings of `options`, since the SDK forbids write-only fields inside the Computed block.
- Resent on every apply because PATCH replaces options wholesale.
- Flatten blanks the API-echoed secret on the write-only path, preventing it from appearing in `options.client_secret`.

```hcl
resource "auth0_connection" "my_connection" {
  /* ... */ 

  options_client_secret_wo         = var.connection_client_secret # ephemeral
  options_client_secret_wo_version = 1

  options { client_id = "1234567" /* ... */ }
}
```

### 📚 References

- https://github.com/auth0/terraform-provider-auth0/discussions/1450#discussioncomment-18095293
- [Known terraform plugin SDK caveat](https://github.com/hashicorp/terraform-plugin-sdk/issues/1612): `plan -refresh=false` can show a spurious non-empty plan; a regular plan/apply works as expeted. Documented in the resource.

### 🔬 Testing

- Unit tests cover expand/flatten: the write-only path blanks the echoed secret and persists the version; the legacy path is unchanged.
- Acceptance test asserts the plan-time `ConflictsWith` / `RequiredWith` constraints. An apply-based test is intentionally omitted because the harness's post-apply non-refresh plan trips on [terraform-plugin-sdk#1612](https://github.com/hashicorp/terraform-plugin-sdk/issues/1612), which does not affect real usage.
- Verified end-to-end against a live tenant, including rotation and no-leak (secret absent from state).

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)
