### PR TITLE
feat: add otp_settings to database connection options (EA only)

### DIFF
--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -151,6 +151,7 @@ Read-Only:
 - `name` (String)
 - `non_persistent_attrs` (Set of String)
 - `oidc_metadata` (String)
+- `otp_settings` (List of Object) (see [below for nested schema](#nestedobjatt--options--otp_settings))
 - `passkey_options` (List of Object) (see [below for nested schema](#nestedobjatt--options--passkey_options))
 - `password_complexity_options` (List of Object) (see [below for nested schema](#nestedobjatt--options--password_complexity_options))
 - `password_dictionary` (List of Object) (see [below for nested schema](#nestedobjatt--options--password_dictionary))
@@ -465,6 +466,33 @@ Read-Only:
 
 - `active` (Boolean)
 - `return_enroll_settings` (Boolean)
+
+
+<a id="nestedobjatt--options--otp_settings"></a>
+### Nested Schema for `options.otp_settings`
+
+Read-Only:
+
+- `email` (List of Object) (see [below for nested schema](#nestedobjatt--options--otp_settings--email))
+- `phone` (List of Object) (see [below for nested schema](#nestedobjatt--options--otp_settings--phone))
+
+<a id="nestedobjatt--options--otp_settings--email"></a>
+### Nested Schema for `options.otp_settings.email`
+
+Read-Only:
+
+- `otp_expiry` (Number)
+- `otp_length` (Number)
+
+
+<a id="nestedobjatt--options--otp_settings--phone"></a>
+### Nested Schema for `options.otp_settings.phone`
+
+Read-Only:
+
+- `otp_expiry` (Number)
+- `otp_length` (Number)
+
 
 
 <a id="nestedobjatt--options--passkey_options"></a>

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -798,6 +798,7 @@ Optional:
 - `name` (String) The public name of the email or SMS Connection. In most cases this is the same name as the connection name.
 - `non_persistent_attrs` (Set of String) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the DenyList here.
 - `oidc_metadata` (String) Additional OIDC metadata to include in the discovery document. Only applicable when strategy=oidc, okta, or samlp. On oidc and okta, Auth0 defaults any omitted `claims_parameter_supported`, `request_parameter_supported`, `request_uri_parameter_supported`, `require_request_uri_registration` field to false. Those defaults are not tracked in provider until set to true explisitly. (EA only)
+- `otp_settings` (Block List, Max: 1) One-time password settings for database (`auth0` strategy) connections, configurable per delivery channel. (EA only) (see [below for nested schema](#nestedblock--options--otp_settings))
 - `passkey_options` (Block List, Max: 1) Defines options for the passkey authentication method (see [below for nested schema](#nestedblock--options--passkey_options))
 - `password_complexity_options` (Block List, Max: 1) Configuration settings for password complexity. (see [below for nested schema](#nestedblock--options--password_complexity_options))
 - `password_dictionary` (Block List, Max: 1) Configuration settings for the password dictionary check, which does not allow passwords that are part of the password dictionary. (see [below for nested schema](#nestedblock--options--password_dictionary))
@@ -1115,6 +1116,33 @@ Optional:
 
 - `active` (Boolean) Indicates whether multifactor authentication is enabled for this connection.
 - `return_enroll_settings` (Boolean) Indicates whether multifactor authentication enrollment settings will be returned.
+
+
+<a id="nestedblock--options--otp_settings"></a>
+### Nested Schema for `options.otp_settings`
+
+Optional:
+
+- `email` (Block List, Max: 1) One-time password settings for the email delivery channel. (see [below for nested schema](#nestedblock--options--otp_settings--email))
+- `phone` (Block List, Max: 1) One-time password settings for the phone delivery channel. (see [below for nested schema](#nestedblock--options--otp_settings--phone))
+
+<a id="nestedblock--options--otp_settings--email"></a>
+### Nested Schema for `options.otp_settings.email`
+
+Optional:
+
+- `otp_expiry` (Number) Number of seconds before the one-time password expires. Must be between 60 and 86400. Defaults to 900 if not set.
+- `otp_length` (Number) Number of digits in the generated one-time password. Must be between 4 and 48. Defaults to 6 if not set.
+
+
+<a id="nestedblock--options--otp_settings--phone"></a>
+### Nested Schema for `options.otp_settings.phone`
+
+Optional:
+
+- `otp_expiry` (Number) Number of seconds before the one-time password expires. Must be between 60 and 86400. Defaults to 900 if not set.
+- `otp_length` (Number) Number of digits in the generated one-time password. Must be between 4 and 48. Defaults to 6 if not set.
+
 
 
 <a id="nestedblock--options--passkey_options"></a>

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/PuerkitoBio/rehttp v1.4.0
-	github.com/auth0/go-auth0 v1.48.0
+	github.com/auth0/go-auth0 v1.48.1-0.20260902131740-0e1bef7aa055
 	github.com/auth0/go-auth0/v3 v3.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/auth0/go-auth0 v1.48.0 h1:INqEEZbDEkXVI0xUZluS1zzoB4YbYzvCysHH2CNEGzc=
-github.com/auth0/go-auth0 v1.48.0/go.mod h1:32sQB1uAn+99fJo6N819EniKq8h785p0ag0lMWhiTaE=
+github.com/auth0/go-auth0 v1.48.1-0.20260902131740-0e1bef7aa055 h1:0OapoROSuHjq/PLfu7s3AG4vd5IUwI1xJCCtRQSa5Ng=
+github.com/auth0/go-auth0 v1.48.1-0.20260902131740-0e1bef7aa055/go.mod h1:32sQB1uAn+99fJo6N819EniKq8h785p0ag0lMWhiTaE=
 github.com/auth0/go-auth0/v3 v3.3.0 h1:p/OxyycZNUtFekO6uXGBqrVXtnJ92gO7ikXtVDuT0ZA=
 github.com/auth0/go-auth0/v3 v3.3.0/go.mod h1:wb20iE6T4wCGWtMXAZTWTTxx1/T1aHfVK+dOWleQvlg=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=

--- a/internal/auth0/connection/expand.go
+++ b/internal/auth0/connection/expand.go
@@ -402,6 +402,32 @@ func expandConnectionOptionsAttributes(config cty.Value) *management.ConnectionO
 	return coa
 }
 
+func expandConnectionOptionsOTPSettings(otpConfig cty.Value) *management.ConnectionOptionsOTPSettings {
+	var otpSettings *management.ConnectionOptionsOTPSettings
+	otpConfig.ForEachElement(
+		func(_ cty.Value, settings cty.Value) (stop bool) {
+			otpSettings = &management.ConnectionOptionsOTPSettings{
+				Email: expandConnectionOptionsOTPChannelSettings(settings.GetAttr("email")),
+				Phone: expandConnectionOptionsOTPChannelSettings(settings.GetAttr("phone")),
+			}
+			return stop
+		})
+	return otpSettings
+}
+
+func expandConnectionOptionsOTPChannelSettings(otpChannelConfig cty.Value) *management.ConnectionOptionsOTPChannelSettings {
+	var channel *management.ConnectionOptionsOTPChannelSettings
+	otpChannelConfig.ForEachElement(
+		func(_ cty.Value, settings cty.Value) (stop bool) {
+			channel = &management.ConnectionOptionsOTPChannelSettings{
+				OTPLength: value.Int(settings.GetAttr("otp_length")),
+				OTPExpiry: value.Int(settings.GetAttr("otp_expiry")),
+			}
+			return stop
+		})
+	return channel
+}
+
 func expandConnectionOptionsEmailAttribute(config cty.Value) *management.ConnectionOptionsEmailAttribute {
 	var coea *management.ConnectionOptionsEmailAttribute
 	config.GetAttr("email").ForEachElement(
@@ -569,6 +595,7 @@ func expandConnectionOptionsAuth0(_ *schema.ResourceData, config cty.Value) (int
 		Attributes:                       expandConnectionOptionsAttributes(config.GetAttr("attributes")),
 		StrategyVersion:                  value.Int(config.GetAttr("strategy_version")),
 		RealmFallback:                    value.Bool(config.GetAttr("realm_fallback")),
+		OTPSettings:                      expandConnectionOptionsOTPSettings(config.GetAttr("otp_settings")),
 	}
 
 	if precedence := value.Strings(config.GetAttr("precedence")); precedence != nil && len(*precedence) > 0 {

--- a/internal/auth0/connection/expand_test.go
+++ b/internal/auth0/connection/expand_test.go
@@ -194,6 +194,59 @@ func TestConnectionOptionsTypeOmitsWhenNil(t *testing.T) {
 	})
 }
 
+// The connection PATCH replaces the whole options object, and the API does not
+// materialize otp_settings defaults on read. So the request must omit otp_settings
+// (and any unset channel or sub-field) entirely rather than send zero values.
+func TestConnectionOptionsOTPSettingsOmitsWhenNil(t *testing.T) {
+	t.Run("omits otp_settings when nil", func(t *testing.T) {
+		payload, err := json.Marshal(&management.ConnectionOptions{})
+		assert.NoError(t, err)
+		assert.NotContains(t, string(payload), "otp_settings")
+	})
+
+	t.Run("omits the phone channel when only email is set", func(t *testing.T) {
+		options := &management.ConnectionOptions{
+			OTPSettings: &management.ConnectionOptionsOTPSettings{
+				Email: &management.ConnectionOptionsOTPChannelSettings{
+					OTPLength: auth0.Int(8),
+					OTPExpiry: auth0.Int(600),
+				},
+			},
+		}
+		payload, err := json.Marshal(options)
+		assert.NoError(t, err)
+		assert.Contains(t, string(payload), `"otp_settings":{"email":{"otp_length":8,"otp_expiry":600}}`)
+		assert.NotContains(t, string(payload), "phone")
+	})
+
+	t.Run("omits an unset sub-field within a channel", func(t *testing.T) {
+		options := &management.ConnectionOptions{
+			OTPSettings: &management.ConnectionOptionsOTPSettings{
+				Email: &management.ConnectionOptionsOTPChannelSettings{
+					OTPLength: auth0.Int(7),
+				},
+			},
+		}
+		payload, err := json.Marshal(options)
+		assert.NoError(t, err)
+		assert.Contains(t, string(payload), `"otp_settings":{"email":{"otp_length":7}}`)
+		assert.NotContains(t, string(payload), "otp_expiry")
+	})
+
+	t.Run("includes both channels when set", func(t *testing.T) {
+		options := &management.ConnectionOptions{
+			OTPSettings: &management.ConnectionOptionsOTPSettings{
+				Email: &management.ConnectionOptionsOTPChannelSettings{OTPLength: auth0.Int(8), OTPExpiry: auth0.Int(600)},
+				Phone: &management.ConnectionOptionsOTPChannelSettings{OTPLength: auth0.Int(6), OTPExpiry: auth0.Int(900)},
+			},
+		}
+		payload, err := json.Marshal(options)
+		assert.NoError(t, err)
+		assert.Contains(t, string(payload), `"email":{"otp_length":8,"otp_expiry":600}`)
+		assert.Contains(t, string(payload), `"phone":{"otp_length":6,"otp_expiry":900}`)
+	})
+}
+
 // The API rejects `oidc_metadata: null` with `"metadata_response" must be of type object`,
 // so an unset attribute has to be omitted from the request rather than nulled.
 func TestConnectionOptionsOIDCMetadataOmitsWhenNil(t *testing.T) {

--- a/internal/auth0/connection/flatten.go
+++ b/internal/auth0/connection/flatten.go
@@ -389,6 +389,35 @@ func flattenCustomPasswordHash(customPasswordHash *management.CustomPasswordHash
 	}
 }
 
+func flattenOTPSettings(otpSettings *management.ConnectionOptionsOTPSettings) interface{} {
+	if otpSettings == nil {
+		return nil
+	}
+
+	otpSettingsMap := map[string]interface{}{}
+
+	if otpSettings.Email != nil {
+		otpSettingsMap["email"] = []interface{}{flattenOTPChannelSettings(otpSettings.GetEmail())}
+	}
+
+	if otpSettings.Phone != nil {
+		otpSettingsMap["phone"] = []interface{}{flattenOTPChannelSettings(otpSettings.GetPhone())}
+	}
+
+	return otpSettingsMap
+}
+
+func flattenOTPChannelSettings(channel *management.ConnectionOptionsOTPChannelSettings) interface{} {
+	if channel == nil {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"otp_length": channel.GetOTPLength(),
+		"otp_expiry": channel.GetOTPExpiry(),
+	}
+}
+
 func flattenPasswordOptions(po *management.PasswordOptions) map[string]interface{} {
 	return map[string]interface{}{
 		"complexity":   []interface{}{flattenPasswordOptionsComplexity(po.GetComplexity())},
@@ -608,6 +637,10 @@ func flattenConnectionOptionsAuth0(
 
 	if options.CustomPasswordHash != nil {
 		optionsMap["custom_password_hash"] = []interface{}{flattenCustomPasswordHash(options.GetCustomPasswordHash())}
+	}
+
+	if options.OTPSettings != nil {
+		optionsMap["otp_settings"] = []interface{}{flattenOTPSettings(options.GetOTPSettings())}
 	}
 
 	if options.PasswordOptions != nil {

--- a/internal/auth0/connection/flatten_test.go
+++ b/internal/auth0/connection/flatten_test.go
@@ -54,6 +54,45 @@ func TestFlattenConnectionOptionsEmail(t *testing.T) {
 	}
 }
 
+func TestFlattenOTPSettings(t *testing.T) {
+	t.Run("returns nil when otp_settings is nil", func(t *testing.T) {
+		assert.Nil(t, flattenOTPSettings(nil))
+	})
+
+	t.Run("sets only the channels the API returned", func(t *testing.T) {
+		result := flattenOTPSettings(&management.ConnectionOptionsOTPSettings{
+			Email: &management.ConnectionOptionsOTPChannelSettings{
+				OTPLength: auth0.Int(8),
+				OTPExpiry: auth0.Int(600),
+			},
+		})
+
+		otpSettings, ok := result.(map[string]interface{})
+		assert.True(t, ok)
+		assert.Contains(t, otpSettings, "email")
+		assert.NotContains(t, otpSettings, "phone")
+
+		email := otpSettings["email"].([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, 8, email["otp_length"])
+		assert.Equal(t, 600, email["otp_expiry"])
+	})
+
+	t.Run("flattens both channels when present", func(t *testing.T) {
+		result := flattenOTPSettings(&management.ConnectionOptionsOTPSettings{
+			Email: &management.ConnectionOptionsOTPChannelSettings{OTPLength: auth0.Int(8), OTPExpiry: auth0.Int(600)},
+			Phone: &management.ConnectionOptionsOTPChannelSettings{OTPLength: auth0.Int(6), OTPExpiry: auth0.Int(900)},
+		})
+
+		otpSettings := result.(map[string]interface{})
+		assert.Contains(t, otpSettings, "email")
+		assert.Contains(t, otpSettings, "phone")
+
+		phone := otpSettings["phone"].([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, 6, phone["otp_length"])
+		assert.Equal(t, 900, phone["otp_expiry"])
+	})
+}
+
 func TestFlattenAuthenticationMethodPassword(t *testing.T) {
 	t.Run("nil input returns nil", func(t *testing.T) {
 		result := flattenAuthenticationMethodPassword(nil)

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -4252,7 +4252,7 @@ func TestAccConnectionOTPSettings(t *testing.T) {
 				),
 			},
 			{
-				// otp_settings round-trips through import unchanged.
+				// The otp_settings round-trips through import unchanged.
 				Config:            acctest.ParseTestName(testAccConnectionOTPSettingsBothChannels, t.Name()),
 				ResourceName:      "auth0_connection.my_connection",
 				ImportState:       true,

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -4193,3 +4193,82 @@ func TestAccConnectionOIDCMetadataOnOkta(t *testing.T) {
 		},
 	})
 }
+
+const testAccConnectionOTPSettingsBothChannels = `
+resource "auth0_connection" "my_connection" {
+	name     = "Acceptance-Test-Connection-{{.testName}}"
+	strategy = "auth0"
+	options {
+		otp_settings {
+			email {
+				otp_length = 8
+				otp_expiry = 600
+			}
+			phone {
+				otp_length = 6
+				otp_expiry = 900
+			}
+		}
+	}
+}
+`
+
+const testAccConnectionOTPSettingsEmailOnly = `
+resource "auth0_connection" "my_connection" {
+	name     = "Acceptance-Test-Connection-{{.testName}}"
+	strategy = "auth0"
+	options {
+		otp_settings {
+			email {
+				otp_length = 7
+				otp_expiry = 600
+			}
+		}
+	}
+}
+`
+
+const testAccConnectionOTPSettingsRemoved = `
+resource "auth0_connection" "my_connection" {
+	name     = "Acceptance-Test-Connection-{{.testName}}"
+	strategy = "auth0"
+	options {
+	}
+}
+`
+
+func TestAccConnectionOTPSettings(t *testing.T) {
+	acctest.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ParseTestName(testAccConnectionOTPSettingsBothChannels, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "strategy", "auth0"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.otp_settings.#", "1"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.otp_settings.0.email.0.otp_length", "8"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.otp_settings.0.email.0.otp_expiry", "600"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.otp_settings.0.phone.0.otp_length", "6"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.otp_settings.0.phone.0.otp_expiry", "900"),
+				),
+			},
+			{
+				// Full-replace (F1): dropping the phone channel and changing email
+				// removes phone entirely rather than merging.
+				Config: acctest.ParseTestName(testAccConnectionOTPSettingsEmailOnly, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.otp_settings.#", "1"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.otp_settings.0.email.0.otp_length", "7"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.otp_settings.0.email.0.otp_expiry", "600"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.otp_settings.0.phone.#", "0"),
+				),
+			},
+			{
+				// Removing the block entirely clears otp_settings from options.
+				Config: acctest.ParseTestName(testAccConnectionOTPSettingsRemoved, t.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.otp_settings.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/internal/auth0/connection/resource_test.go
+++ b/internal/auth0/connection/resource_test.go
@@ -4252,6 +4252,13 @@ func TestAccConnectionOTPSettings(t *testing.T) {
 				),
 			},
 			{
+				// otp_settings round-trips through import unchanged.
+				Config:            acctest.ParseTestName(testAccConnectionOTPSettingsBothChannels, t.Name()),
+				ResourceName:      "auth0_connection.my_connection",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				// Full-replace (F1): dropping the phone channel and changing email
 				// removes phone entirely rather than merging.
 				Config: acctest.ParseTestName(testAccConnectionOTPSettingsEmailOnly, t.Name()),

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -639,9 +639,9 @@ var optionsSchema = &schema.Schema{
 				},
 			},
 			"otp_settings": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
 				Description: "One-time password settings for database (`auth0` strategy) connections, " +
 					"configurable per delivery channel. (EA only)",
 				Elem: &schema.Resource{

--- a/internal/auth0/connection/schema.go
+++ b/internal/auth0/connection/schema.go
@@ -638,6 +638,19 @@ var optionsSchema = &schema.Schema{
 					},
 				},
 			},
+			"otp_settings": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "One-time password settings for database (`auth0` strategy) connections, " +
+					"configurable per delivery channel. (EA only)",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email": otpChannelSettingsSchema("email"),
+						"phone": otpChannelSettingsSchema("phone"),
+					},
+				},
+			},
 			"provider": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -1652,6 +1665,36 @@ var optionsSchema = &schema.Schema{
 			},
 		},
 	},
+}
+
+// otpChannelSettingsSchema returns the one-time password settings schema for a
+// single delivery channel (`email` or `phone`) of a database (`auth0` strategy)
+// connection. The channel name is used to populate the block description.
+func otpChannelSettingsSchema(channel string) *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		MaxItems:    1,
+		Optional:    true,
+		Description: "One-time password settings for the " + channel + " delivery channel.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"otp_length": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(4, 48),
+					Description: "Number of digits in the generated one-time password. " +
+						"Must be between 4 and 48. Defaults to 6 if not set.",
+				},
+				"otp_expiry": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(60, 86400),
+					Description: "Number of seconds before the one-time password expires. " +
+						"Must be between 60 and 86400. Defaults to 900 if not set.",
+				},
+			},
+		},
+	}
 }
 
 var authenticationSchema = &schema.Schema{

--- a/test/data/recordings/TestAccConnectionOTPSettings.yaml
+++ b/test/data/recordings/TestAccConnectionOTPSettings.yaml
@@ -1,0 +1,474 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 199
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","strategy":"auth0","options":{"otp_settings":{"email":{"otp_length":8,"otp_expiry":600},"phone":{"otp_length":6,"otp_expiry":900}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_length":8,"otp_expiry":600},"phone":{"otp_length":6,"otp_expiry":900}},"password_options":{"complexity":{"character_type_rule":"all","identical_characters":"allow","sequential_characters":"allow","max_length_exceeded":"error","min_length":15,"character_types":[]},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]},"history":{"active":false,"size":3},"dictionary":{"active":false,"custom":[],"default":"en_100k"}},"strategy_version":2,"authentication_methods":{"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 201 Created
+        code: 201
+        duration: 566.559958ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 324.878625ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 365.445125ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 320.496917ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 392.046958ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 73
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"options":{"otp_settings":{"email":{"otp_length":7,"otp_expiry":600}}}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 369.99775ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 337.895292ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 284.254458ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 290.71275ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 371.810667ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 15
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: |
+            {"options":{}}
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 380.475125ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 315.721333ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 340.3435ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 41
+        uncompressed: false
+        body: '{"deleted_at":"2026-09-02T13:39:07.782Z"}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 202 Accepted
+        code: 202
+        duration: 303.908875ms

--- a/test/data/recordings/TestAccConnectionOTPSettings.yaml
+++ b/test/data/recordings/TestAccConnectionOTPSettings.yaml
@@ -30,13 +30,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_length":8,"otp_expiry":600},"phone":{"otp_length":6,"otp_expiry":900}},"password_options":{"complexity":{"character_type_rule":"all","identical_characters":"allow","sequential_characters":"allow","max_length_exceeded":"error","min_length":15,"character_types":[]},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]},"history":{"active":false,"size":3},"dictionary":{"active":false,"custom":[],"default":"en_100k"}},"strategy_version":2,"authentication_methods":{"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_length":8,"otp_expiry":600},"phone":{"otp_length":6,"otp_expiry":900}},"password_options":{"complexity":{"character_type_rule":"all","identical_characters":"allow","sequential_characters":"allow","max_length_exceeded":"error","min_length":15,"character_types":[]},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]},"history":{"active":false,"size":3},"dictionary":{"active":false,"custom":[],"default":"en_100k"}},"strategy_version":2,"authentication_methods":{"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"},"passkey":{"enabled":false}},"passkey_options":{"challenge_ui":"both","progressive_enrollment_enabled":true,"local_enrollment_enabled":true},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"enabled_clients":[],"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 201 Created
         code: 201
-        duration: 566.559958ms
+        duration: 582.00025ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -53,7 +53,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
         method: GET
       response:
         proto: HTTP/2.0
@@ -63,13 +63,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 324.878625ms
+        duration: 345.792167ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -86,7 +86,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
         method: GET
       response:
         proto: HTTP/2.0
@@ -96,13 +96,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 365.445125ms
+        duration: 358.356292ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -119,7 +119,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
         method: GET
       response:
         proto: HTTP/2.0
@@ -129,13 +129,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 320.496917ms
+        duration: 341.694458ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -152,7 +152,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
         method: GET
       response:
         proto: HTTP/2.0
@@ -162,14 +162,47 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 392.046958ms
+        duration: 312.82425ms
     - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"mfa":{"active":true,"return_enroll_settings":true},"otp_settings":{"email":{"otp_expiry":600,"otp_length":8},"phone":{"otp_expiry":900,"otp_length":6}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"password_options":{"history":{"size":3,"active":false},"complexity":{"min_length":15,"character_types":[],"character_type_rule":"all","max_length_exceeded":"error","identical_characters":"allow","sequential_characters":"allow"},"dictionary":{"active":false,"custom":[],"default":"en_100k"},"profile_data":{"active":false,"blocked_fields":["name","username","nickname","email","phone_number","user_metadata.name","user_metadata.first","user_metadata.last"]}},"strategy_version":2,"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 316.680125ms
+    - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -188,7 +221,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -198,46 +231,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 369.99775ms
-    - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 337.895292ms
+        duration: 828.887959ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -254,7 +254,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
         method: GET
       response:
         proto: HTTP/2.0
@@ -264,13 +264,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 284.254458ms
+        duration: 425.635458ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -287,7 +287,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
         method: GET
       response:
         proto: HTTP/2.0
@@ -297,13 +297,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 290.71275ms
+        duration: 279.828ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -320,7 +320,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
         method: GET
       response:
         proto: HTTP/2.0
@@ -330,14 +330,47 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 371.810667ms
+        duration: 320.393ms
     - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"otp_settings":{"email":{"otp_expiry":600,"otp_length":7}},"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 336.073917ms
+    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -356,7 +389,7 @@ interactions:
                 - application/json
             User-Agent:
                 - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
         method: PATCH
       response:
         proto: HTTP/2.0
@@ -366,46 +399,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 380.475125ms
-    - id: 11
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: terraform-provider-auth0-dev.eu.auth0.com
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            User-Agent:
-                - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        transfer_encoding: []
-        trailer: {}
-        content_length: -1
-        uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
-        headers:
-            Content-Type:
-                - application/json; charset=utf-8
-        status: 200 OK
-        code: 200
-        duration: 315.721333ms
+        duration: 323.939917ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -422,7 +422,7 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
         method: GET
       response:
         proto: HTTP/2.0
@@ -432,13 +432,13 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: true
-        body: '{"id":"con_a7m80Pn2LUog4PoM","options":{"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 200 OK
         code: 200
-        duration: 340.3435ms
+        duration: 710.144709ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -455,7 +455,40 @@ interactions:
         headers:
             User-Agent:
                 - Go-Auth0/1.48.0
-        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_a7m80Pn2LUog4PoM
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"con_ehdQwHJ7QbWBXmg9","options":{"passkey_options":{"challenge_ui":"both","local_enrollment_enabled":true,"progressive_enrollment_enabled":true},"authentication_methods":{"passkey":{"enabled":false},"password":{"enabled":true,"api_behavior":"required","signup_behavior":"allow"}},"brute_force_protection":true},"strategy":"auth0","name":"Acceptance-Test-Connection-TestAccConnectionOTPSettings","is_domain_connection":false,"authentication":{"active":true},"connected_accounts":{"active":false},"realms":["Acceptance-Test-Connection-TestAccConnectionOTPSettings"]}'
+        headers:
+            Content-Type:
+                - application/json; charset=utf-8
+        status: 200 OK
+        code: 200
+        duration: 327.313416ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: terraform-provider-auth0-dev.eu.auth0.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - Go-Auth0/1.48.0
+        url: https://terraform-provider-auth0-dev.eu.auth0.com/api/v2/connections/con_ehdQwHJ7QbWBXmg9
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -465,10 +498,10 @@ interactions:
         trailer: {}
         content_length: 41
         uncompressed: false
-        body: '{"deleted_at":"2026-09-02T13:39:07.782Z"}'
+        body: '{"deleted_at":"2026-09-02T14:26:53.657Z"}'
         headers:
             Content-Type:
                 - application/json; charset=utf-8
         status: 202 Accepted
         code: 202
-        duration: 303.908875ms
+        duration: 333.369917ms


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

### 🔧 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

Adds `otp_settings` to `auth0_connection` options for the `auth0` (database) strategy. 

- New optional `otp_settings` block with `email` and `phone` channels, each taking `otp_length` (4-48) and `otp_expiry` in seconds (60-86400).
- The whole `otp_settings` object is sent on every create and update, matching the API's replace-not-merge behavior. Dropping a channel removes it rather than leaving it stale.
- Available on both the resource and the `auth0_connection` data source (read-only).

```hcl
resource "auth0_connection" "db" {
  name     = "my-db-connection"
  strategy = "auth0"

  options {
    otp_settings {
      email {
        otp_length = 8
        otp_expiry = 600
      }
      phone {
        otp_length = 6
        otp_expiry = 900
      }
    }
  }
}
```

### 📚 References

- Depends on SDK v1: https://github.com/auth0/go-auth0/pull/860

### 🔬 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

- Unit tests cover the request marshaling and flattening.
- An acceptance test creates a connection with both channels, verifies import round-trips with no drift, updates to a single channel, and removes the block.

```bash
make test-acc FILTER="TestAccConnectionOTPSettings"
```

### 📝 Checklist

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->
