### PR TITLE
feat(client): support custom `client_id` on `auth0_client`

### DIFF
--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -160,6 +160,7 @@ resource "auth0_client" "mcp_server" {
 - `async_approval_notification_channels` (List of String) List of notification channels enabled for CIBA (Client-Initiated Backchannel Authentication) requests initiated by this client. Valid values are `guardian-push` and `email`. The order is significant as this is the order in which notification channels will be evaluated.
 - `callbacks` (List of String) URLs that Auth0 may call back to after a user authenticates for the client. Make sure to specify the protocol (https://) otherwise the callback may fail in some cases. With the exception of custom URI schemes for native clients, all callbacks should use protocol https://.
 - `client_aliases` (List of String) List of audiences/realms for SAML protocol. Used by the wsfed addon.
+- `client_id` (String) The ID of the client. If not provided, Auth0 will generate one automatically. Use this to specify a custom client ID for migration or tenant-copy scenarios. Requires feature flag to be enabled on the tenant.
 - `client_metadata` (Map of String) Metadata associated with the client, in the form of an object with string values (max 255 chars). Maximum of 10 metadata properties allowed. Field names (max 255 chars) are alphanumeric and may only include the following special characters: `:,-+=_*?"/\()<>@ [Tab] [Space]`.
 - `compliance_level` (String) Defines the compliance level for this client, which may restrict it's capabilities. Can be one of `none`, `fapi1_adv_pkj_par`, `fapi1_adv_mtls_par`.
 - `cross_origin_auth` (Boolean) Whether this client can be used to make cross-origin authentication requests (`true`) or it is not allowed to make such requests (`false`).
@@ -204,7 +205,6 @@ resource "auth0_client" "mcp_server" {
 
 ### Read-Only
 
-- `client_id` (String) The ID of the client.
 - `external_client_id` (String) The URL of the Client ID Metadata Document. Only present for CIMD-registered clients.
 - `external_metadata_created_by` (String) Who created the external metadata client: `admin` (via Management API), `client` (self-registered), or `unknown`.
 - `external_metadata_type` (String) Type of external metadata. Value is `cimd` for CIMD-registered clients.

--- a/internal/auth0/client/expand.go
+++ b/internal/auth0/client/expand.go
@@ -90,6 +90,12 @@ func expandClient(data *schema.ResourceData) (*management.Client, error) {
 	}
 
 	if data.IsNewResource() {
+		if clientID := value.String(config.GetAttr("client_id")); clientID != nil {
+			client.ClientID = clientID
+		}
+	}
+
+	if data.IsNewResource() {
 		switch client.GetAppType() {
 		case "native", "spa":
 			client.TokenEndpointAuthMethod = auth0.String("none")

--- a/internal/auth0/client/resource.go
+++ b/internal/auth0/client/resource.go
@@ -89,9 +89,13 @@ func NewResource() *schema.Resource {
 				Description:  "Description of the purpose of the client.",
 			},
 			"client_id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of the client.",
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Description: "The ID of the client. If not provided, Auth0 will generate one automatically. " +
+					"Use this to specify a custom client ID for migration or tenant-copy scenarios. " +
+					"Requires feature flag to be enabled on the tenant.",
 			},
 			"external_client_id": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
## Summary

- `client_id` on `auth0_client` is now `Optional + Computed + ForceNew`  
- When set, the value is passed in the `POST /api/v2/clients` body so Auth0 registers the client with that exact ID. Only for special tenants.
- When omitted, behaviour is unchanged. Auth0 auto-generates the ID  

## Testing

Tested manually on test tenant.
- Custom `client_id` → created with exact ID specified 
- No `client_id` (existing flow) → auto-generated ID, no drift on re-plan 
- Flag disabled → `403 Forbidden` surfaced as a Terraform error ✅
